### PR TITLE
fix: change the weekday names to swedish languge

### DIFF
--- a/packages/components/src/date-picker/DatePicker.tsx
+++ b/packages/components/src/date-picker/DatePicker.tsx
@@ -111,7 +111,10 @@ export const DateRangePicker = <T extends DateValue>({
                   />
                 </Button>
               </header>
-              <CalendarGrid className={styles.calendar}>
+              <CalendarGrid
+                className={styles.calendar}
+                weekdayStyle='short'
+              >
                 {date => (
                   <CalendarCell
                     date={date}
@@ -187,7 +190,10 @@ export const DatePicker = <T extends DateValue>({
                   <ChevronRight />
                 </Button>
               </header>
-              <CalendarGrid className={styles.calendar}>
+              <CalendarGrid
+                className={styles.calendar}
+                weekdayStyle='short'
+              >
                 {date => (
                   <CalendarCell
                     date={date}


### PR DESCRIPTION
## Description
change the weekday names to swedish languge
## Changes

add prop weekdayStyle='short' in CalendarGrid

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
