### PR TITLE
bugfix/className

### DIFF
--- a/packages/components/src/accordion/Accordion.spec.tsx
+++ b/packages/components/src/accordion/Accordion.spec.tsx
@@ -5,26 +5,34 @@
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import { axe } from 'jest-axe'
-import { render, RenderResult } from '@testing-library/react'
+import { render, RenderResult, screen } from '@testing-library/react'
 import { Accordion, AccordionItem } from './'
+import { logDom } from 'packages/components/tests/utils/dom'
 
 const ITEMS = ['One', 'Two', 'Three']
+const testID = 'Accordion'
+const testClass = 'test'
 
 describe('given a single Accordion', () => {
-  let rendered: RenderResult
-
   describe('with default orientation=vertical', () => {
     beforeEach(() => {
-      rendered = render(
+      render(
         <AccordionTest
           variant='uncontained'
           type='single'
-        />
+          data-testid={testID}
+          className={testClass}
+        />,
       )
     })
 
     it('should have no accessibility violations in default state', async () => {
-      expect(await axe(rendered.container)).toHaveNoViolations()
+      expect(await axe(screen.getByTestId(testID))).toHaveNoViolations()
+    })
+
+    it('should preserve its classNames when being passed new ones', async () => {
+      expect(screen.getByTestId(testID)).toHaveClass('root')
+      expect(screen.getByTestId(testID)).toHaveClass(testClass)
     })
 
     // describe('when navigating by keyboard', () => {
@@ -145,7 +153,7 @@ describe('given a multiple Accordion', () => {
       <AccordionTest
         variant='uncontained'
         type='multiple'
-      />
+      />,
     )
   })
 

--- a/packages/components/src/accordion/Accordion.tsx
+++ b/packages/components/src/accordion/Accordion.tsx
@@ -20,6 +20,7 @@ export const Accordion: React.FC<MidasAccordion> = ({
   variant = 'uncontained',
   type = 'single',
   children,
+  className,
   ...props
 }) => {
   return (
@@ -27,7 +28,8 @@ export const Accordion: React.FC<MidasAccordion> = ({
       allowsMultipleExpanded={type === 'multiple'}
       className={clsx(
         styles.root,
-        variant === 'contained' ? styles.contained : styles.uncontained
+        variant === 'contained' ? styles.contained : styles.uncontained,
+        className,
       )}
       {...props}
     >

--- a/packages/components/src/combobox/ComboBox.spec.tsx
+++ b/packages/components/src/combobox/ComboBox.spec.tsx
@@ -8,6 +8,8 @@ import { renderWithForm } from '../../tests/utils/browser'
 
 const label = 'basic combobox'
 const items = generateMockOptions(30)
+const testClass = 'test'
+const testID = 'test'
 
 describe('given a default ComboBox', () => {
   beforeEach(() => {
@@ -15,6 +17,8 @@ describe('given a default ComboBox', () => {
       <ComboBox
         items={items}
         aria-label={label}
+        data-testid={testID}
+        className={testClass}
       >
         {({ name }: Item) => <ComboBoxItem>{name}</ComboBoxItem>}
       </ComboBox>,
@@ -22,7 +26,13 @@ describe('given a default ComboBox', () => {
   })
 
   it('should have no accessibility violations', async () => {
-    expect(await axe(screen.getByLabelText(label))).toHaveNoViolations()
+    expect(await axe(screen.getByTestId(testID))).toHaveNoViolations()
+  })
+
+  it('should preserve its classNames when being passed new ones', async () => {
+    const accordion = screen.getByTestId(testID)
+    expect(accordion).toHaveClass('combobox')
+    expect(accordion).toHaveClass(testClass)
   })
 })
 

--- a/packages/components/src/combobox/ComboBox.tsx
+++ b/packages/components/src/combobox/ComboBox.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import type {
   ComboBoxProps as AriaComboBoxProps,
   ListBoxItemProps,
-  ValidationResult
+  ValidationResult,
 } from 'react-aria-components'
 import {
   Button,
@@ -12,10 +12,11 @@ import {
   Popover,
   ComboBox as AriaComboBox,
   ListBox,
-  ListBoxItem
+  ListBoxItem,
 } from 'react-aria-components'
 import { ChevronDown } from 'lucide-react'
 import { InputWrapper } from '../textfield'
+import clsx from 'clsx'
 
 export interface ComboBoxProps<T extends object>
   extends Omit<AriaComboBoxProps<T>, 'children'> {
@@ -33,13 +34,14 @@ export function ComboBox<T extends object>({
   errorMessage,
   children,
   items,
+  className,
   ...props
 }: ComboBoxProps<T>) {
   const ref = React.useRef<HTMLDivElement>(null)
 
   return (
     <AriaComboBox
-      className={styles.combobox}
+      className={clsx(styles.combobox, className)}
       ref={ref}
       {...props}
     >


### PR DESCRIPTION
## Description

Some components styling could be overridden using the `className` property due to this pattern
```
<Component className={styles.className} {...props} />
```

## Changes

Add classname tests

## Additional Information

This is not critical for all components, but it could lead to bugs in the future

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
