### PR TITLE
docs: update API for InfoBanner

### DIFF
--- a/apps/docs/docs/components/info-banner.mdx
+++ b/apps/docs/docs/components/info-banner.mdx
@@ -14,7 +14,9 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
   overrideHeadlessLink=''
 />
 
-Informationsmeddelande används för att visa statisk information, som till exempel systemnotiser
+Informationsmeddelande visar viktiga och aktuella meddelanden om händelser eller förändringar, som till exempel systemnotiser.
+Den används för att ge användaren feedback, exempelvis vid fel, varningar eller bekräftelser och är
+utformad för att vara tydlig och lätt att förstå utan att störa användarens flöde.
 
 ## Installation och användning
 
@@ -60,8 +62,6 @@ import { InfoBanner } from '@midas-ds/info-banner'
 <br />
 
 ```tsx
-import {InfoBanner} from "@midas-ds/info-banner";
-
 <InfoBanner type={'info'} title={'Information'} message={'Message'} />
 <InfoBanner type={'important'} title={'Important'} message={'Message'}/>
 <InfoBanner type={'warning'} title={'Warning'} message={'Message'}/>

--- a/apps/docs/docs/components/info-banner.mdx
+++ b/apps/docs/docs/components/info-banner.mdx
@@ -51,6 +51,7 @@ import { InfoBanner } from '@midas-ds/info-banner'
   />
   <InfoBanner
     type={'success'}
+    dismissable={true}
     title={'Formuläret har skickats'}
     message={'Visas för användaren för att bekräfta att en action gått rätt till.'}
   />
@@ -61,8 +62,11 @@ import { InfoBanner } from '@midas-ds/info-banner'
 ```tsx
 import {InfoBanner} from "@midas-ds/info-banner";
 
-<InfoBanner type={'info'} title={'Information'} message={'Message'}/>
+<InfoBanner type={'info'} title={'Information'} message={'Message'} />
 <InfoBanner type={'important'} title={'Important'} message={'Message'}/>
 <InfoBanner type={'warning'} title={'Warning'} message={'Message'}/>
-<InfoBanner type={'success'} title={'Success'} message={'Message'}/>
+<InfoBanner type={'success'} title={'Success'} message={'Message'} dismissable={true}/>
 ```
+## API
+
+<PropTable name={'InfoBanner'}/>

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -50,7 +50,16 @@ const config: Config = {
       {
         global: true,
         src: Object.values(packageAliases),
-        parserOptions: {},// see https://github.com/atomicpages/docusaurus-plugin-react-docgen-typescript for options
+        parserOptions: {
+          // prop table gets a bit crowded if we allow everything
+          propFilter: (prop, component) => {
+            if (prop.parent) {
+              return !prop.parent.fileName.includes("@types/react");
+            }
+
+            return true;
+          },
+        },// see https://github.com/atomicpages/docusaurus-plugin-react-docgen-typescript for options
       }
     ],
     [

--- a/packages/info-banner/src/lib/InfoBanner.tsx
+++ b/packages/info-banner/src/lib/InfoBanner.tsx
@@ -9,16 +9,18 @@ export interface InfoBannerProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
-  /** Set appearance of banner accoring to type of message */
+  /**
+   *  Specify what state the InfoBanner represents
+   **/
   type: 'success' | 'info' | 'important' | 'warning'
-  /** InfoBanner title */
+  /** Specify the title */
   title?: string
-  /** InfoBanner message */
-  message?: React.ReactNode | string
+  /** Specify the message. Element or string */
+  message?: string | React.ReactNode
   /** Additional elements displayed inside the banner */
   children?: React.ReactNode
   /**
-   *  Set to true to let user interact and dismiss banner via button in the top right corner
+   *  Specify if the InfoBanner should have a dismiss button in the top right corner
    */
   dismissable?: boolean
 }
@@ -30,7 +32,7 @@ const iconMap = {
   warning: AlertTriangle
 }
 /**
- * Displays a static message as a banner
+ * Displays a static message as an inline banner
  */
 export const InfoBanner: React.FC<InfoBannerProps> = ({
   title,

--- a/packages/info-banner/src/lib/InfoBanner.tsx
+++ b/packages/info-banner/src/lib/InfoBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { CircleCheck, Info, AlertTriangle, AlertCircle, X } from 'lucide-react'
 import styles from './InfoBanner.module.css'
 import clsx from 'clsx'
@@ -9,10 +9,17 @@ export interface InfoBannerProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  /** Set appearance of banner accoring to type of message */
   type: 'success' | 'info' | 'important' | 'warning'
+  /** InfoBanner title */
   title?: string
+  /** InfoBanner message */
   message?: React.ReactNode | string
+  /** Additional elements displayed inside the banner */
   children?: React.ReactNode
+  /**
+   *  Set to true to let user interact and dismiss banner via button in the top right corner
+   */
   dismissable?: boolean
 }
 
@@ -22,7 +29,9 @@ const iconMap = {
   important: AlertCircle,
   warning: AlertTriangle
 }
-
+/**
+ * Displays a static message as a banner
+ */
 export const InfoBanner: React.FC<InfoBannerProps> = ({
   title,
   message,


### PR DESCRIPTION
Stoppade tillbaka propfilter på förekommen anledning. Kan ta den diskussionen och finlira på den om det behövs i annan ticket. Funderar på att commita några andra grejer till denna för tydligare exempel också men kör PR för att bekräfta att det inte är strul med API på gh-pages