### PR TITLE
chore: add workflow to trigger nx release on push to main 🏗️ 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: NX release
+
+on:
+  push:
+    branches:
+      - main
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT }}
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the main branch
+        uses: actions/checkout@v4
+        # Only a single commit is fetched by default
+        # we need full repo history with tags, so we are setting fetch-depth: 0
+        with:
+          fetch-depth: 0
+          ref: main
+          # We need to pass Personal Access Token in order
+          # to force triggering on-publish workflow
+          token: ${{ secrets.PAT }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Sets the base and head SHAs for the nx affected commands in CI
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Build affected libs
+        run: npx nx affected -t build
+
+        # We need to set github email and name as nx release will
+        # create new tag with version and create new github release
+      - name: Run nx release
+        run: |
+          git config --global user.email "bot@midas.dev"
+          git config --global user.name "midas.bot"
+          npx nx release --skip-publish


### PR DESCRIPTION
## Description

🏎️ Remove the need for manually triggering release, instead every push to main should trigger nx release.

## Changes

⛑️ Add workflow file release.yml

## Additional Information

This PR has base **main** which I consider to be correct. We fix this issue separate from the dev and feature branches. Testing for errors is quite hard with this one but release can still be done manually + fingers crossed automation will work🤞 (since it's untested, please double check for any smelly code here when PR:ing!)

## Checklist

- [x] Conventional commit messages
