### PR TITLE
chore(components): 💄replace pseudo-class selectors

### DIFF
--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -68,12 +68,12 @@
         transition: transform --normal-transition ease;
       }
 
-      &:hover {
+      &[data-hovered] {
         background-color: var(--background-hover);
       }
     }
 
-    &:hover {
+    &[data-hovered] {
       background-color: var(--background-hover);
     }
   }

--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -28,7 +28,7 @@
     }
   }
 
-  &:hover {
+  &[data-hovered] {
     background-color: --button-background-primary-hover;
   }
 
@@ -50,7 +50,7 @@
   border-color: --button-border-primary;
   opacity: 1;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --button-background-secondary-hover;
   }
 
@@ -73,7 +73,7 @@
   padding: 0.8125rem 0.9375rem;
   opacity: 1;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --button-background-tertiary-hover;
   }
 
@@ -95,7 +95,7 @@
   display: flex;
   align-items: center;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --button-background-icon-hover;
   }
 
@@ -114,7 +114,7 @@
   background-color: --button-background-danger;
   opacity: 1;
 
-  &:hover {
+  &[data-hovered] {
     color: --white;
     background-color: --button-background-danger-hover;
   }

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -99,3 +99,10 @@ export const Icon = {
     'aria-label': 'Stäng',
   },
 }
+
+export const Danger: Story = {
+  args: {
+    children: 'Button',
+    variant: 'danger',
+  },
+}

--- a/packages/components/src/card/Card.module.css
+++ b/packages/components/src/card/Card.module.css
@@ -16,17 +16,12 @@
     transform --fast-transition ease-in-out,
     background-color --fast-transition ease-in-out;
 
