### PR TITLE
docs(modal): 📝 add examples with form elements

### DIFF
--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -6,25 +6,63 @@ description: Modal som lägger sig över allt annat innehåll.
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
-import { Button, DialogTrigger, Modal } from '@midas-ds/components'
+import {
+  Button,
+  DialogTrigger,
+  Modal,
+  Group,
+  Radio,
+  RadioGroup,
+  Select,
+  Text,
+  TextField,
+  ButtonGroup,
+} from '@midas-ds/components'
+import { ConfirmationExample } from '@site/src/components/examples/ModalExamples'
 
 export const Example = props => {
   return (
     <LiveCodeBlock
       scope={{
         Button,
+        ButtonGroup,
         DialogTrigger,
         Modal,
+        Radio,
+        RadioGroup,
+        Select,
+        Text,
+        TextField,
       }}
       {...props}
     >
       {`
-      <DialogTrigger>
-        <Button>Öppna modal</Button>
-         <Modal title={'Rubrik'}>
-         Innehåll i modal
-         </Modal>
-      </DialogTrigger>`}
+        <DialogTrigger>
+          <Button>Gör din egen fruktkorg</Button>
+          <Modal title='Gör din egen fruktkorg'>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              <Select
+                label='Vilken är din favoritfrukt?'
+                description='Välj en frukt i listan'
+                options={fruits.map(({ name, value }) => ({ id: value, name }))}
+                selectionMode='single'
+              />
+              <TextField
+                label='Namnge din fruktkorg'
+                description='Skriv valfritt namn'
+              />
+              <RadioGroup label='Vill du ha fruktkorgen hemskickad till din hemadress?'>
+                <Radio value='ja'>Ja</Radio>
+                <Radio value='nej'>Nej</Radio>
+              </RadioGroup>
+              <ButtonGroup>
+                <Button>Skicka</Button>
+                <Button variant='secondary'>Avbryt</Button>
+              </ButtonGroup>
+            </div>
+          </Modal>
+        </DialogTrigger>
+      `}
     </LiveCodeBlock>
   )
 }
@@ -50,6 +88,12 @@ import { DialogTrigger, Modal } from '@midas-ds/components'
 ```
 
 <Example hideExample />
+
+### Bekräftelsemodal
+
+För att undvika oönskade fel kan en modal användas för att bekräfta en handling som har konsekvenser för användaren.
+
+<ConfirmationExample />
 
 ## Varianter
 

--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -6,18 +6,6 @@ description: Modal som lägger sig över allt annat innehåll.
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
-import {
-  Button,
-  DialogTrigger,
-  Modal,
-  Group,
-  Radio,
-  RadioGroup,
-  Select,
-  Text,
-  TextField,
-  ButtonGroup,
-} from '@midas-ds/components'
 import { FormExample, ConfirmationExample } from '@site/src/components/examples/ModalExamples'
 
 <ComponentHeader

--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -18,54 +18,7 @@ import {
   TextField,
   ButtonGroup,
 } from '@midas-ds/components'
-import { ConfirmationExample } from '@site/src/components/examples/ModalExamples'
-
-export const Example = props => {
-  return (
-    <LiveCodeBlock
-      scope={{
-        Button,
-        ButtonGroup,
-        DialogTrigger,
-        Modal,
-        Radio,
-        RadioGroup,
-        Select,
-        Text,
-        TextField,
-      }}
-      {...props}
-    >
-      {`
-        <DialogTrigger>
-          <Button>Gör din egen fruktkorg</Button>
-          <Modal title='Gör din egen fruktkorg'>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-              <Select
-                label='Vilken är din favoritfrukt?'
-                description='Välj en frukt i listan'
-                options={fruits.map(({ name, value }) => ({ id: value, name }))}
-                selectionMode='single'
-              />
-              <TextField
-                label='Namnge din fruktkorg'
-                description='Skriv valfritt namn'
-              />
-              <RadioGroup label='Vill du ha fruktkorgen hemskickad till din hemadress?'>
-                <Radio value='ja'>Ja</Radio>
-                <Radio value='nej'>Nej</Radio>
-              </RadioGroup>
-              <ButtonGroup>
-                <Button>Skicka</Button>
-                <Button variant='secondary'>Avbryt</Button>
-              </ButtonGroup>
-            </div>
-          </Modal>
-        </DialogTrigger>
-      `}
-    </LiveCodeBlock>
-  )
-}
+import { FormExample, ConfirmationExample } from '@site/src/components/examples/ModalExamples'
 
 <ComponentHeader
   name={'Modal'}
@@ -75,7 +28,7 @@ export const Example = props => {
 
 Modaler lägger sig över allt annat innehåll för att fokusera användarens fokus på en sak.
 
-<Example hideCode />
+<FormExample />
 
 ## Installation och användning
 
@@ -87,7 +40,12 @@ npm install @midas-ds/components
 import { DialogTrigger, Modal } from '@midas-ds/components'
 ```
 
-<Example hideExample />
+```tsx title='Exempelkod'
+<DialogTrigger>
+  <Button>Öppna modal</Button>
+  <Modal title='Rubrik'>Innehåll i modal</Modal>
+</DialogTrigger>
+```
 
 ### Bekräftelsemodal
 

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -20,15 +20,11 @@ export const ConfirmationExample = () => (
         <Button
           autoFocus
           slot='close'
-        >
-          Ja, ta bort
-        </Button>
-        <Button
-          slot='close'
           variant='secondary'
         >
           Nej, ha kvar
         </Button>
+        <Button slot='close'>Ja, ta bort</Button>
       </ButtonGroup>
     </Modal>
   </DialogTrigger>

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -3,7 +3,10 @@ import {
   ButtonGroup,
   DialogTrigger,
   Modal,
+  Radio,
+  RadioGroup,
   Text,
+  TextField,
 } from '@midas-ds/components'
 
 export const ConfirmationExample = () => (
@@ -14,7 +17,12 @@ export const ConfirmationExample = () => (
         Är du säker att du vill plocka bort "Kiwi" från fruktkorgen?
       </Text>
       <ButtonGroup>
-        <Button slot='close'>Ja, ta bort</Button>
+        <Button
+          autoFocus
+          slot='close'
+        >
+          Ja, ta bort
+        </Button>
         <Button
           slot='close'
           variant='secondary'
@@ -22,6 +30,34 @@ export const ConfirmationExample = () => (
           Nej, ha kvar
         </Button>
       </ButtonGroup>
+    </Modal>
+  </DialogTrigger>
+)
+
+export const FormExample = () => (
+  <DialogTrigger>
+    <Button>Gör din egen fruktkorg</Button>
+    <Modal title='Gör din egen fruktkorg'>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <TextField
+          autoFocus
+          label='Namnge din fruktkorg'
+          description='Skriv valfritt namn'
+        />
+        <RadioGroup label='Vill du ha fruktkorgen hemskickad till din hemadress?'>
+          <Radio value='ja'>Ja</Radio>
+          <Radio value='nej'>Nej</Radio>
+        </RadioGroup>
+        <ButtonGroup>
+          <Button slot='close'>Skicka</Button>
+          <Button
+            slot='close'
+            variant='secondary'
+          >
+            Avbryt
+          </Button>
+        </ButtonGroup>
+      </div>
     </Modal>
   </DialogTrigger>
 )

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -46,7 +46,7 @@ export const FormExample = () => (
           description='Skriv valfritt namn'
         />
         <RadioGroup
-          value='ja'
+          defaultValue='ja'
           label='Vill du ha fruktkorgen hemskickad till din hemadress?'
         >
           <Radio value='ja'>Ja</Radio>

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -1,0 +1,22 @@
+import {
+  Button,
+  ButtonGroup,
+  DialogTrigger,
+  Modal,
+  Text,
+} from '@midas-ds/components'
+
+export const ConfirmationExample = () => (
+  <DialogTrigger>
+    <Button variant='danger'>Ta bort Kiwi</Button>
+    <Modal title='Ta bort saker ur fruktkorgen'>
+      <Text elementType='p'>
+        Är du säker att du vill plocka bort "Kiwi" från fruktkorgen?
+      </Text>
+      <ButtonGroup>
+        <Button variant='secondary'>Nej, ha kvar</Button>
+        <Button>Ja, ta bort</Button>
+      </ButtonGroup>
+    </Modal>
+  </DialogTrigger>
+)

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -40,7 +40,10 @@ export const FormExample = () => (
           label='Namnge din fruktkorg'
           description='Skriv valfritt namn'
         />
-        <RadioGroup label='Vill du ha fruktkorgen hemskickad till din hemadress?'>
+        <RadioGroup
+          value='ja'
+          label='Vill du ha fruktkorgen hemskickad till din hemadress?'
+        >
           <Radio value='ja'>Ja</Radio>
           <Radio value='nej'>Nej</Radio>
         </RadioGroup>

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -18,13 +18,18 @@ export const ConfirmationExample = () => (
       </Text>
       <ButtonGroup>
         <Button
+          variant='danger'
+          slot='close'
+        >
+          Ja, ta bort
+        </Button>
+        <Button
           autoFocus
           slot='close'
           variant='secondary'
         >
           Nej, ha kvar
         </Button>
-        <Button slot='close'>Ja, ta bort</Button>
       </ButtonGroup>
     </Modal>
   </DialogTrigger>

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -8,14 +8,19 @@ import {
 
 export const ConfirmationExample = () => (
   <DialogTrigger>
-    <Button variant='danger'>Ta bort Kiwi</Button>
+    <Button>Ta bort Kiwi</Button>
     <Modal title='Ta bort saker ur fruktkorgen'>
       <Text elementType='p'>
         Är du säker att du vill plocka bort "Kiwi" från fruktkorgen?
       </Text>
       <ButtonGroup>
-        <Button variant='secondary'>Nej, ha kvar</Button>
-        <Button>Ja, ta bort</Button>
+        <Button slot='close'>Ja, ta bort</Button>
+        <Button
+          slot='close'
+          variant='secondary'
+        >
+          Nej, ha kvar
+        </Button>
       </ButtonGroup>
     </Modal>
   </DialogTrigger>

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -5,7 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["DOM"],
     "noEmit": true,
     "noImplicitAny": false,
@@ -23,5 +23,6 @@
         "../../../../packages/components/src/theme/index.ts"
       ]
     }
-  }
+  },
+  "include": ["**/*.tsx"]
 }


### PR DESCRIPTION
## Description

We need better examples of modal content

## Changes

* Add example with form elements
* Add confirmation modal example
* Add react-jsx support to docs typescript compiler (so you dont have to import react to write JSX)

## Additional Information

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
- [x] UX feedback 
