### PR TITLE
feat: ✨💄 add semantic z-index tokens

### DIFF
--- a/packages/components/src/layout/Layout.module.css
+++ b/packages/components/src/layout/Layout.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --breakpoint-md, --background-01, --border-subtle, --layer-01, --text-primary, --button-background-tertiary-hover, --button-background-tertiary-active, --text-secondary, --icon-primary, --focus from tokens;
+@value --font-family, --breakpoint-md, --background-01, --border-subtle, --layer-01, --text-primary, --button-background-tertiary-hover, --button-background-tertiary-active, --text-secondary, --icon-primary, --focus, --z-index-base, --z-index-above, --z-index-skip-to-content from tokens;
 
 .baseLayout {
   --sideBarWidth: 230px;
@@ -28,7 +28,7 @@
 
   @media --breakpoint-md {
     padding: 1.25rem 1rem;
-    z-index: 3;
+    z-index: calc(--z-index-base + --z-index-above);
   }
 }
 
@@ -94,7 +94,7 @@
   height: 100vh;
   width: var(--sideBarWidth);
   transform: translateX(calc(var(--sideBarWidth) * -1));
-  z-index: 2;
+  z-index: calc(--z-index-base);
   border-right: 1px solid --border-subtle;
 
   @media --breakpoint-md {
@@ -333,7 +333,7 @@
   position: absolute;
   top: 0;
   right: 100%;
-  z-index: 1047;
+  z-index: --z-index-skip-to-content;
 
   &[data-focus-visible],
   &:focus-visible {

--- a/packages/components/src/link/Link.module.css
+++ b/packages/components/src/link/Link.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --link-enabled, --link-hover, --link-pressed, --link-visited, --text-disabled, --focus from tokens;
+@value --font-family, --link-enabled, --link-hover, --link-pressed, --link-visited, --text-disabled, --focus, --z-index-base from tokens;
 
 .link {
   font-family: --font-family;
@@ -72,7 +72,7 @@
   &::after {
     position: absolute;
     inset: 0;
-    z-index: 1;
+    z-index: --z-index-base;
     content: '';
   }
 }

--- a/packages/components/src/modal/Dialog.module.css
+++ b/packages/components/src/modal/Dialog.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --layer-01, --background-01, --text-primary from tokens;
+@value --font-family, --layer-01, --background-01, --text-primary, --z-index-modal from tokens;
 
 .modal {
   font-family: --font-family;
@@ -27,7 +27,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000000;
+  z-index: --z-index-modal;
   width: 100vw;
   background: rgba(45 0 0 / 30%);
   display: flex;
@@ -50,7 +50,6 @@
   justify-content: flex-end;
   position: sticky;
   top: 0;
-  z-index: 2;
 }
 
 .modalBody {

--- a/packages/components/src/select/Select.module.css
+++ b/packages/components/src/select/Select.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --text-disabled, --border-strong, --text-primary, --focus, --layer-02, --border-invalid, --layer-hover-02, --layer-selected-02, --layer-selected-hover-02, --text-on-color, --button-background-primary, --button-background-primary-hover, --field-disabled, --border-disabled, --field-01, --field-hover-01, --button-background-disabled, --text-invalid, --z-index-modal, --z-index-above from tokens;
+@value --font-family, --text-disabled, --border-strong, --text-primary, --focus, --layer-02, --border-invalid, --layer-hover-02, --layer-selected-02, --layer-selected-hover-02, --text-on-color, --button-background-primary, --button-background-primary-hover, --field-disabled, --border-disabled, --field-01, --field-hover-01, --button-background-disabled, --text-invalid from tokens;
 
 /** clear the default list styles */
 * > ul {

--- a/packages/components/src/select/Select.module.css
+++ b/packages/components/src/select/Select.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --text-disabled, --border-strong, --text-primary, --focus, --layer-02, --border-invalid, --layer-hover-02, --layer-selected-02, --layer-selected-hover-02, --text-on-color, --button-background-primary, --button-background-primary-hover, --field-disabled, --border-disabled, --field-01, --field-hover-01, --button-background-disabled, --text-invalid from tokens;
+@value --font-family, --text-disabled, --border-strong, --text-primary, --focus, --layer-02, --border-invalid, --layer-hover-02, --layer-selected-02, --layer-selected-hover-02, --text-on-color, --button-background-primary, --button-background-primary-hover, --field-disabled, --border-disabled, --field-01, --field-hover-01, --button-background-disabled, --text-invalid, --z-index-modal, --z-index-above from tokens;
 
 /** clear the default list styles */
 * > ul {

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --focus, --field-disabled, --text-primary, --text-invalid, --border-invalid, --border-strong, --field-01, --field-hover-01, --font-family, --text-disabled from tokens;
+@value --focus, --field-disabled, --text-primary, --text-invalid, --border-invalid, --border-strong, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
 
 * {
   font-family: --font-family;
@@ -146,5 +146,5 @@
   top: 0;
   box-sizing: border-box;
   cursor: pointer;
-  z-index: 3;
+  z-index: calc(--z-index-base + --z-index-above);
 }

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -131,7 +131,7 @@
   display: flex;
   align-items: center;
   top: 3px;
-  z-index: 2;
+  z-index: --z-index-base;
   left: 1rem;
   height: calc(100% - 6px);
   width: calc(100% - 2rem);

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -217,3 +217,10 @@
 
 /* Logo */
 @value --logo-primary: light-dark(--red-100, --white);
+
+/* z-index */
+@value --z-index-base: 1;
+@value --z-index-above: 10;
+@value --z-index-modal: 1000;
+@value --z-index-toast: 1100;
+@value --z-index-skip-to-content: 1200;

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -221,3 +221,11 @@ export const semantic = {
 
   logoPrimary: `light-dark(${baseColors.red100}, ${baseColors.white})`,
 }
+
+export const zIndex = {
+  base: 1,
+  above: 10,
+  modal: 1000,
+  toast: 1100,
+  skipToContent: 1200,
+}

--- a/packages/components/src/toast/Toast.module.css
+++ b/packages/components/src/toast/Toast.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --text-primary, --notification-background-success, --notification-border-success, --notification-background-info, --notification-border-info, --notification-background-important, --notification-border-important, --notification-border-warning, --notification-background-warning, --breakpoint-md, --focus from tokens;
+@value --font-family, --text-primary, --notification-background-success, --notification-border-success, --notification-background-info, --notification-border-info, --notification-background-important, --notification-border-important, --notification-border-warning, --notification-background-warning, --breakpoint-md, --focus, --z-index-toast from tokens;
 
 @keyframes slideInEnd {
   from {
@@ -59,7 +59,7 @@
   gap: 8px;
   border: none;
   width: calc(100% - 2rem);
-  z-index: 1001;
+  z-index: --z-index-toast;
 
   &:focus-visible {
     outline: none;


### PR DESCRIPTION
## Description

Select popover is stacked under modal overlay, we need semantic z-index tokens to prevent bugs like these

## Changes

* Change z-index of modal overlay
* Export semantic z-index tokens
* Use tokens

## Additional Information

Starting at 1000 with the modal overlay to render stuff above docusarus UI (0 - 400).

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
