### PR TITLE
refactor: ignore a style rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -22,7 +22,7 @@
     ],
     "value-keyword-case": null,
     "custom-property-pattern": null,
-    "font-family-name-quotes": "always-unless-keyword",
+    "font-family-name-quotes": null,
     "font-family-no-missing-generic-family-keyword": [
       true,
       { "ignoreFontFamilies": ["display"] }


### PR DESCRIPTION
this rule unintentionally breaks the display variable for the font with new automatic linting