### PR TITLE
fix(file-upload): pass unhandled props to the FileTrigger component

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -22,32 +22,19 @@ const config: StorybookConfig = {
     },
   },
   staticDirs: ['./static'],
-  // https://github.com/storybookjs/storybook/issues/13637#issuecomment-2146148008
   typescript: {
-    check: false,
-    /**
-     * For improved speed use react-docgen instead of react-docgen-typescript
-     * Use react-docgen-typescript for verbose documentation of mantine components
-     */
-    reactDocgen: 'react-docgen-typescript', // use react-docgen instead of react-docgen-typescript to improve speed
+    reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
-      tsconfigPath: './tsconfig.base.json',
-      // Speeds up Storybook build time
-      compilerOptions: {
-        allowSyntheticDefaultImports: false,
-        esModuleInterop: false,
+      tsconfigPath: 'packages/components/tsconfig.lib.json',
+      propFilter: prop => {
+        if (prop.parent) {
+          return !prop.parent.fileName.includes('@types/react')
+        }
+        return true
       },
-      // Makes union prop types like variant and size appear as select controls
+      savePropValueAsString: true,
       shouldExtractLiteralValuesFromEnum: true,
-      // Makes string and boolean types that can be undefined appear as inputs and switches
       shouldRemoveUndefinedFromOptional: true,
-      // Filter out third-party props from node_modules except react-aria-components packages
-      propFilter: prop =>
-        prop.parent
-          ? !/node_modules\/(?!react-aria-components)/.test(
-              prop.parent.fileName,
-            )
-          : true,
     },
   },
 }

--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -3,25 +3,53 @@ import type { StorybookConfig } from '@storybook/react-vite'
 const config: StorybookConfig = {
   stories: [
     '../src/**/*.stories.@(js|jsx|ts|tsx)',
-    './examples/*.stories.@(md|mdx|tsx)'
+    './examples/*.stories.@(md|mdx|tsx)',
   ],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    '@storybook/addon-a11y'
+    '@storybook/addon-a11y',
   ],
   core: {
-    disableTelemetry: true
+    disableTelemetry: true,
   },
   framework: {
     name: '@storybook/react-vite',
     options: {
       builder: {
-        viteConfigPath: 'packages/components/vite.config.ts'
-      }
-    }
+        viteConfigPath: 'packages/components/vite.config.ts',
+      },
+    },
   },
-  staticDirs: ['./static']
+  staticDirs: ['./static'],
+  // https://github.com/storybookjs/storybook/issues/13637#issuecomment-2146148008
+  typescript: {
+    check: false,
+    /**
+     * For improved speed use react-docgen instead of react-docgen-typescript
+     * Use react-docgen-typescript for verbose documentation of mantine components
+     */
+    reactDocgen: 'react-docgen-typescript', // use react-docgen instead of react-docgen-typescript to improve speed
+    reactDocgenTypescriptOptions: {
+      tsconfigPath: './tsconfig.base.json',
+      // Speeds up Storybook build time
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false,
+      },
+      // Makes union prop types like variant and size appear as select controls
+      shouldExtractLiteralValuesFromEnum: true,
+      // Makes string and boolean types that can be undefined appear as inputs and switches
+      shouldRemoveUndefinedFromOptional: true,
+      // Filter out third-party props from node_modules except react-aria-components packages
+      propFilter: prop =>
+        prop.parent
+          ? !/node_modules\/(?!react-aria-components)/.test(
+              prop.parent.fileName,
+            )
+          : true,
+    },
+  },
 }
 
 export default config

--- a/packages/components/src/file-upload/FileUpload.spec.tsx
+++ b/packages/components/src/file-upload/FileUpload.spec.tsx
@@ -35,7 +35,11 @@ describe('given a FileUpload with a custom select handler', () => {
 
   it('should use the provided onSelect callback', async () => {
     const testFile = new File(['derp'], 'derp.png', { type: 'image/png' })
-    await user.upload(screen.getByTestId(label), testFile)
+    const fileUpload: HTMLInputElement = screen.getByTestId(label)
+    await user.upload(fileUpload, testFile)
     expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(fileUpload?.files?.[0]).toStrictEqual(testFile)
+    expect(fileUpload?.files?.item(0)).toStrictEqual(testFile)
+    expect(fileUpload.files).toHaveLength(1)
   })
 })

