### PR TITLE
test: ✅♿️ add default main landmark to storybook

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -42,6 +42,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => {
+      const RootTag: React.ElementType =
+        context?.parameters?.rootElement || 'main'
+
       const [colorMode, setColorMode] = React.useState<'light' | 'dark'>(
         getPreferredColorScheme(),
       )
@@ -71,14 +74,14 @@ const preview: Preview = {
       }, [colorMode])
 
       return (
-        <div
+        <RootTag
           style={{
             colorScheme: colorMode,
             backgroundColor: colorMode === 'light' ? 'white' : '#121212',
           }}
         >
           <Story />
-        </div>
+        </RootTag>
       )
     },
   ],

--- a/packages/components/src/calendar/Calendar.stories.tsx
+++ b/packages/components/src/calendar/Calendar.stories.tsx
@@ -1,22 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Calendar } from './Calendar'
 
-const meta: Meta<typeof Calendar> = {
+type Story = StoryObj<typeof Calendar>
+
+export default {
   component: Calendar,
   title: 'Components/Calendar',
   tags: ['autodocs'],
-  parameters: {
-    a11y: {
-      test: 'todo',
-    },
-  },
-}
-export default meta
-type Story = StoryObj<typeof Calendar>
+} as Meta<typeof Calendar>
 
-export const Primary: Story = {
-  args: {},
-}
+export const Primary: Story = {}
 
 export const Disabled: Story = {
   args: {

--- a/packages/components/src/layout/Layout.stories.tsx
+++ b/packages/components/src/layout/Layout.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof Layout> = {
   component: Layout,
   tags: ['autodocs'],
   title: 'Components/Layout',
-  parameters: { layout: 'fullscreen' },
+  parameters: { layout: 'fullscreen', rootElement: 'div' },
 }
 
 export default meta


### PR DESCRIPTION
## Description

TL:DR; Calendar component had a11y violations

The `<header>` element used in `Calendar` got infered `role=banner` due to missing landmark in the context. Placing the Calendar inside of a `main` or `aside` or whatever landmark fixes this and makes the role `sectionHeader` which is valid.

This PR proposes a default main landmark to render components inside, if needed stories can be configured with:
```js
parameters: {
  rootElement: 'div' 
}
```

## Changes

* Add default main element for stories
* Remove a11y test-todo
* Override main element for `Layout` stories

## Additional Information

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
