### PR TITLE
chore: ignore chore commits in changelog, no version bump for docs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,21 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "release": {
+    "conventionalCommits": {
+      "types": {
+        "docs": {
+          "semverBump": "none",
+          "changelog": {
+            "title": "Documentation Changes"
+          }
+        },
+        "chore": {
+          "changelog": {
+            "hidden": true
+          }
+        }
+      }
+    },
     "changelog": {
       "projectChangelogs": true,
       "automaticFromRef": true

--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,12 @@
   "release": {
     "conventionalCommits": {
       "types": {
+        "test": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": true
+          }
+        },
         "docs": {
           "semverBump": "none",
           "changelog": {


### PR DESCRIPTION
Tar bort lite clutter från framtida changelogs för chore-commits. Alltid work in progress men jag tror det här är vettigt, input?
Lägger även docs under egen rubrik samt undantaget för version bumps