--- a/packages/components/src/file-upload/FileUpload.spec.tsx
+++ b/packages/components/src/file-upload/FileUpload.spec.tsx
@@ -1,17 +1,41 @@
-import { FileUpload, FileTriggerProps } from './FileUpload'
-import '@testing-library/jest-dom'
+import { FileUpload } from './FileUpload'
 import { axe } from 'jest-axe'
-import { render, RenderResult } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import user from '../../tests/utils/user'
 
-describe('given default fileupload', () => {
-  let rendered: RenderResult
+const label = 'Etikett'
+
+describe('given default FileUpload', () => {
   beforeEach(() => {
-    rendered = render(<FileUploadExample label={'Etikett'} />)
+    render(
+      <FileUpload
+        label={label}
+        data-testid={label}
+      />,
+    )
   })
 
   it('should have no accessibility violations', async () => {
-    expect(await axe(rendered.container)).toHaveNoViolations()
+    expect(await axe(screen.getByTestId(label))).toHaveNoViolations()
   })
 })
 
-const FileUploadExample = (props: FileTriggerProps) => <FileUpload {...props} />
+describe('given a FileUpload with a custom select handler', () => {
+  const onSelect = jest.fn()
+
+  beforeEach(() => {
+    render(
+      <FileUpload
+        label={label}
+        data-testid={label}
+        onSelect={onSelect}
+      />,
+    )
+  })
+
+  it('should use the provided onSelect callback', async () => {
+    const testFile = new File(['derp'], 'derp.png', { type: 'image/png' })
+    await user.upload(screen.getByTestId(label), testFile)
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/components/src/file-upload/FileUpload.tsx
+++ b/packages/components/src/file-upload/FileUpload.tsx
@@ -4,13 +4,14 @@ import {
   FileTrigger as AriaFileTrigger,
   FileTriggerProps as AriaFileTriggerProps,
   DropZone,
-  Text
+  Text,
 } from 'react-aria-components'
 import React from 'react'
 import { X } from 'lucide-react'
 import styles from './FileUpload.module.css'
 import { Button } from '../button'
 import { InputWrapper } from '../textfield'
+import { DropEvent } from 'react-aria'
 
 export interface FileTriggerProps extends AriaFileTriggerProps {
   /** Label for the file upload button */
@@ -27,7 +28,8 @@ export const FileUpload: React.FC<FileTriggerProps> = ({
   allowsMultiple,
   label,
   description,
-  dropzone
+  dropzone,
+  ...rest
 }) => {
   const [files, setFiles] = React.useState<FileState>(null)
 
@@ -36,10 +38,10 @@ export const FileUpload: React.FC<FileTriggerProps> = ({
     // TODO: actually handle files?
   }
 
-  const handleDrop = async (e: any) => {
+  const handleDrop = async (e: DropEvent) => {
     const filePromises = e.items
-      .filter((file: any) => file.kind === 'file')
-      .map((file: any) => file.getFile())
+      .filter(file => file.kind === 'file')
+      .map(file => file.getFile())
 
     const resolvedFiles: File[] = await Promise.all(filePromises)
     setFiles(resolvedFiles)
@@ -77,6 +79,7 @@ export const FileUpload: React.FC<FileTriggerProps> = ({
         <AriaFileTrigger
           allowsMultiple={allowsMultiple}
           onSelect={files => handleUpload(files)}
+          {...rest}
         >
           <Button
             variant='secondary'

--- a/packages/components/src/file-upload/FileUpload.tsx
+++ b/packages/components/src/file-upload/FileUpload.tsx
@@ -2,52 +2,29 @@
 
 import {
   FileTrigger as AriaFileTrigger,
+  FileTriggerProps as AriaFileTriggerProps,
   DropZone,
   Text,
 } from 'react-aria-components'
-import React, { FC, ReactNode } from 'react'
+import React from 'react'
 import { X } from 'lucide-react'
 import styles from './FileUpload.module.css'
 import { Button } from '../button'
 import { InputWrapper } from '../textfield'
 import { DropEvent } from 'react-aria'
 
-export interface FileTriggerProps {
+export interface FileTriggerProps extends AriaFileTriggerProps {
   /** Label for the file upload button */
   label?: string
   /**  Additional description field */
   description?: string
   /**  Use DropZone version */
   dropzone?: boolean
-  /**
-   * Specifies what mime type of files are allowed.
-   */
-  acceptedFileTypes?: Array<string>
-  /**
-   * Whether multiple files can be selected.
-   */
-  allowsMultiple?: boolean
-  /**
-   * Specifies the use of a media capture mechanism to capture the media on the spot.
-   */
-  defaultCamera?: 'user' | 'environment'
-  /**
-   * Handler when a user selects a file.
-   */
-  onSelect?: (files: FileList | null) => void
-  /**
-   * The children of the component.
-   */
-  children?: ReactNode
-  /**
-   * Enables the selection of directories instead of individual files.
-   */
-  acceptDirectory?: boolean
 }
 
 type FileState = File[] | null | undefined
 
-export const FileUpload: FC<FileTriggerProps> = ({
+export const FileUpload: React.FC<FileTriggerProps> = ({
   allowsMultiple,
   label,
   description,

--- a/packages/components/src/file-upload/FileUpload.tsx
+++ b/packages/components/src/file-upload/FileUpload.tsx
@@ -6,7 +6,7 @@ import {
   DropZone,
   Text,
 } from 'react-aria-components'
-import React from 'react'
+import * as React from 'react'
 import { X } from 'lucide-react'
 import styles from './FileUpload.module.css'
 import { Button } from '../button'

--- a/packages/components/src/file-upload/FileUpload.tsx
+++ b/packages/components/src/file-upload/FileUpload.tsx
@@ -2,29 +2,52 @@
 
 import {
   FileTrigger as AriaFileTrigger,
-  FileTriggerProps as AriaFileTriggerProps,
   DropZone,
   Text,
 } from 'react-aria-components'
-import React from 'react'
+import React, { FC, ReactNode } from 'react'
 import { X } from 'lucide-react'
 import styles from './FileUpload.module.css'
 import { Button } from '../button'
 import { InputWrapper } from '../textfield'
 import { DropEvent } from 'react-aria'
 
-export interface FileTriggerProps extends AriaFileTriggerProps {
+export interface FileTriggerProps {
   /** Label for the file upload button */
   label?: string
   /**  Additional description field */
   description?: string
   /**  Use DropZone version */
   dropzone?: boolean
+  /**
+   * Specifies what mime type of files are allowed.
+   */
+  acceptedFileTypes?: Array<string>
+  /**
+   * Whether multiple files can be selected.
+   */
+  allowsMultiple?: boolean
+  /**
+   * Specifies the use of a media capture mechanism to capture the media on the spot.
+   */
+  defaultCamera?: 'user' | 'environment'
+  /**
+   * Handler when a user selects a file.
+   */
+  onSelect?: (files: FileList | null) => void
+  /**
+   * The children of the component.
+   */
+  children?: ReactNode
+  /**
+   * Enables the selection of directories instead of individual files.
+   */
+  acceptDirectory?: boolean
 }
 
 type FileState = File[] | null | undefined
 
-export const FileUpload: React.FC<FileTriggerProps> = ({
+export const FileUpload: FC<FileTriggerProps> = ({
   allowsMultiple,
   label,
   description,


### PR DESCRIPTION
## Description

FileUpload exposed some props that we didn't handle

## Changes

Create a test for the unhandled prop `onSelect`
Pass the unhandled props to the `FileTrigger` component
Add the correct type for the `handleDrop` callback
Update the docgen config for storybook to match the same props as docusarus

## Additional Information

The `acceptedFileTypes` prop is easiest to test manually

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
