### PR TITLE
fix(textfield): set the initial value for useState 

### DIFF
--- a/packages/components/src/textarea/TextArea.spec.tsx
+++ b/packages/components/src/textarea/TextArea.spec.tsx
@@ -92,3 +92,19 @@ describe('given a TextArea with custom validation', () => {
     expect(screen.getByText(errorMessage)).toBeInTheDocument()
   })
 })
+
+describe('given a TextArea with showCounter and an initial value', () => {
+  beforeEach(() =>
+    renderWithForm(
+      <TextArea
+        label={label}
+        showCounter
+        value='HEJ'
+      />,
+    ),
+  )
+
+  it('should show the correct count for its initial value', async () => {
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/textarea/TextArea.spec.tsx
+++ b/packages/components/src/textarea/TextArea.spec.tsx
@@ -108,3 +108,19 @@ describe('given a TextArea with showCounter and an initial value', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 })
+
+describe('given a TextArea with showCounter and an initial defaultValue', () => {
+  beforeEach(() =>
+    renderWithForm(
+      <TextArea
+        label={label}
+        showCounter
+        defaultValue='HEJ'
+      />,
+    ),
+  )
+
+  it('should show the correct count for its initial value', async () => {
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/textarea/TextArea.tsx
+++ b/packages/components/src/textarea/TextArea.tsx
@@ -41,7 +41,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   validate,
   ...props
 }) => {
-  const [value, setValue] = React.useState('')
+  const [value, setValue] = React.useState(props.value || '')
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = event.target.value
     setValue(newValue)

--- a/packages/components/src/textarea/TextArea.tsx
+++ b/packages/components/src/textarea/TextArea.tsx
@@ -41,7 +41,9 @@ export const TextArea: React.FC<TextAreaProps> = ({
   validate,
   ...props
 }) => {
-  const [value, setValue] = React.useState(props.value || '')
+  const [value, setValue] = React.useState(
+    props.defaultValue ?? props.value ?? '',
+  )
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = event.target.value
     setValue(newValue)

--- a/packages/components/src/textfield/TextField.spec.tsx
+++ b/packages/components/src/textfield/TextField.spec.tsx
@@ -97,3 +97,19 @@ describe('given a TextField with showCounter and an initial value', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 })
+
+describe('given a TextField with showCounter and an initial defaultValue', () => {
+  beforeEach(() =>
+    renderWithForm(
+      <TextField
+        label={label}
+        showCounter
+        defaultValue='HEJ'
+      />,
+    ),
+  )
+
+  it('should show the correct count for its initial value', async () => {
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/textfield/TextField.spec.tsx
+++ b/packages/components/src/textfield/TextField.spec.tsx
@@ -81,3 +81,19 @@ describe('given a TextField with type "number"', () => {
     expect(screen.getByLabelText(label)).toHaveValue(null)
   })
 })
+
+describe('given a TextField with showCounter and an initial value', () => {
+  beforeEach(() =>
+    renderWithForm(
+      <TextField
+        label={label}
+        showCounter
+        value='HEJ'
+      />,
+    ),
+  )
+
+  it('should show the correct count for its initial value', async () => {
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -42,7 +42,9 @@ export const TextField: React.FC<TextFieldProps> = ({
   showCounter,
   ...props
 }) => {
-  const [value, setValue] = React.useState<string>(props.value || '')
+  const [value, setValue] = React.useState<string>(
+    props.defaultValue ?? props.value ?? '',
+  )
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -42,7 +42,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   showCounter,
   ...props
 }) => {
-  const [value, setValue] = React.useState<string>('')
+  const [value, setValue] = React.useState<string>(props.value || '')
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value


### PR DESCRIPTION
## Description

`TextField` and `TextArea` counter value shows `0` if the default `value` or `defaultValue` property is used

## Changes

Add tests, set the initialValue for `useState` in both components

## Additional Information

Test case described in ticket

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
