### PR TITLE
fix(accordion): fix render of dynamic content in AccordionItem

### DIFF
--- a/apps/playground/src/app/app.tsx
+++ b/apps/playground/src/app/app.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+
 import styles from './app.module.css'
 import {
   Button,
@@ -6,42 +6,64 @@ import {
   Logo,
   TextField,
   Skeleton,
+  Accordion,
+  AccordionItem,
+  RadioGroup,
+  Radio
 } from '@midas-ds/components'
+import React from 'react'
 
 export function App() {
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setLoading(false)
-    }, 5000)
-
-    return () => clearTimeout(timeoutId)
-  }, [])
-
+  const [bolle, setBolle] = React.useState<boolean>(false);
   return (
     <div className={styles.container}>
+
+      <Accordion defaultExpandedKeys={['Två']} variant="contained">
+        <AccordionItem id="Ett" title="En öppningsbar panel ett">
+          Innehåll i öppningsbarpanel Ett Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellendus
+          perspiciatis officia, voluptate ratione quam nemo quod aut maiores animi nostrum, in labore adipisci
+          ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor, sit amet consectetur adipisicing
+          elit. Impedit dolorem tempora laboriosam asperiores eum dignissimos accusantium voluptate eligendi
+          beatae vel quis rerum error dolore cum incidunt pariatur accusamus, illum consequuntur?
+        </AccordionItem>
+        <AccordionItem id="Två" title="En öppningsbar panel två">
+          Innehåll i öppningsbarpanel Två Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellendus
+          perspiciatis officia, voluptate ratione quam nemo quod aut maiores animi nostrum, in labore adipisci
+          ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor, sit amet consectetur adipisicing
+          elit. Impedit dolorem tempora laboriosam asperiores eum dignissimos accusantium voluptate eligendi
+          beatae vel quis rerum error dolore cum incidunt pariatur accusamus, illum consequuntur?
+          <button onClick={() => setBolle(!bolle)}>Visa mer</button>
+          {bolle && (
+            <div>
+              Innehåll i öppningsbarpanel Två Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              Repellendus perspiciatis officia, voluptate ratione quam nemo quod aut maiores animi nostrum, in
+              labore adipisci ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor, sit amet
+              consectetur adipisicing elit. Impedit dolorem tempora laboriosam asperiores eum dignissimos
+              accusantium voluptate eligendi beatae vel quis rerum error dolore cum incidunt pariatur
+              accusamus, illum consequuntur?
+            </div>
+          )}
+        </AccordionItem>
+        <AccordionItem id="Tre" title="En öppningsbar panel tre">
+          Innehåll i öppningsbarpanel Tre Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellendus
+          perspiciatis officia, voluptate ratione quam nemo quod aut maiores animi nostrum, in labore adipisci
+          ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor, sit amet consectetur adipisicing
+          elit. Impedit dolorem tempora laboriosam asperiores eum dignissimos accusantium voluptate eligendi
+          beatae vel quis rerum error dolore cum incidunt pariatur accusamus, illum consequuntur?
+        </AccordionItem>
+        <AccordionItem id="Fyra" title="En öppningsbar panel fyra">
+          Innehåll i öppningsbarpanel Fyra Lorem ipsum dolor sit amet consectetur adipisicing elit.
+          Repellendus perspiciatis officia, voluptate ratione quam nemo quod aut maiores animi nostrum, in
+          labore adipisci ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor, sit amet consectetur
+          adipisicing elit. Impedit dolorem tempora laboriosam asperiores eum dignissimos accusantium
+          voluptate eligendi beatae vel quis rerum error dolore cum incidunt pariatur accusamus, illum
+          consequuntur?
+        </AccordionItem>
+      </Accordion>
       <Button variant={'secondary'}>Secondary Button</Button>
       <Button>Primary Button</Button>
       <SearchField placeholder={'Search...'} />
       <Logo />
-
-      {loading ? (
-        <>
-          <Skeleton
-            variant='rectangular'
-            animation='wave'
-          />
-          <Skeleton
-            variant='rectangular'
-            animation={false}
-          />
-        </>
-      ) : (
-        <div>
-          <TextField label={'Text'} />
-        </div>
-      )}
     </div>
   )
 }

--- a/packages/components/src/accordion/AccordionItem.tsx
+++ b/packages/components/src/accordion/AccordionItem.tsx
@@ -37,7 +37,7 @@ export const AccordionItem: React.FC<MidasAccordionItem> = ({
     if (panelRef.current) {
       setPanelHeight(panelRef.current.clientHeight)
     }
-  }, [])
+  })
 
   return (
     <Disclosure


### PR DESCRIPTION
## Description

Users could not put dynamic content inside accordion item because the view did not re-render on other changes 

## Changes

Remove dependency array from `useLayoutEffect`. The view re-renders on any change but costs in performance

## Additional Information

Tests WIP

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
