### PR TITLE
docs: ♿️💄 sync markdown links

### DIFF
--- a/apps/docs/docs/components/button.mdx
+++ b/apps/docs/docs/components/button.mdx
@@ -4,7 +4,7 @@ description: Knappar används när användaren vill utföra en handling t.ex. sp
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { Button, ButtonGroup, Flex, FlexItem } from '@midas-ds/components'
+import { Button, ButtonGroup, Flex, FlexItem, Link } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 import { Plus } from 'lucide-react'
@@ -150,7 +150,7 @@ import { ButtonContext } from 'react-aria-components'
 
 ### Val av komponent
 
-Se mönstret [Knappar och länkar](/design-patterns/buttons-and-links)
+Se mönstret <Link href='/design-patterns/buttons-and-links'> {'Knappar och länkar'}</Link>
 
 ### Generella riktlinjer
 

--- a/apps/docs/docs/components/calendar.mdx
+++ b/apps/docs/docs/components/calendar.mdx
@@ -4,7 +4,7 @@ description: Använd en kalender när användaren ska välja ett datum eller vis
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { Calendar } from '@midas-ds/components'
+import { Calendar, Link } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
@@ -26,7 +26,7 @@ export const Example = props => {
 />
 
 Kalender kan användas när användaren ska välja ett datum eller visualisera ett valt datum. Normalt sett
-är [DatePicker](/components/date-picker) standardvalet men kalendern kan användas när inputfältet inte
+är <Link href='/components/date-picker'>{'DatePicker'}</Link> standardvalet men kalendern kan användas när inputfältet inte
 behövs, inte ligger i direkt anslutning till kalendern, eller om kalendern inte ska presenteras som en popover.
 
 <Example hideCode />

--- a/apps/docs/docs/components/checkbox.mdx
+++ b/apps/docs/docs/components/checkbox.mdx
@@ -5,7 +5,7 @@ description: Används för att låta användaren välja inget, ett eller flera a
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { Checkbox, CheckboxGroup, Flex, FlexItem, Button } from '@midas-ds/components'
+import { Checkbox, CheckboxGroup, Flex, FlexItem, Button, Link } from '@midas-ds/components'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
 export const Example = props => {
@@ -105,7 +105,7 @@ Ibland kan det vara lämligt att ge användaren möjlighet att snabbt kryssa i a
 
 ## Riktlinjer
 
-- Om det är många alternativ så bör [Select](./select.mdx) användas istället.
+- Om det är många alternativ så bör <Link href='/components/select'>{'Select'}</Link> användas istället.
 - Använd inte kryssruta om användaren väntar sig att valet ska få effekt direkt
 - Fältetikett ska inledas med en stor bokstav och inte följas av punkt.
 

--- a/apps/docs/docs/components/combobox.mdx
+++ b/apps/docs/docs/components/combobox.mdx
@@ -5,7 +5,7 @@ description: Sökbar version av Select
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { ComboBox, ComboBoxItem } from '@midas-ds/components'
+import { ComboBox, ComboBoxItem, Link } from '@midas-ds/components'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
 export const Example = props => {
@@ -51,8 +51,8 @@ import { ComboBox } from '@midas-ds/components'
 
 ### Val av komponent
 
-- Om det ska gå att välja flera eller inget alternativ är det [Checkbox](./checkbox.mdx) eller [Select](./select.mdx) som ska användas.
-- Om det är färre alternativ än fyra (4) används med fördel [Radio](./radio.mdx) istället.
+- Om det ska gå att välja flera eller inget alternativ är det <Link href='/components/checkbox'>{'Checkbox'}</Link> eller <Link href='/components/select'>{'Select'}</Link> som ska användas.
+- Om det är färre alternativ än fyra (4) används med fördel <Link href='/components/radio'>{'Radio'}</Link> istället.
 
 ## API
 

--- a/apps/docs/docs/components/link-button.mdx
+++ b/apps/docs/docs/components/link-button.mdx
@@ -4,7 +4,7 @@ description: Komponent med samma utseende och beteende som knapp men avsedd att 
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { LinkButton, Flex, FlexItem } from '@midas-ds/components'
+import { LinkButton, Flex, FlexItem, Link } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 import { Plus } from 'lucide-react'
@@ -36,7 +36,7 @@ export const Example = props => {
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/Link.html'
 />
 
-Komponent med samma utseende och beteende som [Button](/components/button) men avsedd att använda som länk internt eller externt i en applikation.
+Komponent med samma utseende och beteende som <Link href='/components/button'>{'Button'}</Link> men avsedd att använda som länk internt eller externt i en applikation.
 
 <Example hideCode />
 
@@ -54,7 +54,7 @@ import { LinkButton } from '@midas-ds/components'
 
 ## Riktlinjer
 
-Se mönstret [Knappar och länkar](/design-patterns/buttons-and-links)
+Se mönstret <Link href='/design-patterns/buttons-and-links'>{'Knappar och länkar'}</Link>
 
 ## API
 

--- a/apps/docs/docs/components/link.mdx
+++ b/apps/docs/docs/components/link.mdx
@@ -92,7 +92,7 @@ Använd `stretched` för att låta hela förälderelementet vara klickbart till 
 
 ## Riktlinjer
 
-Se mönstret [Knappar och länkar](/design-patterns/buttons-and-links)
+Se mönstret <Link href='/design-patterns/buttons-and-links'>{'Knappar och länkar'}</Link>
 
 ## API
 

--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -4,7 +4,7 @@ description: Radio är en typ av inmatningsfält som används för att välja et
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { Radio, RadioGroup } from '@midas-ds/components'
+import { Radio, RadioGroup, Link } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
@@ -51,8 +51,8 @@ import { Radio, RadioGroup } from '@midas-ds/components'
 - Radioknapparna placeras som regel vertikalt för att underlätta avläsning. Om antalet alternativ för en given fråga är
   begränsat till två (2) och det är ont om vertikalt utrymme så kan en horisontell orientering användas.
 - Fältetiketten ska inledas med stor bokstav och inte följas av punkt.
-- Om alternativen inte utesluter varandra, använd [Checkbox](./checkbox.mdx).
-- Om det är fler alternativ än fem bör [Select](./select.mdx) användas istället.
+- Om alternativen inte utesluter varandra, använd <Link href='/components/checkbox'>{'Checkbox'}</Link>.
+- Om det är fler alternativ än fem bör <Link href='/components/select'>{'Select'}</Link> användas istället.
 
 ## API
 

--- a/apps/docs/docs/components/skeleton.mdx
+++ b/apps/docs/docs/components/skeleton.mdx
@@ -63,7 +63,7 @@ Skeleton har som standard en animationen `wave` aktiverad. Den går att stänga 
 
 ## Riktlinjer
 
-För val av laddningsindikator se <Link href="/design-patterns/page-loading" >Mönster för laddningsindikatorer</Link>
+För val av laddningsindikator se <Link href="/design-patterns/page-loading" >{'Mönster för laddningsindikatorer'}</Link>
 
 ## API
 

--- a/apps/docs/docs/components/spinner.mdx
+++ b/apps/docs/docs/components/spinner.mdx
@@ -65,7 +65,7 @@ Använd varianten `small` för att kombinera med andra komponenter t.ex. Button
 
 Om det väntas ta mer än 10 sekunder att ladda sidan bör det förutom en spinner finnas ett meddelande till användaren om det.
 
-För val av laddningsindikator se <Link href="/design-patterns/page-loading" >Mönster för laddningsindikatorer</Link>
+För val av laddningsindikator se <Link href="/design-patterns/page-loading" >{'Mönster för laddningsindikatorer'}</Link>
 
 ## API
 

--- a/apps/docs/docs/components/textarea.mdx
+++ b/apps/docs/docs/components/textarea.mdx
@@ -5,7 +5,7 @@ description: När användaren ska fylla i längre information
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { TextArea } from '@midas-ds/components'
+import { TextArea, Link } from '@midas-ds/components'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
 export const Example = props => {
@@ -30,7 +30,7 @@ export const Example = props => {
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/TextField.html#textarea-1'
 />
 
-Inmatningsfält awdsom används när användaren behöver fylla i längre information t.ex. en beskrivning, kommentar eller fritext. För kortare, striktare inmatning används [TextField](./textfield.mdx).
+Inmatningsfält awdsom används när användaren behöver fylla i längre information t.ex. en beskrivning, kommentar eller fritext. För kortare, striktare inmatning används <Link href='/components/textfield'>{'TextField'}</Link>.
 
 <Example hideCode />
 

--- a/apps/docs/docs/components/textfield.mdx
+++ b/apps/docs/docs/components/textfield.mdx
@@ -4,7 +4,7 @@ description: Använd ett textfält när användaren ska fylla i en rad med text.
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { TextField } from '@midas-ds/components'
+import { TextField, Link } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Grid, GridItem } from '@midas-ds/components'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
@@ -29,7 +29,7 @@ export const Example = props => {
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/TextField.html'
 />
 
-Inmatningsfält när användaren ska fylla i kortare information, tex namn, personnummer eller epostadress. För längre inmatning används [TextArea](./textarea.mdx).
+Inmatningsfält när användaren ska fylla i kortare information, tex namn, personnummer eller epostadress. För längre inmatning används <Link href='/components/textarea'>{'TextArea'}</Link>.
 
 <Example hideCode />
 
@@ -160,7 +160,7 @@ Komponenten har flertalet inbyggda valideringsmetoder beroende på vad som händ
 />
 ```
 
-Läs mer om validering i [React Arias dokumentation](https://react-spectrum.adobe.com/react-aria/forms.html#validation).
+Läs mer om validering i <Link href='https://react-spectrum.adobe.com/react-aria/forms.html#validation'>{'React Arias dokumentation'}</Link>.
 
 ## API
 

--- a/apps/docs/docs/design-patterns/buttons-and-links.mdx
+++ b/apps/docs/docs/design-patterns/buttons-and-links.mdx
@@ -37,7 +37,7 @@ Användaren ska uppfatta att en handling utförs. Exempel på situationer där d
   hideCode
   scope={{ LinkButton }}
 >
-  {`<LinkButton href="/components/link-button">Till sidan för Länkknapp</LinkButton>`}
+  {`<LinkButton href="/components/link-button">{'Till sidan för Länkknapp'}</LinkButton>`}
 </LiveCodeBlock>
 
 ### Fristående länk
@@ -48,7 +48,7 @@ Fristående länk är en variant av länk som används när en länk ligger utan
   hideCode
   scope={{ Link }}
 >
-  {`<Link standalone href="/components/link">Läs mer om länkar</Link>`}
+  {`<Link standalone href="/components/link">{'Läs mer om länkar'}</Link>`}
 </LiveCodeBlock>
 
 ### Länk
@@ -59,5 +59,5 @@ Länk används när länken är i ett textstycke.
   hideCode
   scope={{ Link }}
 >
-  {`<p>Designsystemet har två olika varianter av <Link href="/components/link">länkar</Link>.</p>`}
+  {`<p>Designsystemet har två olika varianter av <Link href="/components/link">{'länkar'}</Link>.</p>`}
 </LiveCodeBlock>

--- a/apps/docs/docs/design-patterns/page-loading.mdx
+++ b/apps/docs/docs/design-patterns/page-loading.mdx
@@ -4,7 +4,7 @@ import { Flex, FlexItem, Skeleton, Spinner, Link } from '@midas-ds/components'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
 Laddningsindikatorer är visuella platshållare för komponenter eller information som visas medan de laddas.
-Vi använder oss av två olika laddningsindikator: <Link href="/components/skeleton" >Skeleton</Link> och <Link href="/components/spinner" >Spinner</Link>.
+Vi använder oss av två olika laddningsindikator: <Link href="/components/skeleton" >{'Skeleton'}</Link> och <Link href="/components/spinner" >{'Spinner'}</Link>.
 
 Vi använder i regel Skeleton som laddningsindikator. Undantagen är 1) när sidan laddar utan att någon ändras eller 2) när du inte vet hur gränssnittet kommer att se ut efter att det har laddat klart
 

--- a/apps/docs/docs/design-patterns/personnummer.mdx
+++ b/apps/docs/docs/design-patterns/personnummer.mdx
@@ -4,12 +4,17 @@ import { Link } from '@midas-ds/components'
 
 Vi följer Skatteverkets regler gällande hur ett personnummer är formaterat. Personnummer består av födelsetid (ÅÅMMDD) och födelsenummer (NNNN) separerat med bindestreck `-` eller med plus `+` för personer som är äldre än hundra år. Ett personnummer skrivs alltså på formen `ÅÅMMDD-NNNN` och det är så vi anger det i hjälptexter m.m.
 
-Men för att göra det så lätt som möjligt för användaren att mata in personnummer finns det en förlåtande personnummerinmatning som en egenskap till <Link href="/components/textfield" >TextField</Link>. Med den accepteras alla möjliga sätt att skriva ett (giltigt) personnummer. Implementationen är uppbyggd så att den:
+Men för att göra det så lätt som möjligt för användaren att mata in personnummer finns det en förlåtande personnummerinmatning som en egenskap till <Link href="/components/textfield" >{'TextField'}</Link>. Med den accepteras alla möjliga sätt att skriva ett (giltigt) personnummer. Implementationen är uppbyggd så att den:
 
 - Tillåter frivilliga sekelsiffor: `19` eller `20`
 - Tillåter flera olika avgränsare: `+`, `-`, `blanksteg` eller inget
 
-<Link standalone href='/components/textfield/#personnummer'>Mer information om vår förlåtande personnummerinmatning</Link>
+<Link
+  standalone
+  href='/components/textfield/#personnummer'
+>
+  {'Mer information om vår förlåtande personnummerinmatning'}
+</Link>
 
 ## Födelsetid
 

--- a/apps/docs/docs/dev/client-side-routing.mdx
+++ b/apps/docs/docs/dev/client-side-routing.mdx
@@ -3,6 +3,8 @@ title: Routing på klientnivå
 description: Hantera Client Side Navigation tillsammans med designsystemet
 ---
 
+import { Link } from '@midas-ds/components'
+
 # Routing på klientnivå
 
 **Client Side Routing, navigering i webbläsaren**
@@ -46,4 +48,4 @@ export default function App() {
 }
 ```
 
-Du kan läsa mer om detta på React Arias dokumentationswebb. [React Aria Client Side Routing](https://react-spectrum.adobe.com/react-aria/routing.html).
+Du kan läsa mer om detta på React Arias dokumentationswebb. <Link href='https://react-spectrum.adobe.com/react-aria/routing.html'>{'React Aria Client Side Routing'}</Link>.

--- a/apps/docs/docs/dev/common-issues.mdx
+++ b/apps/docs/docs/dev/common-issues.mdx
@@ -3,6 +3,8 @@ title: Vanliga problem
 description: Hantera Client Side Navigation tillsammans med designsystemet
 ---
 
+import { Link } from '@midas-ds/components'
+
 ## Remix
 
 Använder ni Remix? Då behöver ni lägga till följande i er config för att låta CSS ladda korrekt.
@@ -12,14 +14,14 @@ Använder ni Remix? Då behöver ni lägga till följande i er config för att l
 ```tsx {2-4} title="vite.config.ts"
 export default defineConfig({
   ssr: {
-    noExternal: [/^@midas-ds\/.+/]
-  }
+    noExternal: [/^@midas-ds\/.+/],
+  },
 })
 ```
 
 ### Äldre Remix - Classic Remix Compiler
 
-Följ detta: [CSS Bundling](https://remix.run/docs/en/main/styling/bundling) och [CSS Imports](https://remix.run/docs/en/main/styling/css-imports)
+Följ detta: <Link href='https://remix.run/docs/en/main/styling/bundling'>{'CSS Bundling'}</Link> och <Link href='https://remix.run/docs/en/main/styling/css-imports'>{'CSS Imports'}</Link>
 
 ```tsx title="root.tsx"
 import { cssBundleHref } from '@remix-run/css-bundle'
@@ -28,7 +30,7 @@ import type { LinksFunction } from '@remix-run/node'
 // ...
 
 export const links: LinksFunction = () => [
-  ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : [])
+  ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
   // ...
 ]
 ```
@@ -37,6 +39,6 @@ export const links: LinksFunction = () => [
 // ...
 export default {
   // ...
-  serverDependenciesToBundle: [/^@midas-ds\/.+/]
+  serverDependenciesToBundle: [/^@midas-ds\/.+/],
 }
 ```

--- a/apps/docs/docs/dev/localization.mdx
+++ b/apps/docs/docs/dev/localization.mdx
@@ -53,13 +53,12 @@ eller annan information, det sätts via browsern.
 
 ## useMessageFormatter
 
-För att översätta eller anpassa enskilda strängar finns
-
-<Link href='https://react-spectrum.adobe.com/react-aria/useMessageFormatter.html'>{'useMessageFormatter'}</Link>.
-Motsvarande för siffror och valutor är <Link href='https://react-spectrum.adobe.com/react-aria/useNumberFormatter.html'>
-  {'useNumberFormatter'}
-</Link>
-.
+<p>
+  För att översätta eller anpassa enskilda strängar finns
+  <Link href='https://react-spectrum.adobe.com/react-aria/useMessageFormatter.html'>{'useMessageFormatter'}</Link>.
+  Motsvarande för siffror och valutor är
+  <Link href='https://react-spectrum.adobe.com/react-aria/useNumberFormatter.html'>{'useNumberFormatter'}</Link>.
+</p>
 
 ## Midas komponenter
 

--- a/apps/docs/docs/dev/localization.mdx
+++ b/apps/docs/docs/dev/localization.mdx
@@ -2,6 +2,7 @@
 title: Lokalisering
 ---
 
+import { Link } from '@midas-ds/components'
 import { LocaleExample, I18nExample, ErrorMessageExample } from '@site/src/components/examples/LocalizationExamples'
 
 # Lokalisering
@@ -10,13 +11,13 @@ React Aria har en rad inbyggda funktioner som underlättar skapandet av tillgän
 och internationella användargränssnitt. Midas komponenter, som bygger på React Aria
 uppdateras automatiskt när språkmiljön ändras. Detta innebär att din applikation kan anpassa
 sig dynamiskt till olika språk utan alltför mycket manuell handpåläggning. För mer ingående dokumentation,
-se [React Aria Internationalization](https://react-spectrum.adobe.com/react-aria/internationalization.html).
+se <Link href="https://react-spectrum.adobe.com/react-aria/internationalization.html" >{'React Aria Internationalization'}</Link>.
 
 ## useLocale
 
 För att säkerställa att lokalisering fungerar bör `useLocale` användas i root av applikationen. På så sätt får
 du tillgång till browserns språkinställning. Normalt fungerar `locale` utan att hämta in den explicit men för till
-exempel SSR bör `useLocale` användas, se [React Aria](https://react-spectrum.adobe.com/react-aria/internationalization.html) för referens.
+exempel SSR bör `useLocale` användas, se <Link href="https://react-spectrum.adobe.com/react-aria/internationalization.html" >{'React Aria'}</Link> för referens.
 
 ```typescript jsx
 import {useLocale} from 'react-aria-components';
@@ -53,8 +54,12 @@ eller annan information, det sätts via browsern.
 ## useMessageFormatter
 
 För att översätta eller anpassa enskilda strängar finns
-[useMessageFormatter](https://react-spectrum.adobe.com/react-aria/useMessageFormatter.html). Motsvarande för
-siffror och valutor är [useNumberFormatter](https://react-spectrum.adobe.com/react-aria/useNumberFormatter.html).
+
+<Link href='https://react-spectrum.adobe.com/react-aria/useMessageFormatter.html'>{'useMessageFormatter'}</Link>.
+Motsvarande för siffror och valutor är <Link href='https://react-spectrum.adobe.com/react-aria/useNumberFormatter.html'>
+  {'useNumberFormatter'}
+</Link>
+.
 
 ## Midas komponenter
 
@@ -62,4 +67,5 @@ Officiellt har Midas inte fullt stöd för flera språk men i utgångsläget fun
 och respekterar användarens inställningar i browsern. Framtida uppdateringar eller nya komponenter
 bygger på React Arias ramverk så den allmänna rekommendationen är att använda metoder och hooks därifrån för
 att lösa eventuella lokaliseringsproblem. Buggrapport eller Feature requests kan skapas via
-[github issues](https://github.com/migrationsverket/midas/issues).
+
+<Link href='https://github.com/migrationsverket/midas/issues'>{'github issues'}</Link>.

--- a/apps/docs/docs/get-started/contribute.mdx
+++ b/apps/docs/docs/get-started/contribute.mdx
@@ -2,6 +2,8 @@
 sidebar_label: 'Bidra'
 ---
 
+import { Link } from '@midas-ds/components'
+
 # Bidra till komponentbiblioteket
 
 Att komma igång och bidra med kod till Midas är enkelt!
@@ -76,7 +78,7 @@ Branch namnges enligt `[feature|bugfix|hotfix|docs|refactor|chore|test]/[scope]/
 
 ### Commit
 
-Commits görs enligt [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary). Använd engelska,
+Commits görs enligt <Link href='https://www.conventionalcommits.org/en/v1.0.0/#summary'>{'conventional commits'}</Link>. Använd engelska,
 imperativ form, definiera type `feat|docs|fix|refactor|test|ci` och scope `(button|etc...)` och lägg till referenser
 till andra issues vid behov. Tänk på att även en merge (med squash) skapar en commit så lägg en extra tanke på
 vilken information som kommer med och inte kommer med. Våra commits är hela projektets historik och är indata till
@@ -112,8 +114,9 @@ Generellt, använd övriga komponenter som referens när nya läggs till.
 
 - Som standard, exportera en komponent per fil
 - Använd barrel-files `index.ts` för att exportera hela mappar
-- Formatera enligt [Prettier](https://prettier.io/) standard
+- Formatera enligt <Link href='https://prettier.io/'>{'Prettier'}</Link> standard
 - Importera och använd tokens i `[component].module.css` enligt
+
 ```css title="Button.module.css"
 // highlight-start
 @value tokens: "../theme/tokens.css";
@@ -126,14 +129,14 @@ Generellt, använd övriga komponenter som referens när nya läggs till.
 
 ### Importera headless-bibliotek
 
-Komponenter ska i första hand byggas på [React Aria](https://react-spectrum.adobe.com/react-aria/getting-started.html) i den mån det går. React Aria har ett omfattande bibliotek av
+Komponenter ska i första hand byggas på <Link href='https://react-spectrum.adobe.com/react-aria/getting-started.html'>{'React Aria'}</Link> i den mån det går. React Aria har ett omfattande bibliotek av
 färdiga komponenter och hooks som går att kombinera ihop för att uppnå önskat resultat. Fördelen med att följa React Arias
 konventioner är att det följer med mycket gratis i form av stöd för skärmläsare, tangentbordsnavigation och olika states.
 
 ### Skriv enhetstester
 
 Ur perspektivet att tillgänglighet är ett av designsystemets viktigaste fokusområden är det viktigt att vi regressionstestar.
-Använd [axe-core](https://github.com/dequelabs/axe-core) för att fånga upp problem innan de blir buggar. Det finns inget
+Använd <Link href='https://github.com/dequelabs/axe-core'>{'axe-core'}</Link> för att fånga upp problem innan de blir buggar. Det finns inget
 specificerat mål någon viss code coverage men ta inspiration från headless-biblioteken. Grundläggande funktion av komponenter
 bör också täckas av enhetstester.
 
@@ -145,14 +148,14 @@ verktyg för UX och utvecklare i designsystemet men också en publikt exponerad 
 ### Dokumentation
 
 Komponenten dokumenteras på dokumentationswebben med lämpliga exempel, beskrivning och properties. Normalt plockas
-properties upp från komponenten via [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript)
-men om det har införts nya types eller interfaces kan de behöva specificeras enligt [JSDoc](https://jsdoc.app/).
+properties upp från komponenten via <Link href='https://github.com/styleguidist/react-docgen-typescript'>{'react-docgen-typescript'}</Link>
+men om det har införts nya types eller interfaces kan de behöva specificeras enligt <Link href='https://jsdoc.app/'>{'JSDoc'}</Link>.
 
 ---
 
 ## Release & publish
 
-Designsystemet använder Nx för versionshantering och release enligt [nx release](https://nx.dev/recipes/nx-release/get-started-with-nx-release).
+Designsystemet använder Nx för versionshantering och release enligt <Link href='https://nx.dev/recipes/nx-release/get-started-with-nx-release'>{'nx release'}</Link>.
 När du kör `nx release --skip-publish` räknas komponentbiblioteket upp till rätt version
 och Nx gör en commit med uppdaterad changelog samt sätter en git tag med rätt versionsnummer.
 
@@ -166,9 +169,10 @@ Kontrollera att allt stämmer, gör release utan `--dry-run`, skapa en release-b
 git checkout -b release/[insert version number here]
 git push -u origin release/[insert version number here] --follow-tags
 ```
+
 När en ny tag `v{x.x.x}` finns på remote triggas ett workflow med publicering till NPM.
 För att slutföra release, gör en PR till main och gör en **merge** när den är godkänd. Observera
-att du *inte* ska göra en rebase eftersom git tags då inte är kopplade till rätt commit och
+att du _inte_ ska göra en rebase eftersom git tags då inte är kopplade till rätt commit och
 Nx kan inte längre räkna ut vilken version som är aktuell.
 
 ---

--- a/apps/docs/docs/get-started/use.mdx
+++ b/apps/docs/docs/get-started/use.mdx
@@ -4,19 +4,18 @@ sidebar_label: Använda
 sidebar_position: 1
 ---
 
+import { Link } from '@midas-ds/components'
+
 ## Designer
 
 För dig som designar gränssnitt finns två UI-kit till Adobe XD, ett för ljust och ett för mörkt tema. De innehåller färdiga designkomponenter och layoutmallar som följer Migrationsverkets digitala stil och grafiska profil. Om du inte har Adobe XD har vi onlineversioner för både
-[ljust](https://xd.adobe.com/view/3956fdcc-49a2-4103-be79-826cd32b03a1-6c05/?hints=off) och [mörkt](https://xd.adobe.com/view/e8603d75-698d-4896-a7ea-686d6847479e-bd33/?hints=off) tema
 
-<a
-  target='\_blank'
-  href={require('/files/MIDAS_UIkit_20.zip').default}
-  download
->
-  Här kan du ladda ner våra UI-kit till Adobe XD (version 20)
-</a>
+<Link href='https://xd.adobe.com/view/3956fdcc-49a2-4103-be79-826cd32b03a1-6c05/?hints=off'>{'ljust'}</Link> och <Link href='https://xd.adobe.com/view/e8603d75-698d-4896-a7ea-686d6847479e-bd33/?hints=off'>
+  {' '}
+  {'mörkt'}
+</Link> tema
 
+<Link href='/files/MIDAS_UIkit_20.zip'>{'Här kan du ladda ner våra UI-kit till Adobe XD (version 20)'}</Link>
 ## Utvecklare
 
 Installera komponenter via `npm install @midas-ds/components`.
@@ -49,9 +48,9 @@ export default App
 
 Det går självklart att använda andra metoder så länge vikterna 400, 500 och 600 inkluderas samt att det importerade typsnittet heter just "Inter" för att komponenterna ska ta användning av det.
 
-Mer info finns på [GitHub](https://github.com/migrationsverket/midas) samt under [guider](/dev/common-issues)
+Mer info finns på <Link href='https://github.com/migrationsverket/midas'>{'GitHub'}</Link> samt under <Link href='/dev/common-issues'>{'guider'}</Link>
 
 ## Rapportera buggar eller förslag till nya features
 
-Hittat en bugg eller förbättringsmöjlighet? Det går utmärkt att skapa ärenden via [github issues](https://github.com/migrationsverket/midas/issues).
+Hittat en bugg eller förbättringsmöjlighet? Det går utmärkt att skapa ärenden via <Link href='https://github.com/migrationsverket/midas/issues'>{'github issues'}</Link>.
 Det går naturligtvis också bra att kontakta MIDAS-teamet via alla de normala kontaktvägarna. Alla synpunkter är välkomna!

--- a/apps/docs/docs/get-started/use.mdx
+++ b/apps/docs/docs/get-started/use.mdx
@@ -8,13 +8,13 @@ import { Link } from '@midas-ds/components'
 
 ## Designer
 
-För dig som designar gränssnitt finns två UI-kit till Adobe XD, ett för ljust och ett för mörkt tema. De innehåller färdiga designkomponenter och layoutmallar som följer Migrationsverkets digitala stil och grafiska profil. Om du inte har Adobe XD har vi onlineversioner för både
-
-<Link href='https://xd.adobe.com/view/3956fdcc-49a2-4103-be79-826cd32b03a1-6c05/?hints=off'>{'ljust'}</Link> och <Link href='https://xd.adobe.com/view/e8603d75-698d-4896-a7ea-686d6847479e-bd33/?hints=off'>
-  {' '}
-  {'mörkt'}
-</Link> tema
-
+<p>
+  För dig som designar gränssnitt finns två UI-kit till Adobe XD, ett för ljust och ett för mörkt tema. De innehåller
+  färdiga designkomponenter och layoutmallar som följer Migrationsverkets digitala stil och grafiska profil. Om du inte
+  har Adobe XD har vi onlineversioner för både
+  <Link href='https://xd.adobe.com/view/3956fdcc-49a2-4103-be79-826cd32b03a1-6c05/?hints=off'>{'ljust'}</Link> och
+  <Link href='https://xd.adobe.com/view/e8603d75-698d-4896-a7ea-686d6847479e-bd33/?hints=off'>{'mörkt'}</Link> tema.
+</p>
 <Link href='/files/MIDAS_UIkit_20.zip'>{'Här kan du ladda ner våra UI-kit till Adobe XD (version 20)'}</Link>
 ## Utvecklare
 

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -52,6 +52,7 @@
   --search-local-modal-background: white;
   --search-local-muted-color: #808080;
   --search-local-highlight-color: #25607f;
+  --ifm-link-color: #2e7ca5;
 }
 
 .code-card {
@@ -87,6 +88,7 @@
   --search-local-modal-background: white;
   --search-local-muted-color: #808080;
   --search-local-highlight-color: #25607f;
+  --ifm-link-color: #4289ad;
 
   .code-card {
     background-color: rgb(203 203 203 / 30%);

--- a/apps/docs/static/files/CHANGELOG.md
+++ b/apps/docs/static/files/CHANGELOG.md
@@ -1,3 +1,64 @@
+### 6.1.0
+
+#### 🚀 Features
+
+- **text:** add description slot ([73d308a13](https://github.com/migrationsverket/midas/commit/73d308a13))
+
+#### 🩹 Fixes
+
+- **textfield:** fix token on input value ([e79f935e3](https://github.com/migrationsverket/midas/commit/e79f935e3))
+- **link-button:** add pseudo-classes in CSS link-button ([#385](https://github.com/migrationsverket/midas/pull/385))
+
+### 6.0.1
+
+#### 🩹 Fixes
+
+- **select:** 🐛 Selected values doesn't match selected IDs
+
+## 6.0.0
+
+#### 🚀 Features
+
+- **modal:** replace h2 with heading component
+- ⚠️ **modal:** deprecate `ModalTrigger` and `Dialog`
+- **modal:** fix overlay position to avoid moving the modal when y-overflow
+- **modal:** increase z-index on overlay
+- **modal:** add focustrap to modal
+- **modal:** add styles and clean up types
+- **modal:** add boilerplate code for new modal implementation
+- use `cursor: not-allowed` for disabled elements
+
+#### 🩹 Fixes
+
+- **layout:** change minimize menu button to icon variant
+- **button:** change iconbtn color token
+- **button:** tokenize icon button for better dark mode support
+- **button:** clarify use of labels on button groups
+- **button:** clarify use of labels on button groups
+- add react types to dependencies
+- remove test setup from build
+
+#### ⚠️ Breaking Changes
+
+- **modal:** Use the new DialogTrigger and Modal instead of ModalTrigger and Dialog. New API will apply.
+
+### 5.0.1
+
+#### 🩹 Fixes
+
+- **checkbox:** swap old focus token
+- **checkbox:** swap old tokens
+- **radio:** remove old tokens
+- **link-button:** fix colors on hover state
+- **toast:** re-organize animations and breakpoints
+- **toast:** remove explicit dep
+- **toast:** update react-aria deps
+- **toast:** add temporary implementation of useToastState
+
+#### Documentation Changes
+
+- display project changelog on docweb
+
 ## 5.0.0 (2025-03-17)
 
 #### 🚀 Features


### PR DESCRIPTION
## Description

Links in the documentation has different styling and doesn't meet WCAG color contrast requirements

## Changes

* Change color of markdown links `[i am a markdown link](//google.com)`
* Replace markdown links with `<Link>` component

## Additional Information

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
