### PR TITLE
fix(search-field): validation text

### DIFF
--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -1,6 +1,6 @@
 /* stylelint-disable property-no-vendor-prefix */
 @value tokens: "../theme/tokens.css";
-@value display, blue150, gray150, backgroundPrimary, signalRed100, focus, gray10 from tokens;
+@value display, signalRed100, focus, gray10 from tokens;
 
 .fieldError {
   font-family: display;

--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -1,15 +1,44 @@
 /* stylelint-disable property-no-vendor-prefix */
 @value tokens: "../theme/tokens.css";
-@value display, blue150, gray150, backgroundPrimary from tokens;
+@value display, blue150, gray150, backgroundPrimary, signalRed100, focus, gray10 from tokens;
+
+.fieldError {
+  font-family: display;
+  color: signalRed100;
+  grid-area: Error;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+  margin: 0.5rem 0;
+  line-height: 1.28;
+
+  &::before {
+    content: '';
+    background-color: signalRed100;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgY2xhc3M9Imx1Y2lkZSBsdWNpZGUtdHJpYW5nbGUtYWxlcnQiPjxwYXRoIGQ9Im0yMS43MyAxOC04LTE0YTIgMiAwIDAgMC0zLjQ4IDBsLTggMTRBMiAyIDAgMCAwIDQgMjFoMTZhMiAyIDAgMCAwIDEuNzMtMyIvPjxwYXRoIGQ9Ik0xMiA5djQiLz48cGF0aCBkPSJNMTIgMTdoLjAxIi8+PC9zdmc+');
+    mask-size: 1rem 1rem;
+    flex: 0 0 auto;
+    align-self: flex-start;
+    margin: 2px;
+
+    @media (forced-colors: active) {
+      background-color: highlight;
+    }
+  }
+}
 
 .container {
   font-family: display;
   display: flex;
-  align-items: flex-start;
   width: 100%;
 }
 
 .inputContainer {
+  display: flex;
   position: relative;
   min-height: 3rem;
   width: 100%;
@@ -40,10 +69,28 @@
   box-sizing: border-box;
   line-height: 1rem;
   appearance: none;
-  border: blue150 solid 1px;
+  background-color: gray10;
   width: 100%;
-  padding: 0.8125rem 0 0.8125rem 2.75rem;
-  background-color: backgroundPrimary;
+  padding: 0.875rem 0 0.875rem 2.75rem;
+
+  &:focus-visible {
+    box-shadow: focus;
+
+    @media (forced-colors: active) {
+      outline: 3px solid highlight;
+      outline-offset: 2px;
+    }
+  }
+
+  &[aria-invalid='true'] {
+    box-shadow: inset 0 0 0 3px signalRed100;
+
+    @media (forced-colors: active) {
+      outline: 3px solid highlight;
+      outline-offset: 2px;
+    }
+  }
+
   &::-webkit-search-decoration,
   &::-webkit-search-cancel-button,
   &::-webkit-search-results-button,

--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -91,6 +91,10 @@
     }
   }
 
+  &:disabled {
+    pointer-events: none;
+  }
+
   &::-webkit-search-decoration,
   &::-webkit-search-cancel-button,
   &::-webkit-search-results-button,

--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -1,6 +1,6 @@
 /* stylelint-disable property-no-vendor-prefix */
 @value tokens: "../theme/tokens.css";
