### PR TITLE
fix(select): change direct element selector

### DIFF
--- a/packages/components/src/select/Select.module.css
+++ b/packages/components/src/select/Select.module.css
@@ -317,7 +317,7 @@
 }
 
 /* checkbox stuff */
-input[type='checkbox'] {
+.checkbox {
   /* -webkit-appearance: none; */
   appearance: none;
   background-color: blue150;
@@ -331,7 +331,7 @@ input[type='checkbox'] {
   border-radius: 0;
 }
 
-input[type='checkbox']::before {
+.checkbox::before {
   content: '';
   width: 0.9rem;
   height: 0.9rem;
@@ -342,13 +342,13 @@ input[type='checkbox']::before {
   cursor: pointer;
 }
 
-input[type='checkbox']:checked::before {
+.checkbox:checked::before {
   transform: scale(1);
   mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrIj48cGF0aCBkPSJNMjAgNiA5IDE3bC01LTUiLz48L3N2Zz4=');
   mask-size: 0.9rem 0.9rem;
 }
 
-input[type='checkbox']:indeterminate::before {
+.checkbox:indeterminate::before {
   width: 1rem;
   height: 1rem;
   mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1pbnVzIj48cGF0aCBkPSJNNSAxMmgxNCIvPjwvc3ZnPg==');

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -326,6 +326,7 @@ export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
                           >
                             <div className={styles.checkboxContainer}>
                               <input
+                                className={styles.checkbox}
                                 type='checkbox'
                                 checked={isAllSelection}
                                 ref={refAllButton}

--- a/packages/components/src/select/SelectListBox.tsx
+++ b/packages/components/src/select/SelectListBox.tsx
@@ -47,6 +47,7 @@ const Option = <T,>({ item, state }: OptionProps<T>) => {
       {state.selectionMode === 'multiple' && (
         <div className={styles.checkboxContainer}>
           <input
+            className={styles.checkbox}
             type='checkbox'
             disabled={isDisabled}
             checked={isSelected}


### PR DESCRIPTION
## Description

Selecting elements directly causes css to bleed out of component scope (in Storybook etc.)

## Changes

Add a class to checkbox inputs
Select the class instead of the input in the css file

## Additional Information


## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
