### PR TITLE
fix(theme): point to theme types

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,8 @@
     },
     "./theme": {
       "import": "./theme.js",
-      "require": "./theme.cjs"
+      "require": "./theme.cjs",
+      "types": "./theme/index.d.ts"
     }
   },
   "dependencies": {


### PR DESCRIPTION
gör sig av med den här lilla rackaren: 

![Skärmbild 2025-02-11 140212](https://github.com/user-attachments/assets/772db26f-8be9-4505-b6cf-03788ea9678e)

typningen verkar dock fungera oavsett 🤷‍♂️ 
