### PR TITLE
fix: set correct cursor for radio, checkbox, datepicker

### DIFF
--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -117,6 +117,7 @@
 
   &[data-disabled] {
     color: gray50;
+    cursor: not-allowed;
   }
 
   &[data-disabled][data-selected] div {

--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -53,6 +53,7 @@
   forced-color-adjust: none;
   display: flex;
   width: max-content;
+  cursor: pointer;
 
   &:hover div {
     border-color: gray100;

--- a/packages/components/src/date-picker/DatePicker.module.css
+++ b/packages/components/src/date-picker/DatePicker.module.css
@@ -27,6 +27,7 @@
     padding-left: 1rem;
     color: black;
     background-color: gray10;
+    cursor: pointer;
 
     &:hover {
       background-color: gray20;
@@ -86,6 +87,7 @@
     border: none;
     color: black;
     background-color: gray10;
+    cursor: pointer;
 
     &:focus-visible,
     &[data-focus-visible] {
@@ -107,6 +109,7 @@
 
 .day {
   border: solid 2px gray10;
+  cursor: pointer;
 
   &:hover {
     background-color: gray20;

--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -26,6 +26,7 @@
   align-items: center;
   gap: 0.5rem;
   color: inputText;
+  cursor: pointer;
 
   &::before {
     content: '';

--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -52,6 +52,7 @@
 
   &[data-disabled] {
     color: gray50;
+    cursor: not-allowed;
   }
 
   &[data-disabled]::before {


### PR DESCRIPTION
## Description

Sets `cursor: pointer` on interactive elements, `cursor: not-allowed` on disabled elements

## Additional Information

Fixes #299 (Select will be in separate issue)

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
