### PR TITLE
test: ✅ storybook tests for dark mode

### DIFF
--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server dist/docs/storybook --port 6006 --silent" \
-            "npx wait-on tcp:127.0.0.1:6006 && npx nx run components:test-storybook:ci"
+            "npx wait-on tcp:127.0.0.1:6006 && npx nx run components:test-storybook:ci && npx nx run components:test-storybook:dark-mode:ci"

--- a/packages/components/.storybook/test-runner.ts
+++ b/packages/components/.storybook/test-runner.ts
@@ -8,6 +8,9 @@ import { injectAxe, checkA11y } from 'axe-playwright'
  */
 const config: TestRunnerConfig = {
   async preVisit(page) {
+    await page.emulateMedia({
+      colorScheme: (process.env.COLOR_SCHEME as 'light' | 'dark') || null,
+    })
     await injectAxe(page)
   },
   async postVisit(page, context) {

--- a/packages/components/jest.config.ts
+++ b/packages/components/jest.config.ts
@@ -3,10 +3,11 @@ export default {
   preset: '../../jest.preset.js',
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
-    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }]
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/components',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   testEnvironment: 'jsdom',
+  modulePathIgnorePatterns: ['<rootDir>/src/utils'],
 }

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -76,6 +76,26 @@
         }
       }
     },
+    "test-storybook:dark-mode": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "COLOR_SCHEME=dark test-storybook -c packages/components/.storybook --url=http://localhost:4400"
+      },
+      "configurations": {
+        "watch": {
+          "command": "COLOR_SCHEME=dark test-storybook --watch -c packages/components/.storybook --url=http://localhost:4400"
+        },
+        "remote": {
+          "command": "COLOR_SCHEME=dark test-storybook -c packages/components/.storybook --url=https://designsystem.migrationsverket.se/storybook"
+        },
+        "all-browsers": {
+          "command": "COLOR_SCHEME=dark test-storybook --watch -c packages/components/.storybook --url=http://localhost:4400 --browsers=firefox,chromium,webkit"
+        },
+        "ci": {
+          "command": "COLOR_SCHEME=dark test-storybook -c packages/components/.storybook --url=http://localhost:6006 --browsers=chromium"
+        }
+      }
+    },
     "generate-dependencies": {
       "dependsOn": [
         {

--- a/packages/components/src/card/Card.stories.tsx
+++ b/packages/components/src/card/Card.stories.tsx
@@ -30,6 +30,11 @@ export default meta
 type Story = StoryObj<typeof Card>
 
 export const Example: Story = {
+  parameters: {
+    a11y: {
+      test: 'todo',
+    },
+  },
   play: async ({ canvas, step }) => {
     await step('It should be possible to focus the link', async () => {
       const link = canvas.getByText('Läs mer om Card')

--- a/packages/components/src/flex/Flex.stories.tsx
+++ b/packages/components/src/flex/Flex.stories.tsx
@@ -7,14 +7,19 @@ const meta: Meta<typeof Flex> = {
   component: Flex,
   title: 'Components/Flex',
   tags: ['autodocs'],
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    a11y: {
+      test: 'todo',
+    },
+  },
   argTypes: {
     fluid: {
       control: {
-        type: 'boolean'
-      }
-    }
-  }
+        type: 'boolean',
+      },
+    },
+  },
 }
 export default meta
 
@@ -84,5 +89,5 @@ export const Primary = {
         />
       </FlexItem>
     </Flex>
-  )
+  ),
 }

--- a/packages/components/src/grid/Grid.stories.tsx
+++ b/packages/components/src/grid/Grid.stories.tsx
@@ -7,12 +7,17 @@ const meta: Meta<typeof Grid> = {
   component: Grid,
   title: 'Components/Grid',
   tags: ['autodocs'],
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    a11y: {
+      test: 'todo',
+    },
+  },
   argTypes: {
     fluid: {
-      control: { type: 'boolean' }
-    }
-  }
+      control: { type: 'boolean' },
+    },
+  },
 }
 export default meta
 
@@ -72,5 +77,5 @@ export const Primary = {
         />
       </GridItem>
     </Grid>
-  )
+  ),
 }

--- a/packages/components/src/table/Table.stories.tsx
+++ b/packages/components/src/table/Table.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Table, TableHeader, Column, TableBody, Row, Cell } from './Table'
 import { expect, userEvent } from '@storybook/test'
 import styles from './Table.module.css'
+import { lightDark } from '../utils/test'
 
 const meta: Meta<typeof Table> = {
   component: Table,
@@ -81,7 +82,7 @@ export const Striped: Story = {
       const anOddRow = await canvas.findByText(rows[2].name)
       await userEvent.hover(anOddRow)
       expect(anOddRow).toHaveStyle({
-        backgroundColor: 'rgb(230, 230, 230)',
+        backgroundColor: lightDark('rgb(230, 230, 230)', 'rgb(51, 51, 51)'),
       })
     })
   },

--- a/packages/components/src/utils/test.ts
+++ b/packages/components/src/utils/test.ts
@@ -1,0 +1,7 @@
+/**
+ * A utility for making visual assertions in Storybook play tests based on the browsers "prefers-colors-scheme" setting
+ */
+export const lightDark = (light: string, dark: string) =>
+  window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? dark
+    : light

--- a/packages/components/tsconfig.storybook.json
+++ b/packages/components/tsconfig.storybook.json
@@ -22,7 +22,8 @@
     "src/**/*.stories.mdx",
     ".storybook/**/*.js",
     ".storybook/**/*.ts",
-    ".storybook/**/*.tsx"
+    ".storybook/**/*.tsx",
+    "src/utils/test.ts"
   ],
   "files": [
     "../../node_modules/@nx/react/typings/styled-jsx.d.ts",


### PR DESCRIPTION
## Description

We're not running automated tests for storybook dark mode

## Changes

* Emulate media for "prefers-color-scheme" in test runner config
* Bypass failing tests

## Additional Information

Some a11y violations in dark mode. If we merge this I will create issues for all occurencies of `test: 'todo'`

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