-  &:hover {
+  &:has([data-hovered]) {
     background-color: --layer-hover-02;
   }
 
-  &:active {
+  &:has([data-pressed]) {
     background-color: --layer-selected-02;
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: --focus;
   }
 }
 

--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -47,7 +47,7 @@
   cursor: pointer;
   color: --text-primary;
 
-  &:hover div {
+  &[data-hovered] div {
     border-color: --button-background-primary-hover;
   }
 
@@ -149,7 +149,7 @@
       border: 1px solid --border-strong;
       width: auto;
 
-      &:hover {
+      &[data-hovered] {
         background-color: --layer-hover-01;
       }
 

--- a/packages/components/src/combobox/ComboBox.module.css
+++ b/packages/components/src/combobox/ComboBox.module.css
@@ -12,7 +12,8 @@
   background-color: --field-01;
   box-shadow: 0 1px 0 0 --border-strong;
 
-  &:hover {
+  &[data-hovered],
+  &:has(+ [data-hovered]) {
     background-color: --field-hover-01;
   }
 
@@ -80,6 +81,10 @@
 
   &[aria-expanded='true'] {
     transform: rotate(180deg);
+  }
+
+  &[data-hovered] {
+    cursor: pointer;
   }
 }
 

--- a/packages/components/src/dropdown/Dropdown.module.css
+++ b/packages/components/src/dropdown/Dropdown.module.css
@@ -12,7 +12,7 @@
   }
 }
 
-.dropdownMenu {
+.menuItem {
   width: 100%;
 
   &:focus-visible {

--- a/packages/components/src/dropdown/Dropdown.module.css
+++ b/packages/components/src/dropdown/Dropdown.module.css
@@ -6,7 +6,7 @@
   box-shadow: 2px 2px 4px 0 rgb(0 0 0 / 25%);
   background-color: --button-background-tertiary-hover;
 
-  &:focus-visible {
+  &[data-focus-visible] {
     outline: none;
     box-shadow: --focus;
   }
@@ -15,7 +15,7 @@
 .menuItem {
   width: 100%;
 
-  &:focus-visible {
+  &[data-focus-visible] {
     outline: none;
     box-shadow: --focus;
   }

--- a/packages/components/src/dropdown/Dropdown.tsx
+++ b/packages/components/src/dropdown/Dropdown.tsx
@@ -5,11 +5,12 @@ import {
   Popover,
   type MenuItemProps,
   type MenuProps,
-  type MenuTriggerProps
+  type MenuTriggerProps,
 } from 'react-aria-components'
 import { Button } from '../button'
 import { EllipsisVertical } from 'lucide-react'
 import styles from './Dropdown.module.css'
+import clsx from 'clsx'
 
 interface MidasMenuButtonProps<T>
   extends MenuProps<T>,
@@ -58,7 +59,12 @@ export function DropdownItem(props: MenuItemProps) {
       {...props}
       textValue={textValue}
       className={({ isFocused, isOpen }) =>
-        `${styles.dropdownMenu} ${isFocused ? 'focused' : ''} ${isOpen ? 'open' : ''}`
+        clsx(
+          styles.menuItem,
+          props.className,
+          isFocused && 'focused',
+          isOpen && 'open',
+        )
       }
     >
       {({ hasSubmenu }) => (

--- a/packages/components/src/file-upload/FileUpload.module.css
+++ b/packages/components/src/file-upload/FileUpload.module.css
@@ -63,7 +63,7 @@
   text-align: center;
   background-color: --background-01;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --background-hover-01;
   }
 }

--- a/packages/components/src/file-upload/FileUpload.stories.tsx
+++ b/packages/components/src/file-upload/FileUpload.stories.tsx
@@ -18,6 +18,12 @@ type Story = StoryObj<typeof FileUpload>
 
 export const Primary: Story = {}
 
+export const DropZone: Story = {
+  args: {
+    dropzone: true,
+  },
+}
+
 export const CustomSelectHandler: Story = {
   tags: ['!dev'],
   args: {

--- a/packages/components/src/layout/Layout.module.css
+++ b/packages/components/src/layout/Layout.module.css
@@ -254,7 +254,7 @@
     stroke: --icon-primary;
   }
 
-  &:hover,
+  &[data-hovered],
   &:visited {
     background-color: --button-background-tertiary-hover;
     color: --text-primary;

--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --size-03, --button-background-primary, --text-on-color, --button-background-primary-hover, --button-background-primary-active, --focus, --button-background-disabled, --text-disabled, --text-brand, --border-brand, --button-background-secondary, --button-background-secondary-hover, --button-background-secondary-active, --border-disabled, --button-background-tertiary-hover, --button-background-tertiary-active, --button-background-danger, --button-background-danger-hover, --button-background-danger-active, --white, --icon-secondary from tokens;
+@value --font-family, --size-03, --button-background-primary, --text-on-color, --button-background-primary-hover, --button-background-primary-active, --focus, --button-background-disabled, --text-disabled, --text-brand, --border-brand, --button-background-secondary, --button-background-secondary-hover, --button-background-secondary-active, --border-disabled, --button-background-tertiary-hover, --button-background-tertiary-active, --button-background-danger, --button-background-danger-hover, --button-background-danger-active, --white, --icon-secondary, --button-background-icon-hover from tokens;
 
 .linkButton {
   font-family: --font-family;
@@ -17,7 +17,7 @@
   gap: 0.5rem;
   text-decoration: none;
 
-  &:hover {
+  &[data-hovered] {
     text-decoration: none;
     background-color: --button-background-primary-hover;
     color: --text-on-color;
@@ -53,7 +53,7 @@
     color: --icon-secondary;
   }
 
-  &:hover {
+  &[data-hovered] {
     color: --text-brand;
     background-color: --button-background-secondary-hover;
   }
@@ -72,7 +72,7 @@
   background-color: transparent;
   opacity: 1;
 
-  &:hover {
+  &[data-hovered] {
     color: --text-brand;
     background-color: --button-background-tertiary-hover;
   }
@@ -87,7 +87,7 @@
   background-color: --button-background-danger;
   opacity: 1;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --button-background-danger-hover;
   }
 
@@ -104,8 +104,8 @@
   display: flex;
   align-items: center;
 
-  &:hover {
-    background-color: rgba(0 0 0 / 10%);
+  &[data-hovered] {
+    background-color: --button-background-icon-hover;
   }
 
   &[data-disabled] {

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { LinkButton } from './LinkButton'
+import { X } from 'lucide-react'
 
 const meta: Meta<typeof LinkButton> = {
   component: LinkButton,
@@ -11,18 +12,18 @@ const meta: Meta<typeof LinkButton> = {
     variant: {
       options: ['primary', 'secondary', 'tertiary', 'danger'],
       control: { type: 'radio' },
-      defaultValue: 'primary'
+      defaultValue: 'primary',
     },
     isDisabled: {
       options: [true, false],
-      control: { type: 'radio' }
+      control: { type: 'radio' },
     },
     iconPlacement: {
       options: ['right', 'left'],
       control: { type: 'radio' },
-      defaultValue: 'left'
-    }
-  }
+      defaultValue: 'left',
+    },
+  },
 }
 export default meta
 type Story = StoryObj<typeof LinkButton>
@@ -30,42 +31,57 @@ type Story = StoryObj<typeof LinkButton>
 export const Primary: Story = {
   args: {
     children: 'Till E-tjänst',
-    href: '#'
-  }
+    href: '#',
+  },
 }
 
 export const Secondary: Story = {
   args: {
     ...Primary.args,
-    variant: 'secondary'
-  }
+    variant: 'secondary',
+  },
 }
 
 export const Tertiary: Story = {
   args: {
     ...Primary.args,
-    variant: 'tertiary'
-  }
+    variant: 'tertiary',
+  },
 }
 
 export const Previous: Story = {
   args: {
     ...Primary.args,
     children: 'Föregående',
-    iconPlacement: 'left'
-  }
+    iconPlacement: 'left',
+  },
 }
 
 export const Disabled: Story = {
   args: {
     ...Primary.args,
-    isDisabled: true
-  }
+    isDisabled: true,
+  },
 }
 
 export const AppLink: Story = {
   args: {
     children: 'Till E-tjänst',
-    onPress: () => alert('navigation fn')
-  }
+    onPress: () => alert('navigation fn'),
+  },
+}
+
+export const Danger: Story = {
+  args: {
+    children: 'Radera',
+    variant: 'danger',
+  },
+}
+
+export const Icon: Story = {
+  args: {
+    variant: 'icon',
+    icon: X,
+    'aria-label': 'Close',
+  },
 }

--- a/packages/components/src/link/Link.module.css
+++ b/packages/components/src/link/Link.module.css
@@ -11,7 +11,7 @@
   font-weight: 400;
   align-items: center;
 
-  &:hover {
+  &[data-hovered] {
     color: --link-hover;
   }
 
@@ -52,7 +52,7 @@
   text-decoration: none;
   font-weight: 500;
 
-  &:hover {
+  &[data-hovered] {
     text-decoration: underline;
   }
 

--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -50,7 +50,7 @@
     }
   }
 
-  &:hover {
+  &[data-hovered] {
     &::before {
       border-color: --border-medium;
     }
@@ -97,7 +97,7 @@
     border: 1px solid --border-strong;
     width: auto;
 
-    &:hover {
+    &[data-hovered] {
       background-color: --field-hover-02;
     }
 

--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -75,7 +75,7 @@
   padding: 0.875rem 0 0.875rem 3rem;
   border-bottom: 1px solid --border-strong;
 
-  &[data-focus-visible] {
+  &:focus-visible {
     box-shadow: --focus;
 
     @media (forced-colors: active) {

--- a/packages/components/src/search-field/SearchField.module.css
+++ b/packages/components/src/search-field/SearchField.module.css
@@ -75,7 +75,7 @@
   padding: 0.875rem 0 0.875rem 3rem;
   border-bottom: 1px solid --border-strong;
 
-  &:focus-visible {
+  &[data-focus-visible] {
     box-shadow: --focus;
 
     @media (forced-colors: active) {
@@ -88,7 +88,7 @@
     border: 2px solid --border-invalid;
   }
 
-  &:disabled {
+  &[data-disabled] {
     pointer-events: none;
   }
 

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -8,7 +8,7 @@ import styles from './SearchField.module.css'
 import clsx from 'clsx'
 import * as React from 'react'
 import { useSearchFieldState } from 'react-stately'
-import { useSearchField } from 'react-aria'
+import { useFocusVisible, useSearchField } from 'react-aria'
 import type { ValidationError } from '@react-types/shared'
 
 export interface SearchFieldProps
@@ -53,6 +53,8 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
     { value, setValue },
     ref,
   )
+
+  const { isFocusVisible } = useFocusVisible({ isTextInput: true })
 
   const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
     setValue(target.value)
@@ -99,6 +101,8 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
           />
           <input
             {...inputProps}
+            {...(isFocusVisible && { 'data-focus-visible': true })}
+            {...(inputProps.disabled && { 'data-disabled': true })}
             className={clsx(
               TextFieldStyles.input,
               styles.input,

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -8,7 +8,7 @@ import styles from './SearchField.module.css'
 import clsx from 'clsx'
 import * as React from 'react'
 import { useSearchFieldState } from 'react-stately'
-import { useFocusVisible, useSearchField } from 'react-aria'
+import { useSearchField } from 'react-aria'
 import type { ValidationError } from '@react-types/shared'
 
 export interface SearchFieldProps
@@ -53,8 +53,6 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
     { value, setValue },
     ref,
   )
-
-  const { isFocusVisible } = useFocusVisible({ isTextInput: true })
 
   const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
     setValue(target.value)
@@ -101,7 +99,6 @@ export const SearchField: React.FC<SearchFieldProps> = props => {
           />
           <input
             {...inputProps}
-            {...(isFocusVisible && { 'data-focus-visible': true })}
             {...(inputProps.disabled && { 'data-disabled': true })}
             className={clsx(
               TextFieldStyles.input,

--- a/packages/components/src/tag/Tag.module.css
+++ b/packages/components/src/tag/Tag.module.css
@@ -7,7 +7,7 @@
   padding: 0.375rem !important;
   border-radius: 1.5rem;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --field-hover-01;
   }
 

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -103,7 +103,7 @@
   box-sizing: border-box;
   width: 100%;
 
-  &:hover {
+  &[data-hovered] {
     background-color: --field-hover-01;
 
     & + .passwordText {


### PR DESCRIPTION
## Description

For **building high quality interactions** we should use React Aria's data-attributes instead of native pseudo-classes when possible

## Changes

Replace pseudo-classes found in components

## Additional Information

UX approves my deletion in `Card.module.css`

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
