### PR TITLE
fix(link): add high contrast focus outline

### DIFF
--- a/packages/components/src/link/Link.module.css
+++ b/packages/components/src/link/Link.module.css
@@ -34,6 +34,11 @@
 
   &[data-focus-visible] {
     box-shadow: focus;
+
+    @media (forced-colors: active) {
+      outline: 2px solid Highlight;
+      outline-offset: 2px;
+    }
   }
 }
 


### PR DESCRIPTION
ärendet gällde `breadcrumbs`, men problemet låg i `link`
fixar också ärendet för `card`