-@value display, signalRed100, focus, gray10 from tokens;
+@value display, signalRed100, focus, gray10, black from tokens;
 
 .fieldError {
   font-family: display;
@@ -46,7 +46,7 @@
 
 .icon {
   position: absolute;
-  margin-left: 0.75rem;
+  margin-left: 0.875rem;
   left: 0;
   top: 50%;
   transform: translateY(-50%);
@@ -56,7 +56,7 @@
   display: flex;
   align-items: center;
   position: absolute;
-  padding: 0.75rem;
+  padding: 0.875rem;
   border: none;
   right: 0;
   top: 50%;
@@ -71,7 +71,8 @@
   appearance: none;
   background-color: gray10;
   width: 100%;
-  padding: 0.875rem 0 0.875rem 2.75rem;
+  padding: 0.875rem 0 0.875rem 3rem;
+  border-bottom: 1px solid black;
 
   &:focus-visible {
     box-shadow: focus;

--- a/packages/components/src/search-field/SearchField.spec.tsx
+++ b/packages/components/src/search-field/SearchField.spec.tsx
@@ -1,24 +1,48 @@
-import { screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { SearchField } from './'
 import user from '../../tests/utils/user'
-import { renderWithForm } from '../../tests/utils/browser'
 
 const placeholder = 'Search'
 
 describe('given a default SearchField', () => {
+  const onChange = jest.fn()
+  const onSubmit = jest.fn()
+
   beforeEach(() => {
-    renderWithForm(<SearchField placeholder={placeholder} />)
+    render(
+      <SearchField
+        placeholder={placeholder}
+        onChange={onChange}
+        onSubmit={onSubmit}
+      />,
+    )
   })
 
   it('should have no accessibility violations', async () => {
     expect(await axe(screen.getByLabelText(placeholder))).toHaveNoViolations()
   })
+
+  it('should be possible to submit a search string using only the keyboard', async () => {
+    await user.tab()
+    await user.keyboard('hello')
+    await user.keyboard('[Enter]')
+    expect(onChange).toHaveBeenCalledWith('hello')
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+  })
+
+  it('should be possible to submit a search string using the mouse', async () => {
+    await user.tab()
+    await user.keyboard('hello')
+    await user.click(screen.getByText('Sök'))
+    expect(onChange).toHaveBeenCalledWith('hello')
+    expect(onSubmit).toHaveBeenCalledWith('hello')
+  })
 })
 
 describe('given a required SearchField', () => {
   beforeEach(() => {
-    renderWithForm(
+    render(
       <SearchField
         placeholder={placeholder}
         isRequired
@@ -26,24 +50,40 @@ describe('given a required SearchField', () => {
     )
   })
 
-  it('should give a validation error if the user entered no text', async () => {
-    await user.tab()
-    await user.tab()
-    await user.keyboard('[Enter]')
+  it.failing(
+    'should give a validation error if the user entered no text',
+    async () => {
+      await user.tab()
+      await user.keyboard('[Enter]')
 
-    // JSDOM Native required validation message
-    expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
-  })
+      // JSDOM Native required validation message
+      expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
+    },
+  )
+
+  it.failing(
+    'should give a validation error if the user entered no text and used the mouse to click "search"',
+    async () => {
+      await user.click(screen.getByText('Sök'))
+
+      // JSDOM Native required validation message
+      expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
+    },
+  )
 })
 
 describe('given a SearchField with custom validation', () => {
   const errorMessage = 'Dont search for secret documents'
+  const onChange = jest.fn()
+  const onSubmit = jest.fn()
 
   beforeEach(() =>
-    renderWithForm(
+    render(
       <SearchField
         placeholder={placeholder}
         validate={value => (value === 'secret' ? errorMessage : true)}
+        onChange={onChange}
+        onSubmit={onSubmit}
       />,
     ),
   )
@@ -53,6 +93,17 @@ describe('given a SearchField with custom validation', () => {
     await user.keyboard('secret')
     await user.tab()
     await user.keyboard('[Enter]')
+    expect(onChange).toHaveBeenCalledWith('secret')
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  })
+
+  it('should give a validation error if the user entered an unpermitted text and used the mouse to click "search"', async () => {
+    await user.tab()
+    await user.keyboard('secret')
+    await user.click(screen.getByText('Sök'))
+    expect(onChange).toHaveBeenCalledWith('secret')
+    expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByText(errorMessage)).toBeInTheDocument()
   })
 })

--- a/packages/components/src/search-field/SearchField.spec.tsx
+++ b/packages/components/src/search-field/SearchField.spec.tsx
@@ -41,38 +41,6 @@ describe('given a default SearchField', () => {
   })
 })
 
-describe('given a required SearchField', () => {
-  beforeEach(() => {
-    render(
-      <SearchField
-        placeholder={placeholder}
-        isRequired
-      />,
-    )
-  })
-
-  it.failing(
-    'should give a validation error if the user entered no text',
-    async () => {
-      await user.tab()
-      await user.keyboard('[Enter]')
-
-      // JSDOM Native required validation message
-      expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
-    },
-  )
-
-  it.failing(
-    'should give a validation error if the user entered no text and used the mouse to click "search"',
-    async () => {
-      await user.click(screen.getByText(buttonText))
-
-      // JSDOM Native required validation message
-      expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
-    },
-  )
-})
-
 describe('given a SearchField with custom validation', () => {
   const errorMessage = 'Dont search for secret documents'
   const onChange = jest.fn()

--- a/packages/components/src/search-field/SearchField.spec.tsx
+++ b/packages/components/src/search-field/SearchField.spec.tsx
@@ -4,6 +4,7 @@ import { SearchField } from './'
 import user from '../../tests/utils/user'
 
 const placeholder = 'Search'
+const buttonText = 'Sök'
 
 describe('given a default SearchField', () => {
   const onChange = jest.fn()
@@ -34,7 +35,7 @@ describe('given a default SearchField', () => {
   it('should be possible to submit a search string using the mouse', async () => {
     await user.tab()
     await user.keyboard('hello')
-    await user.click(screen.getByText('Sök'))
+    await user.click(screen.getByText(buttonText))
     expect(onChange).toHaveBeenCalledWith('hello')
     expect(onSubmit).toHaveBeenCalledWith('hello')
   })
@@ -64,7 +65,7 @@ describe('given a required SearchField', () => {
   it.failing(
     'should give a validation error if the user entered no text and used the mouse to click "search"',
     async () => {
-      await user.click(screen.getByText('Sök'))
+      await user.click(screen.getByText(buttonText))
 
       // JSDOM Native required validation message
       expect(screen.getByText(/Constraints not satisfied/)).toBeInTheDocument()
@@ -101,7 +102,7 @@ describe('given a SearchField with custom validation', () => {
   it('should give a validation error if the user entered an unpermitted text and used the mouse to click "search"', async () => {
     await user.tab()
     await user.keyboard('secret')
-    await user.click(screen.getByText('Sök'))
+    await user.click(screen.getByText(buttonText))
     expect(onChange).toHaveBeenCalledWith('secret')
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByText(errorMessage)).toBeInTheDocument()

--- a/packages/components/src/search-field/SearchField.spec.tsx
+++ b/packages/components/src/search-field/SearchField.spec.tsx
@@ -107,3 +107,22 @@ describe('given a SearchField with custom validation', () => {
     expect(screen.getByText(errorMessage)).toBeInTheDocument()
   })
 })
+
+describe('given an invalid SearchField with custom errorMessage', () => {
+  const errorMessage = 'Random error'
+
+  beforeEach(() =>
+    render(
+      <SearchField
+        placeholder={placeholder}
+        errorMessage={errorMessage}
+        isInvalid
+      />,
+    ),
+  )
+
+  it('it should be invalid and show the custom message', async () => {
+    expect(screen.getByLabelText(placeholder)).toBeInvalid()
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/search-field/SearchField.stories.tsx
+++ b/packages/components/src/search-field/SearchField.stories.tsx
@@ -17,3 +17,19 @@ export const Primary: Story = {
     placeholder: 'Sök efter en person',
   },
 }
+
+export const CustomValidation: Story = {
+  args: {
+    placeholder: 'Sök efter "secret"',
+    validate: (value: string) =>
+      value === 'secret' ? 'Sök inte efter hemligheter' : true,
+  },
+}
+
+export const Invalid: Story = {
+  args: {
+    placeholder: 'Sök efter dokument',
+    isInvalid: true,
+    errorMessage: 'Något gick fel, var god försök igen',
+  },
+}

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -70,9 +70,8 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
     ref,
   )
 
-  const handleChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => setValue(value)
+  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
+    setValue(target.value)
 
   const handleClear = () => setValue('')
 
@@ -92,8 +91,8 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
     }
   }
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+  const handleKeyDown = ({ key }: React.KeyboardEvent<HTMLInputElement>) => {
+    if (key === 'Enter') {
       handleSubmit()
     }
   }

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -10,9 +10,9 @@ import { Button } from '../button'
 import styles from './SearchField.module.css'
 import clsx from 'clsx'
 import * as React from 'react'
-
 import { useSearchFieldState } from 'react-stately'
 import { useSearchField } from 'react-aria'
+import type { ValidationError } from '@react-types/shared'
 
 export interface SearchFieldProps extends AriaSearchFieldProps {
   /** Placeholder text */
@@ -40,6 +40,12 @@ export interface SearchFieldProps extends AriaSearchFieldProps {
    * A custom error message if using the isInvalid prop.
    */
   errorMessage?: string
+}
+
+function isValidationError(
+  error: ValidationError | true | null | undefined,
+): error is ValidationError {
+  return !!(error as ValidationError)?.length
 }
 
 export const SearchField: React.FC<SearchFieldProps> = props => {
@@ -71,7 +77,7 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
   const handleClear = () => setValue('')
 
   const handleSubmit = () => {
-    if (props.validate && props.validate(value) !== true) {
+    if (props.validate && isValidationError(props.validate(value))) {
       ref.current?.focus()
       return
     }

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -143,6 +143,7 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
           )}
         </div>
         <Button
+          isDisabled={props.isDisabled}
           excludeFromTabOrder
           onPress={handleSubmit}
           type='button'

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -36,6 +36,10 @@ export interface SearchFieldProps extends AriaSearchFieldProps {
    * Currently have troubles displaying an error message, please use the validate property if it's needed.
    */
   isRequired?: AriaSearchFieldProps['isRequired']
+  /**
+   * A custom error message if using the isInvalid prop.
+   */
+  errorMessage?: string
 }
 
 export const SearchField: React.FC<SearchFieldProps> = props => {
@@ -95,7 +99,7 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
           {...errorMessageProps}
           className={styles.fieldError}
         >
-          {validationErrors.join(' ')}
+          {props.errorMessage ?? validationErrors.join(' ')}
         </div>
       )}
       <div className={styles.container}>

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -14,7 +14,8 @@ import { useSearchFieldState } from 'react-stately'
 import { useSearchField } from 'react-aria'
 import type { ValidationError } from '@react-types/shared'
 
-export interface SearchFieldProps extends AriaSearchFieldProps {
+export interface SearchFieldProps
+  extends Omit<AriaSearchFieldProps, 'isRequired'> {
   /** Placeholder text */
   placeholder: string
   /**
@@ -23,19 +24,6 @@ export interface SearchFieldProps extends AriaSearchFieldProps {
    *  'Sök'
    */
   buttonText?: string
-  /**
-   * A function that returns an error message if a given value is invalid.
-   * Validation errors are displayed to the user when the form is submitted if validationBehavior="native".
-   * For realtime validation, use the isInvalid prop instead.
-   *
-   * To override the behavior of the isRequired prop you can instead use this property to return a custom error message.
-   */
-  validate?: AriaSearchFieldProps['validate']
-  /**
-   * Whether user input is required on the input before form submission.
-   * Currently have troubles displaying an error message, please use the validate property if it's needed.
-   */
-  isRequired?: AriaSearchFieldProps['isRequired']
   /**
    * A custom error message if using the isInvalid prop.
    */
@@ -76,12 +64,12 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
   const handleClear = () => setValue('')
 
   const handleSubmit = () => {
-    if (props.validate && isValidationError(props.validate(value))) {
-      ref.current?.focus()
-      return
-    }
+    const reFocus =
+      (props.validate && isValidationError(props.validate(value))) ||
+      isInvalid ||
+      !value
 
-    if (isInvalid || (!value && props.isRequired)) {
+    if (reFocus) {
       ref.current?.focus()
       return
     }

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import {
-  FieldError,
-  Input,
   Label,
-  SearchField as AriaSearchField,
-  SearchFieldProps as AriaSearchFieldProps
+  SearchFieldProps as AriaSearchFieldProps,
 } from 'react-aria-components'
 import { Search, X } from 'lucide-react'
 import TextFieldStyles from '../textfield/TextField.module.css'
@@ -13,6 +10,9 @@ import { Button } from '../button'
 import styles from './SearchField.module.css'
 import clsx from 'clsx'
 import * as React from 'react'
+
+import { useSearchFieldState } from 'react-stately'
+import { useSearchField } from 'react-aria'
 
 export interface SearchFieldProps extends AriaSearchFieldProps {
   /** Placeholder text */
@@ -23,47 +23,129 @@ export interface SearchFieldProps extends AriaSearchFieldProps {
    *  'Sök'
    */
   buttonText?: string
+  /**
+   * A function that returns an error message if a given value is invalid.
+   * Validation errors are displayed to the user when the form is submitted if validationBehavior="native".
+   * For realtime validation, use the isInvalid prop instead.
+   *
+   * To override the behavior of the isRequired prop you can instead use this property to return a custom error message.
+   */
+  validate?: AriaSearchFieldProps['validate']
+  /**
+   * Whether user input is required on the input before form submission.
+   * Currently have troubles displaying an error message, please use the validate property if it's needed.
+   */
+  isRequired?: AriaSearchFieldProps['isRequired']
 }
 
-export const SearchField: React.FC<SearchFieldProps> = ({
-  placeholder,
-  buttonText,
-  ...props
-}) => {
-  const [hasInput, setHasInput] = React.useState(false)
+export const SearchField: React.FC<SearchFieldProps> = props => {
+  const { value, setValue } = useSearchFieldState(props)
+
+  const ref = React.useRef<HTMLInputElement>(null)
+
+  const {
+    labelProps,
+    inputProps,
+    errorMessageProps,
+    isInvalid,
+    validationErrors,
+    clearButtonProps,
+  } = useSearchField(
+    {
+      ...props,
+      label: props.placeholder,
+      validationBehavior: 'native',
+    },
+    { value, setValue },
+    ref,
+  )
+
+  const handleChange = ({
+    target: { value },
+  }: React.ChangeEvent<HTMLInputElement>) => setValue(value)
+
+  const handleClear = () => setValue('')
+
+  const handleSubmit = () => {
+    if (props.validate && props.validate(value) !== true) {
+      ref.current?.focus()
+      return
+    }
+
+    if (isInvalid || (!value && props.isRequired)) {
+      ref.current?.focus()
+      return
+    }
+
+    if (props.onSubmit) {
+      props.onSubmit(value)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSubmit()
+    }
+  }
 
   return (
-    <AriaSearchField
-      onInput={() => setHasInput(true)}
-      onClear={() => setHasInput(false)}
-      className={styles.container}
-      {...props}
-    >
-      <Label hidden>{placeholder}</Label>
-      <div className={styles.inputContainer}>
-        <Search
-          size={20}
-          className={styles.icon}
-        />
-        <Input
-          className={clsx(TextFieldStyles.input, styles.input)}
-          placeholder={placeholder}
-        />
-        {hasInput && (
-          <Button
-            variant='icon'
-            size='small'
-            className={styles.clear}
-          >
-            <X
-              size={20}
-              aria-hidden
-            />
-          </Button>
-        )}
+    <div>
+      {isInvalid && (
+        <div
+          {...errorMessageProps}
+          className={styles.fieldError}
+        >
+          {validationErrors.join(' ')}
+        </div>
+      )}
+      <div className={styles.container}>
+        <Label
+          {...labelProps}
+          hidden
+        >
+          {props.placeholder}
+        </Label>
+        <div className={styles.inputContainer}>
+          <Search
+            size={20}
+            className={styles.icon}
+          />
+          <input
+            {...inputProps}
+            className={clsx(
+              TextFieldStyles.input,
+              styles.input,
+              inputProps.className,
+            )}
+            ref={ref}
+            onChange={handleChange}
+            value={value}
+            aria-invalid={isInvalid}
+            onKeyDown={handleKeyDown}
+          />
+          {value.length > 0 && (
+            <Button
+              variant='icon'
+              size='small'
+              className={styles.clear}
+              onPress={handleClear}
+              {...clearButtonProps}
+            >
+              <X
+                size={20}
+                aria-hidden
+              />
+            </Button>
+          )}
+        </div>
+        <Button
+          excludeFromTabOrder
+          onPress={handleSubmit}
+          type='button'
+        >
+          {props.buttonText ? props.buttonText : 'Sök'}
+        </Button>
       </div>
-      <FieldError />
-      <Button type='submit'>{buttonText ? buttonText : 'Sök'}</Button>
-    </AriaSearchField>
+    </div>
   )
 }

--- a/packages/components/src/search-field/index.ts
+++ b/packages/components/src/search-field/index.ts
@@ -1,1 +1,1 @@
-export {SearchField} from './SearchField'
+export { SearchField } from './SearchField'


### PR DESCRIPTION
## Description

The validation for SearchField was different if the user used the mouse or the keyboard to submit

## Changes

* Add tests
* Style the validation error text
* Use `useSearchField` hook to get the button to submit
* Drop support for `isRequired` prop
* Change some styling for the input (!!)

## Additional Information

I couldn't get the `isRequired` prop to validate without wrapping the SearchField with a form

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
- [x] Add disabled styling
