### PR TITLE
fix: ♿️🐛 error message color in dark mode

### DIFF
--- a/packages/components/src/combobox/ComboBox.module.css
+++ b/packages/components/src/combobox/ComboBox.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --text-disabled --field-01, --field-hover-01, --layer-02, --layer-hover-02, --border-strong, --focus, --field-disabled, --border-disabled, --text-placeholder, --icon-primary, --text-primary, --layer-selected-02, --border-invalid, --text-invalid, --font-family from tokens;
+@value --text-disabled --field-01, --field-hover-01, --layer-02, --layer-hover-02, --border-strong, --focus, --field-disabled, --border-disabled, --text-placeholder, --icon-primary, --text-primary, --layer-selected-02, --border-invalid, --font-family from tokens;
 
 .combobox {
   font-family: --font-family;
@@ -21,10 +21,6 @@
   /** Temp solution so things look ok while refactoring */
   [slot='description'] {
     grid-area: Desc;
-  }
-
-  &[data-disabled] {
-    color: --text-invalid;
   }
 
   &[data-invalid] .input {
@@ -121,17 +117,6 @@
   width: calc(var(--trigger-width) - 0.125rem);
   background: --layer-02;
   overflow-y: auto;
-}
-
-.fieldError {
-  margin-top: 0.625rem;
-  display: flex;
-  gap: 0.625rem;
-  font-size: 0.875rem;
-
-  & svg {
-    color: --text-invalid;
-  }
 }
 
 .listBoxItem {

--- a/packages/components/src/date-field/DateField.module.css
+++ b/packages/components/src/date-field/DateField.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family,--text-placeholder,--text-invalid, --border-invalid, --focus, --field-hover-01, --border-strong, --field-01, --text-primary, --text-disabled from tokens;
+@value --font-family,--text-placeholder, --border-invalid, --focus, --field-hover-01, --border-strong, --field-01, --text-primary, --text-disabled from tokens;
 
 .dateField {
   font-family: --font-family;

--- a/packages/components/src/date-picker/DatePicker.module.css
+++ b/packages/components/src/date-picker/DatePicker.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --field-01, --icon-primary,--text-invalid, --border-strong, --border-invalid, --text-disabled, --text-placeholder, --field-hover-01, --focus, --layer-01, --text-primary, --border-brand, --button-background-primary from tokens;
+@value --font-family, --field-01, --icon-primary, --border-strong, --border-invalid, --text-disabled, --text-placeholder, --field-hover-01, --focus, --layer-01, --text-primary, --border-brand, --button-background-primary from tokens;
 
 .datePicker {
   font-family: --font-family;

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --focus, --field-disabled, --text-primary, --text-invalid, --border-invalid, --border-strong, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
+@value --focus, --field-disabled, --text-primary, --border-invalid, --border-strong, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
 
 * {
   font-family: --font-family;

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -40,6 +40,7 @@
 @value --signal-green-20: #d5f2d9;
 @value --signal-green-140: #008d3c;
 @value --signal-red-20: #ffdfdf;
+@value --signal-red-120: #eb4e4e;
 @value --signal-red-140: #e62323;
 @value --signal-red-160: #b31b1b;
 @value --signal-red-180: #801313;
@@ -137,7 +138,7 @@
 @value --border-medium: light-dark(--gray-110, --gray-90);
 @value --border-subtle: light-dark(--gray-50, --gray-160);
 @value --border-brand: light-dark(--blue-170, --blue-170);
-@value --border-invalid: light-dark(--signal-red-140, --signal-red-140);
+@value --border-invalid: light-dark(--signal-red-140, --signal-red-120);
 @value --border-disabled: light-dark(--gray-50, --gray-140);
 @value --border-skeleton: light-dark(--gray-10, --gray-180);
 @value --border-inverse: light-dark(--white, --gray-180);
@@ -192,7 +193,7 @@
 @value --text-inverse: light-dark(--gray-10, --gray-200);
 @value --text-subtle: light-dark(--gray-90, --gray-90);
 @value --text-disabled: light-dark(--gray-50, --gray-140);
-@value --text-invalid: light-dark(--signal-red-140, --signal-red-140);
+@value --text-invalid: light-dark(--signal-red-140, --signal-red-120);
 @value --text-placeholder: light-dark(--gray-70, --gray-140);
 
 /* Button */


### PR DESCRIPTION
## Description

Our error message doesn't meet WCAG contrast ratio in dark mode

## Changes

* Implement `@value --signal-red-120: #eb4e4e;`
* Replace `--border-invalid` and `--text-invalid` in dark mode
* Remove some unused css imports

## Additional Information

Currently we're not catching WCAG violations in dark mode with the test runner, something to look into!

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
