### PR TITLE
fix(tabs): fix dark mode on tabs and example on docweb

### DIFF
--- a/apps/docs/docs/components/tabs.mdx
+++ b/apps/docs/docs/components/tabs.mdx
@@ -6,37 +6,37 @@ description: Fördela information över flertalet tabbar.
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
-import { Tabs as MidasTabs, Button } from '@midas-ds/components'
+import { Tabs as MidasTabs, Button, Text } from '@midas-ds/components'
 
 export const Example = props => {
   return (
     <LiveCodeBlock
-      scope={{ MidasTabs, Button }}
+      scope={{ MidasTabs, Button, Text }}
       {...props}
     >
       {`<MidasTabs
           defaultSelected="Viktigt att veta"
           label="Följ processen"
           tabs={['Frukter', 'Bär', 'Fruktförband av stenfrukter'] as const}
-      >
-          <div>
-              Lorem ipsum dolor sit amet consectetur
-              adipisicing elit. Asperiores expedita, excepturi, hic modi tenetur
-              maxime dicta omnis aliquam quas doloremque cumque repellendus iure.
-              Eveniet reprehenderit sapiente quidem culpa nam? Vel?
-          </div>
-          <div>
-              Lorem, ipsum dolor sit amet consectetur
-              adipisicing elit. Ipsum veritatis quisquam amet, rem aperiam error
-              nostrum earum consequuntur quidem fugit. Blanditiis odit corrupti
-              consequatur nam culpa nesciunt cupiditate autem suscipit.
-          </div>
-          <div>
+        >
+          <Text>
             Lorem ipsum dolor sit amet consectetur
-              adipisicing elit. Asperiores expedita, excepturi, hic modi tenetur
-              maxime dicta omnis aliquam quas doloremque cumque repellendus iure.
-              Eveniet reprehenderit sapiente quidem culpa nam? Vel?
-          </div>
+            adipisicing elit. Asperiores expedita, excepturi, hic modi tenetur
+            maxime dicta omnis aliquam quas doloremque cumque repellendus iure.
+            Eveniet reprehenderit sapiente quidem culpa nam? Vel?
+          </Text>
+          <Text>
+            Lorem ipsum dolor sit amet consectetur
+            adipisicing elit. Asperiores expedita, excepturi, hic modi tenetur
+            maxime dicta omnis aliquam quas doloremque cumque repellendus iure.
+            Eveniet reprehenderit sapiente quidem culpa nam? Vel?
+          </Text>
+        <Text>
+          Lorem ipsum dolor sit amet consectetur
+          adipisicing elit. Asperiores expedita, excepturi, hic modi tenetur
+          maxime dicta omnis aliquam quas doloremque cumque repellendus iure.
+          Eveniet reprehenderit sapiente quidem culpa nam? Vel?
+        </Text>
       </MidasTabs>`}
     </LiveCodeBlock>
   )

--- a/packages/components/src/tabs/Tabs.module.css
+++ b/packages/components/src/tabs/Tabs.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --border-subtle, --border-brand, --focus, --breakpoint-sm from tokens;
+@value --font-family, --text-primary, --border-subtle, --border-brand, --focus, --breakpoint-sm from tokens;
 
 .container {
   font-family: --font-family;
@@ -14,6 +14,7 @@
 .listItem {
   padding: 0.5rem 1.25rem;
   cursor: pointer;
+  color: --text-primary;
 
   &[data-selected] {
     font-weight: 500;


### PR DESCRIPTION
## Description

- Fix tab title in dark mode
- Add better example on docweb with typography components

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
