### PR TITLE
fix(card): append props.className

### DIFF
--- a/packages/components/src/card/Card.spec.tsx
+++ b/packages/components/src/card/Card.spec.tsx
@@ -9,6 +9,7 @@ const link = { children: linkText, href: '#' }
 const title = 'Rubrik'
 const content = 'Lorem ipsum'
 const testId = 'card'
+const testClass = 'test-class'
 
 describe('given a default card', () => {
   beforeEach(() => {
@@ -18,7 +19,8 @@ describe('given a default card', () => {
         title={title}
         content={content}
         link={link}
-      />
+        className={testClass}
+      />,
     )
   })
 
@@ -34,6 +36,10 @@ describe('given a default card', () => {
 
     expect(screen.getByText(linkText)).toHaveFocus()
   })
+
+  it('should preserve its classNames when being passed new ones', async () => {
+    expect(screen.getByTestId(testId)).toHaveClass('card', testClass)
+  })
 })
 
 describe('given a card with background', () => {
@@ -45,7 +51,7 @@ describe('given a card with background', () => {
         content={content}
         background
         link={link}
-      />
+      />,
     )
   })
 
@@ -64,7 +70,7 @@ describe('given a card with image', () => {
         content={content}
         image={{ source: '', description: '' }}
         link={link}
-      />
+      />,
     )
   })
 

--- a/packages/components/src/card/Card.tsx
+++ b/packages/components/src/card/Card.tsx
@@ -43,16 +43,13 @@ export const Card: React.FC<CardProps> = ({
   headingTag: HeadingTag = 'h1',
   customImageComponent,
   customLinkComponent: CustomLinkComponent,
+  className,
   ...rest
 }) => {
   const contentId = React.useId()
   return (
     <div
-      className={clsx(
-        styles.card,
-        background && styles.background,
-        rest.className,
-      )}
+      className={clsx(styles.card, background && styles.background, className)}
       {...rest}
     >
       <div className={styles.content}>


### PR DESCRIPTION
## Description

Card css breaks when using the `className` prop

## Changes

Add a test
Break out the className prop

## Checklist

- [x] Tests added if applicable
- [x] Conventional commit messages
