### PR TITLE
fix(link-button): fix colors on hover state

### DIFF
--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -19,8 +19,8 @@
 
   &:hover {
     text-decoration: none;
-    color: --text-on-color;
     background-color: --button-background-primary-hover;
+    color: --text-on-color;
   }
 
   &[data-pressed] {
@@ -54,6 +54,7 @@
   }
 
   &:hover {
+    color: --text-brand;
     background-color: --button-background-secondary-hover;
   }
 
@@ -72,6 +73,7 @@
   opacity: 1;
 
   &:hover {
+    color: --text-brand;
     background-color: --button-background-tertiary-hover;
   }
 


### PR DESCRIPTION
## Description

Fix bug with dark mode tokens on LinkButton hover states

## Changes

Prevented that hover text is sometimes white.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [X] Conventional commit messages
