### PR TITLE
fix: fix focus in high contrast mode

### DIFF
--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -21,6 +21,11 @@
   &[data-focus-visible],
   &:focus-visible {
     box-shadow: focus;
+
+    @media (forced-colors: active) {
+      outline-offset: 2px;
+      outline: 3px solid Highlight !important;
+    }
   }
 
   &:hover {


### PR DESCRIPTION
Problemet är att använda box-shadow för fokus
Windows HCM ignorerar box-shadow, så om fokusläge är beroende av det kommer det inte att vara synligt.
Potentiell lösning:
Att använda @media (forced-colors: active), gör den focus i högkontrastlägen

eller 

Använda outline och outline-offset istället av för box-shadow