### PR TITLE
chore: revert node_env in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Install dependencies
         run: npm install
         shell: bash
-        env:
-          NODE_ENV: production
 
       - name: Print Environment Info
         run: npx nx report


### PR DESCRIPTION
## Description

Only change to publish file since last successful publish, testing to see if this solves the problem. **CONFIRMED WORKING!**

## Changes

- remove node_env setting in publish workflow 