### PR TITLE
fix(link-button): add pseudo-classes in CSS link-button to primary and secondary

### DIFF
--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -17,18 +17,21 @@
   gap: 0.5rem;
   text-decoration: none;
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     text-decoration: none;
     background-color: --button-background-primary-hover;
     color: --text-on-color;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     background-color: --button-background-primary-active;
     outline: none;
   }
 
-  &[data-focus-visible] {
+  &[data-focus-visible],
+  &:focus-visible {
     box-shadow: --focus;
 
     @media (forced-colors: active) {
@@ -53,7 +56,8 @@
     color: --icon-secondary;
   }
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     color: --text-brand;
     background-color: --button-background-secondary-hover;
   }
@@ -62,7 +66,8 @@
     border-color: --border-disabled;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     background-color: --button-background-secondary-active;
   }
 }

--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --size-03, --button-background-primary, --text-on-color, --button-background-primary-hover, --button-background-primary-active, --focus, --button-background-disabled, --text-disabled, --text-brand, --border-brand, --button-background-secondary, --button-background-secondary-hover, --button-background-secondary-active, --border-disabled, --button-background-tertiary-hover, --button-background-tertiary-active, --button-background-danger, --button-background-danger-hover, --button-background-danger-active, --white, --icon-secondary, --button-background-icon-hover from tokens;
+@value --font-family, --size-03, --breakpoint-sm, --button-background-primary, --text-on-color, --button-background-primary-hover, --button-background-primary-active, --focus, --button-background-disabled, --text-disabled, --text-brand, --border-brand, --button-background-secondary, --button-background-secondary-hover, --button-background-secondary-active, --border-disabled, --button-background-tertiary-hover, --button-background-tertiary-active, --button-background-danger, --button-background-danger-hover, --button-background-danger-active, --white, --icon-secondary, --button-background-icon-hover from tokens;
 
 .linkButton {
   font-family: --font-family;
@@ -40,7 +40,8 @@
     }
   }
 
-  &[data-disabled] {
+  &[data-disabled],
+  &:disabled {
     color: --text-disabled;
     pointer-events: none;
     background-color: --button-background-disabled;
@@ -62,7 +63,8 @@
     background-color: --button-background-secondary-hover;
   }
 
-  &[data-disabled] {
+  &[data-disabled],
+  &:disabled {
     border-color: --border-disabled;
   }
 
@@ -77,12 +79,14 @@
   background-color: transparent;
   opacity: 1;
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     color: --text-brand;
     background-color: --button-background-tertiary-hover;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     background-color: --button-background-tertiary-active;
   }
 }
@@ -92,11 +96,13 @@
   background-color: --button-background-danger;
   opacity: 1;
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     background-color: --button-background-danger-hover;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     background-color: --button-background-danger-active;
     outline: none;
   }
@@ -109,16 +115,19 @@
   display: flex;
   align-items: center;
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     background-color: --button-background-icon-hover;
   }
 
-  &[data-disabled] {
+  &[data-disabled],
+  &:disabled {
     color: --text-disabled;
     pointer-events: none;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     background-color: --button-background-tertiary-active;
   }
 }
@@ -131,7 +140,7 @@
   width: 100%;
 }
 
-@media smBreakpoint {
+@media --breakpoint-sm {
   .button {
     width: 100%;
   }

--- a/packages/components/src/link/Link.module.css
+++ b/packages/components/src/link/Link.module.css
@@ -11,7 +11,8 @@
   font-weight: 400;
   align-items: center;
 
-  &[data-hovered] {
+  &[data-hovered],
+  &:hover {
     color: --link-hover;
   }
 
@@ -19,20 +20,24 @@
     color: --link-visited;
   }
 
-  &[data-disabled] {
+  &[data-disabled],
+  &:disabled {
     cursor: not-allowed;
     color: --text-disabled;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     color: --link-pressed;
   }
 
-  &[data-focused] {
+  &[data-focused],
+  &:focus {
     outline: none;
   }
 
-  &[data-focus-visible] {
+  &[data-focus-visible],
+  &:focus-visible {
     box-shadow: --focus;
 
     @media (forced-colors: active) {
@@ -52,11 +57,13 @@
   text-decoration: none;
   font-weight: 500;
 
-  &[data-hovered]:not([data-disabled='true']) {
+  &[data-hovered]:not([data-disabled='true']),
+  &:hover:not(:disabled) {
     text-decoration: underline;
   }
 
-  &[data-pressed] {
+  &[data-pressed],
+  &:active {
     text-decoration: underline;
   }
 }


### PR DESCRIPTION

## Description

In first page in Docs webb the link buttons pseudo-classes not working

## Changes

Add pseudo-classes to primary and secondary buttons in css link button 

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
