### PR TITLE
feat(button): set primary border to 2px when in high-contrast mode

### DIFF
--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -146,3 +146,9 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
 }
+
+@media (forced-colors: active) {
+  .primary {
+    border-width: 2px;
+  }
+}


### PR DESCRIPTION
## Description

Primary button looks the same as other buttons. This increases border width for primary

## Changes

When `forced-colors: active` -> `border-width: 2px` on primary btn

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
