### PR TITLE
refactor(docs): remove version log link on component pages

### DIFF
--- a/apps/docs/src/components/getComponentMetaData.tsx
+++ b/apps/docs/src/components/getComponentMetaData.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Flex, FlexItem, LinkButton } from '@midas-ds/components'
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import { kebabCase } from 'lodash'
-import { BookMarked, BookText, FileCode } from 'lucide-react'
+import { BookMarked, BookText } from 'lucide-react'
 
 export const ComponentHeader = ({
   name,
@@ -27,17 +26,6 @@ export const ComponentHeader = ({
       <Flex fluid={true}>
         <FlexItem className='friendlyName'>
           <b>{friendlyName}</b>
-        </FlexItem>
-        <FlexItem col='auto'>
-          <LinkButton
-            href={`https://github.com/migrationsverket/midas/tree/main/packages/${kebabCase(name)}/CHANGELOG.md`}
-            target='_blank'
-            variant='tertiary'
-            icon={FileCode}
-            iconPlacement='left'
-          >
-            Versionslogg
-          </LinkButton>
         </FlexItem>
         <FlexItem col='auto'>
           <LinkButton


### PR DESCRIPTION
we're not providing a changelog per component anymore, this button is unnessecary