### PR TITLE
fix(radio): fix hover on mobile, remove 100% height on RadioGroup

### DIFF
--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -1,11 +1,10 @@
 @value tokens: "../theme/tokens.css";
-@value display, inputLabel, inputText, black, blue150, gray50, gray60, signalRed10, signalRed100, medium, gray150, regular, smBreakpoint, focus, mdBreakpoint, borderSecondary from tokens;
+@value display, inputLabel, inputText, black, blue150, gray50, gray60, gray10, signalRed10, signalRed100, medium, gray150, regular, smBreakpoint, focus, mdBreakpoint, borderSecondary from tokens;
 
 .radioGroup {
   font-family: display;
   display: flex;
   flex-direction: column;
-  height: 100%;
 
   &[data-disabled] {
     pointer-events: none;


### PR DESCRIPTION
## Description

Fixes issue from support where RadioGroup renders incorrectly in some situations.

## Changes

1. Remove `height: 100%` on RadioGroup
2. Set correct hover background in mobile view

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
