### PR TITLE
Chore/commitlint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,24 @@
+async function getConfig() {
+  const {
+    default: {
+      utils: { getProjects }
+    }
+  } = await import('@commitlint/config-nx-scopes')
+
+  return {
+    rules: {
+      'scope-enum': async ctx => [
+        2,
+        'always',
+        [
+          ...(await getProjects(
+            ctx,
+            ({ name, projectType }) => !name.includes('e2e')
+          ))
+        ]
+      ]
+    }
+  }
+}
+
+module.exports = getConfig()

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,3 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional', '@commitlint/config-nx-scopes']
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@babel/preset-react": "^7.14.5",
         "@commitlint/cli": "^18.6.1",
         "@commitlint/config-conventional": "^18.6.2",
+        "@commitlint/config-nx-scopes": "^19.5.0",
         "@docusaurus/core": "^3.4.0",
         "@docusaurus/module-type-aliases": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
@@ -2419,6 +2420,51 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-nx-scopes": {
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-nx-scopes/-/config-nx-scopes-19.5.0.tgz",
+      "integrity": "sha512-YjJVN9n5PJGnom1JqpC9tnQzWsWPeCbKN63AU6jTk25yxNpMtMVKNNEFU+yEPneo4kJk2yIicKjtPuRqYqL3Wg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^19.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "nx": ">=14.0.0"
+      },
+      "peerDependenciesMeta": {
+        "nx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@commitlint/config-nx-scopes/node_modules/@commitlint/types": {
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
+      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+      "dev": true,
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-nx-scopes/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -17955,6 +18001,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-react": "^7.14.5",
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.2",
+    "@commitlint/config-nx-scopes": "^19.5.0",
     "@docusaurus/core": "^3.4.0",
     "@docusaurus/module-type-aliases": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",


### PR DESCRIPTION
Scopet I en commit måste nu ha EXAKT namnet av ett projekt i NX. Detta är viktigt för att conventional commits ska fungera och vi ska få ny version på den komponent som berörts. 
T.ex fix(textField): ... triggar inte en ny version på textfield för att man skrivit fel casing. 
Det går dock fortfarande att ha utan ett scope för kodbasändringar.