### PR TITLE
feat!/textarea & textfield validation

### DIFF
--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -16,7 +16,7 @@ export const Example = props => {
         Button,
         Modal,
         Flex,
-        FlexItem
+        FlexItem,
       }}
       {...props}
     >
@@ -90,7 +90,7 @@ Modaler kan även innehålla mer avancerat innehåll som ett formulär. Använd 
                     autoFocus
                     label='Ange anledning'
                     description='Skriv anledning'
-                    maxCharacters={100}
+                    maxLength={100}
                 />
             </FlexItem>
         </Flex>

--- a/apps/docs/docs/components/textarea.mdx
+++ b/apps/docs/docs/components/textarea.mdx
@@ -17,7 +17,7 @@ export const Example = props => {
       {`<TextArea
           label="Kommentar"
           description="Skriv en kommentar"
-          maxCharacters={50}
+          maxLength={50}
           type={'email'}
       />`}
     </LiveCodeBlock>

--- a/packages/components/src/textarea/TextArea.spec.tsx
+++ b/packages/components/src/textarea/TextArea.spec.tsx
@@ -1,27 +1,37 @@
 import { render, screen } from '@testing-library/react'
-import { TextArea } from './TextArea'
+import { TextArea, TextAreaProps } from './TextArea'
 import { axe } from 'jest-axe'
 import user from '../../tests/utils/user'
 
-const label = 'Label for input'
+const label = 'Enter your text here'
+
+const TestForm = (props: TextAreaProps) => (
+  <form>
+    <TextArea
+      {...props}
+      label={label}
+    />
+    <button type='submit'>Submit</button>
+  </form>
+)
 
 describe('given a default TextArea', () => {
-  beforeEach(() => {
-    render(
-      <form>
-        <TextArea
-          label={label}
-          maxCharacters={4}
-          minLength={2}
-        />
-        <button type='submit'>Submit</button>
-      </form>,
-    )
-  })
+  beforeEach(() => render(<TestForm />))
 
   it('should have no accessibility violations', async () => {
     expect(await axe(screen.getByLabelText(label))).toHaveNoViolations()
   })
+})
+
+describe('given a TextArea with maxCharacters and minLength', () => {
+  beforeEach(() =>
+    render(
+      <TestForm
+        maxCharacters={4}
+        minLength={2}
+      />,
+    ),
+  )
 
   it('should give a validation error if the given text is too long', async () => {
     await user.tab()
@@ -49,24 +59,14 @@ describe('given a default TextArea', () => {
 })
 
 describe('given a required TextArea', () => {
-  beforeEach(() => {
-    render(
-      <form>
-        <TextArea
-          label={label}
-          isRequired
-        />
-        <button type='submit'>Submit</button>
-      </form>,
-    )
-  })
+  beforeEach(() => render(<TestForm isRequired />))
 
   it('should give a validation error if the user entered no text', async () => {
     await user.tab()
     await user.tab()
     await user.keyboard('[Enter]')
 
-    // Native validation message
+    // JSDOM Native required validation message
     expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
   })
 })
@@ -74,21 +74,15 @@ describe('given a required TextArea', () => {
 describe('given a TextArea with custom validation', () => {
   const errorMessage = 'Only numbers are allowed'
 
-  beforeEach(() => {
-    const validate = (value: string) => {
-      return !/^\d+$/.test(value) ? errorMessage : undefined
-    }
+  beforeEach(() =>
     render(
-      <form>
-        <TextArea
-          label={label}
-          isRequired
-          validate={validate}
-        />
-        <button type='submit'>Submit</button>
-      </form>,
-    )
-  })
+      <TestForm
+        validate={(value: string) =>
+          !/^\d+$/.test(value) ? errorMessage : true
+        }
+      />,
+    ),
+  )
 
   it('should give a validation error if the user entered an unpermitted text', async () => {
     await user.tab()

--- a/packages/components/src/textarea/TextArea.spec.tsx
+++ b/packages/components/src/textarea/TextArea.spec.tsx
@@ -1,19 +1,100 @@
-import { render, RenderResult } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { TextArea } from './TextArea'
-import { AriaTextFieldProps as TextFieldProps } from 'react-aria'
 import { axe } from 'jest-axe'
+import user from '../../tests/utils/user'
 
-describe('given a default TextField', () => {
-  let rendered: RenderResult
+const label = 'Label for input'
 
+describe('given a default TextArea', () => {
   beforeEach(() => {
-    rendered = render(<TextAreaTest label={'Label for input'}></TextAreaTest>)
+    render(
+      <form>
+        <TextArea
+          label={label}
+          maxCharacters={4}
+          minLength={2}
+        />
+        <button type='submit'>Submit</button>
+      </form>,
+    )
   })
 
   it('should have no accessibility violations', async () => {
-    expect(await axe(rendered.container)).toHaveNoViolations()
+    expect(await axe(screen.getByLabelText(label))).toHaveNoViolations()
+  })
+
+  it('should give a validation error if the given text is too long', async () => {
+    await user.tab()
+    await user.keyboard('12345')
+    await user.tab()
+    await user.keyboard('[Enter]')
+    expect(
+      screen.getByText(
+        /Du har angett 1 tecken för mycket. Fältet är begränsat till 4 tecken/,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('should give a validation error if the given text is too short', async () => {
+    await user.tab()
+    await user.keyboard('1')
+    await user.tab()
+    await user.keyboard('[Enter]')
+    expect(
+      screen.getByText(
+        /Du har angett 1 tecken för lite. Fältet kräver åtminstone 2 tecken/,
+      ),
+    ).toBeInTheDocument()
   })
 })
 
-// @ts-ignore
-const TextAreaTest = (props: TextFieldProps) => <TextArea {...props}></TextArea>
+describe('given a required TextArea', () => {
+  beforeEach(() => {
+    render(
+      <form>
+        <TextArea
+          label={label}
+          isRequired
+        />
+        <button type='submit'>Submit</button>
+      </form>,
+    )
+  })
+
+  it('should give a validation error if the user entered no text', async () => {
+    await user.tab()
+    await user.tab()
+    await user.keyboard('[Enter]')
+
+    // Native validation message
+    expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
+  })
+})
+
+describe('given a TextArea with custom validation', () => {
+  const errorMessage = 'Only numbers are allowed'
+
+  beforeEach(() => {
+    const validate = (value: string) => {
+      return !/^\d+$/.test(value) ? errorMessage : undefined
+    }
+    render(
+      <form>
+        <TextArea
+          label={label}
+          isRequired
+          validate={validate}
+        />
+        <button type='submit'>Submit</button>
+      </form>,
+    )
+  })
+
+  it('should give a validation error if the user entered an unpermitted text', async () => {
+    await user.tab()
+    await user.keyboard('abc')
+    await user.tab()
+    await user.keyboard('[Enter]')
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/textarea/TextArea.spec.tsx
+++ b/packages/components/src/textarea/TextArea.spec.tsx
@@ -23,11 +23,11 @@ describe('given a default TextArea', () => {
   })
 })
 
-describe('given a TextArea with maxCharacters and minLength', () => {
+describe('given a TextArea with maxLength and minLength', () => {
   beforeEach(() =>
     render(
       <TestForm
-        maxCharacters={4}
+        maxLength={4}
         minLength={2}
       />,
     ),

--- a/packages/components/src/textarea/TextArea.stories.tsx
+++ b/packages/components/src/textarea/TextArea.stories.tsx
@@ -33,10 +33,10 @@ export const NotValid = {
   },
 }
 
-export const MaxCharacters = {
+export const MaxLength = {
   args: {
     ...Primary.args,
-    maxCharacters: 50,
+    maxLength: 50,
   },
 }
 

--- a/packages/components/src/textarea/TextArea.tsx
+++ b/packages/components/src/textarea/TextArea.tsx
@@ -19,8 +19,6 @@ export interface TextAreaProps extends AriaTextFieldProps {
   description?: string
   /** Set number of rows for the TextArea */
   rows?: number
-  /** Set number of characters that are allowed before the TextArea is put in an invalid state */
-  maxCharacters?: number
   /** Set minimum number of characters that are allowed before the TextArea is put in an invalid state */
   minLength?: number
   /**
@@ -36,7 +34,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   label,
   description,
   rows,
-  maxCharacters,
+  maxLength,
   minLength,
   errorMessage,
   showCounter,
@@ -50,15 +48,15 @@ export const TextArea: React.FC<TextAreaProps> = ({
   }
 
   const Count = () => {
-    if (maxCharacters) {
+    if (maxLength) {
       return (
         <span
           className={clsx(
             styles.count,
-            value.length > maxCharacters && styles.countExceeded,
+            value.length > maxLength && styles.countExceeded,
           )}
         >
-          {value.length} / {maxCharacters}
+          {value.length} / {maxLength}
         </span>
       )
     }
@@ -71,9 +69,9 @@ export const TextArea: React.FC<TextAreaProps> = ({
   }
 
   const validateInput = (value: string) => {
-    const maxCharactersError =
-      maxCharacters && value.length > maxCharacters
-        ? `Du har angett ${value.length - maxCharacters} tecken för mycket. Fältet är begränsat till ${maxCharacters} tecken.`
+    const maxLengthError =
+      maxLength && value.length > maxLength
+        ? `Du har angett ${value.length - maxLength} tecken för mycket. Fältet är begränsat till ${maxLength} tecken.`
         : null
 
     const minLengthError =
@@ -83,7 +81,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
 
     const otherValidationError = validate ? validate(value) : null
 
-    return maxCharactersError || minLengthError || otherValidationError || true
+    return maxLengthError || minLengthError || otherValidationError || true
   }
 
   return (

--- a/packages/components/src/textarea/TextArea.tsx
+++ b/packages/components/src/textarea/TextArea.tsx
@@ -5,7 +5,7 @@ import {
   TextField as AriaTextField,
   TextArea as AriaTextArea,
   ValidationResult,
-  TextFieldProps as AriaTextFieldProps
+  TextFieldProps as AriaTextFieldProps,
 } from 'react-aria-components'
 import { InputWrapper } from '../textfield'
 import TextFieldStyles from '../textfield/TextField.module.css'
@@ -21,6 +21,8 @@ export interface TextAreaProps extends AriaTextFieldProps {
   rows?: number
   /** Set number of characters that are allowed before the TextArea is put in an invalid state */
   maxCharacters?: number
+  /** Set minimum number of characters that are allowed before the TextArea is put in an invalid state */
+  minLength?: number
   /**
    * Whether to show the character counter or not
    * @default
@@ -35,6 +37,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   description,
   rows,
   maxCharacters,
+  minLength,
   errorMessage,
   showCounter,
   validate,
@@ -52,7 +55,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
         <span
           className={clsx(
             styles.count,
-            value.length > maxCharacters && styles.countExceeded
+            value.length > maxCharacters && styles.countExceeded,
           )}
         >
           {value.length} / {maxCharacters}
@@ -73,9 +76,14 @@ export const TextArea: React.FC<TextAreaProps> = ({
         ? `Du har angett ${value.length - maxCharacters} tecken för mycket. Fältet är begränsat till ${maxCharacters} tecken.`
         : null
 
+    const minLengthError =
+      minLength && value.length < minLength
+        ? `Du har angett ${Math.abs(value.length - minLength)} tecken för lite. Fältet kräver åtminstone ${minLength} tecken.`
+        : null
+
     const otherValidationError = validate ? validate(value) : null
 
-    return maxCharactersError || otherValidationError || true
+    return maxCharactersError || minLengthError || otherValidationError || true
   }
 
   return (

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -8,16 +8,16 @@ const meta: Meta<typeof TextField> = {
   argTypes: {
     label: {
       type: 'string',
-      description: 'Etikett'
+      description: 'Etikett',
     },
     description: {
-      type: 'string'
+      type: 'string',
     },
     type: {
       options: ['password', 'text', 'email'],
-      control: { type: 'select' }
-    }
-  }
+      control: { type: 'select' },
+    },
+  },
 }
 export default meta
 type Story = StoryObj<typeof TextField>
@@ -25,37 +25,37 @@ type Story = StoryObj<typeof TextField>
 export const Primary: Story = {
   args: {
     label: 'Label',
-    description: 'Description'
-  }
+    description: 'Description',
+  },
 }
 
 export const Password = {
   args: {
     label: 'Enter Password',
-    type: 'password'
-  }
+    type: 'password',
+  },
 }
 
 export const NotValid = {
   args: {
     ...Primary.args,
     isInvalid: true,
-    errorMessage: 'Fel i valideringen'
-  }
+    errorMessage: 'Fel i valideringen',
+  },
 }
 
 export const Required = {
   args: {
     ...Primary.args,
-    isRequired: true
-  }
+    isRequired: true,
+  },
 }
 
 export const Disabled = {
   args: {
     ...Primary.args,
-    isDisabled: true
-  }
+    isDisabled: true,
+  },
 }
 
 export const Personnummer = {
@@ -65,20 +65,20 @@ export const Personnummer = {
     label: 'Personnummer',
     description: undefined,
     errorMessage: `Fel format för ett personnummer`,
-    maxCharacters: 12
-  }
+    maxLength: 12,
+  },
 }
 
-export const MaxCharacters = {
+export const MaxLength = {
   args: {
     ...Primary.args,
-    maxCharacters: 50
-  }
+    maxLength: 50,
+  },
 }
 
 export const ShowCounter = {
   args: {
     ...Primary.args,
-    showCounter: true
-  }
+    showCounter: true,
+  },
 }

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -24,8 +24,6 @@ export interface TextFieldProps extends AriaTextFieldProps {
   errorMessage?: string | ((validation: ValidationResult) => string) | undefined
   /** Enable validations or add your own regex */
   validationType?: 'ssn' | 'dossnr' | RegExp
-  /** Set number of characters that are allowed before the TextField is put in an invalid state */
-  maxCharacters?: number
   /**
    * Whether to show the character counter or not
    * @default
@@ -40,7 +38,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   errorMessage,
   validationType,
   validate,
-  maxCharacters,
+  maxLength,
   showCounter,
   ...props
 }) => {
@@ -65,9 +63,9 @@ export const TextField: React.FC<TextFieldProps> = ({
         ? null
         : errorMessage?.toString()
 
-    if (maxCharacters)
-      return maxCharacters && value.length > maxCharacters
-        ? `Du har angett ${value.length - maxCharacters} tecken för mycket. Fältet är begränsat till ${maxCharacters} tecken.`
+    if (maxLength)
+      return maxLength && value.length > maxLength
+        ? `Du har angett ${value.length - maxLength} tecken för mycket. Fältet är begränsat till ${maxLength} tecken.`
         : null
 
     if (validate) return validate(value)
@@ -76,15 +74,15 @@ export const TextField: React.FC<TextFieldProps> = ({
   }
 
   const Count = () => {
-    if (maxCharacters) {
+    if (maxLength) {
       return (
         <span
           className={clsx(
             styles.count,
-            value.length > maxCharacters && styles.countExceeded,
+            value.length > maxLength && styles.countExceeded,
           )}
         >
-          {value.length} / {maxCharacters}
+          {value.length} / {maxLength}
         </span>
       )
     }


### PR DESCRIPTION
breaking change för `TextArea` och `TextField`, byter ut propertyn `maxCharacters` mot `maxLength` enligt motsvarande attributnamn för HTML `<input>` och `<textarea>`

uppdatera validering för `minLength`-attributet
skriv tester för `maxLength`, `minLength`, `isRequired` och custom `validate`-funktioner