### PR TITLE
docs: move mobile menu trigger

### DIFF
--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -17,7 +17,7 @@ import { InfoBanner } from '@midas-ds/info-banner'
 
 <div className="row">
   <div className="col col--8">
-    # Migrationsverkets designsystem 
+    # Migrations&shy;<wbr />verkets design&shy;<wbr />system
     ## Midas
 
     Här hittar du designriktlinjer, dokumentation om komponenter samt andra resurser som används för att bygga Migrationsverkets tjänster och system.

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -230,3 +230,19 @@ nav.menu {
 .theme-doc-breadcrumbs {
   margin-bottom: 1.5rem;
 }
+
+.breadcrumbs__item--active .breadcrumbs__link {
+  background: none;
+}
+
+/* stylelint-disable-next-line media-feature-range-notation */
+@media (max-width: 1024px) {
+  .navbar__items {
+    justify-content: space-between;
+    flex-direction: row-reverse;
+
+    .navbar__toggle {
+      margin: 0;
+    }
+  }
+}


### PR DESCRIPTION
- menytriggern är nu till höger i mobilt läge
- bättre avstavning i mobil (när det behövs) på h1 på startsidan