### PR TITLE
chore: bump to node 22

### DIFF
--- a/.github/workflows/components-ci.yml
+++ b/.github/workflows/components-ci.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
+          cache: npm
       - run: npm ci
       - run: npx nx run-many -t lint,test,build --projects=components

--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/documentation-pr.yml
+++ b/.github/workflows/documentation-pr.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -47,4 +47,4 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./dist/docs
-          custom-url: 'designsystem.migrationsverket.se'
+          pages-base-url: 'designsystem.migrationsverket.se'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 jobs:
   test:
     name: Publish
@@ -23,8 +23,9 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
+          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/apps/docs/docs/get-started/contribute.mdx
+++ b/apps/docs/docs/get-started/contribute.mdx
@@ -8,7 +8,7 @@ Att komma igång och bidra med kod till Midas är enkelt!
 
 ## Du behöver
 
-- En normalt fungerande WSL eller motsvarande setup med Node version >20.
+- En normalt fungerande WSL eller motsvarande setup med Node version >22.
 - [Nx](https://nx.dev) installerat globalt `npm install --global nx@latest`
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,7 @@
         "vitest": "^1.3.1"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=22.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=22.0"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": "eslint --cache --fix",


### PR DESCRIPTION
## Description

Bump to Node v22 in GH Actions and codebase

## Changes

- Changed to node 22 in all gh actions
- Added NPM cache on some gh actions where it was lacking
- Codebase now demands node 22 or higher
- Changed get started docs

## Additional Information

All must upgrade to node to at least 22 or run nvm

## Checklist

- [] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
