### PR TITLE
fix(theme): add global css export

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,6 +42,9 @@
       "types": "./theme/index.d.ts",
       "import": "./theme.js",
       "require": "./theme.cjs"
+    },
+    "./global.css": {
+      "import": "./global.css"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Our npm package has no explicit export for the global css file

## Changes

Add the export to package.json

## Additional Information

tested locally using `nx build components` -> `npm pack` -> `npm i ...`

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
