### PR TITLE
fix(textfield): fix token on input value

### DIFF
--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -93,6 +93,7 @@
 .input {
   all: unset;
   grid-area: Input;
+  color: --text-primary;
   border-bottom: 1px solid --border-strong;
   min-height: 48px;
   font-size: 1rem;


### PR DESCRIPTION
## Description

Fixes support ticket about dark mode on textfield

## Changes

Added token to textfield input

## Additional Information

Change to dark mode and enter something in TextField, the input should be white

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
