### PR TITLE
docs: 📝 add example for errorPosition property

### DIFF
--- a/apps/docs/docs/design-patterns/forms.mdx
+++ b/apps/docs/docs/design-patterns/forms.mdx
@@ -20,22 +20,24 @@ Följer vi den regeln faller det sig naturligt att de flesta fält i ett formul�
 />
 ```
 
-<Flex>
-  <FlexItem col='6'>
-    <TextField
-      label='Fullständigt namn'
-      description='För och efternamn'
-      isRequired
-      errorMessage='Detta är ett obligatoriskt fält'
-    />
-  </FlexItem>
-  <FlexItem col='6'>
-    <TextField
-      label='Favoritfrukter (Valfritt)'
-      description='Kan lämnas tomt'
-    />
-  </FlexItem>
-</Flex>
+<div className='card'>
+  <Flex>
+    <FlexItem col='6'>
+      <TextField
+        label='Fullständigt namn'
+        description='För och efternamn'
+        isRequired
+        errorMessage='Detta är ett obligatoriskt fält'
+      />
+    </FlexItem>
+    <FlexItem col='6'>
+      <TextField
+        label='Favoritfrukter (Valfritt)'
+        description='Kan lämnas tomt'
+      />
+    </FlexItem>
+  </Flex>
+</div>
 
 ### Undantag 1: Valfria fält är fler än de obligatoriska
 

--- a/apps/docs/docs/design-patterns/forms.mdx
+++ b/apps/docs/docs/design-patterns/forms.mdx
@@ -1,34 +1,41 @@
 # Formulär
 
 import { Flex, FlexItem, TextField } from '@midas-ds/components'
-import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
 
 ## Obligatorisk vs valfri
 
 Huvudregeln är att bara fråga användaren om uppgifter som är nödvändiga för att ta ett beslut eller liknande.
 Följer vi den regeln faller det sig naturligt att de flesta fält i ett formulär är obligatoriska. Det ger oss grundregeln: Vi markerar endast eventuella valfria fält med texten `”(valfritt)”`.
 
-<LiveCodeBlock
-  hideCode
-  scope={{ Flex, FlexItem, TextField }}
->
-  {`<Flex>
-  <FlexItem col="fluid">
-  <TextField
-    label="Skriv ditt fullständiga namn"
-    description="Både för och efternamn"
-    isRequired
-    errorMessage="Detta är ett obligatoriskt fält"
+```jsx
+<TextField
+  label="Fullständigt namn"
+  description="För och efternamn"
+  isRequired
+  errorMessage="Detta är ett obligatoriskt fält"
 />
+<TextField
+  label="Favoritfrukter (Valfritt)"
+  description="Kan lämnas tomt"
+/>
+```
+
+<Flex>
+  <FlexItem col='6'>
+    <TextField
+      label='Fullständigt namn'
+      description='För och efternamn'
+      isRequired
+      errorMessage='Detta är ett obligatoriskt fält'
+    />
   </FlexItem>
-  <FlexItem col="fluid">
-  <TextField
-    label="Skriv dina favoritfrukter (Valfritt)"
-    description="Du kan lämna fältet tomt om du inte har någon favoritfrukt"
-/>
- </FlexItem>
-</Flex>`}
-</LiveCodeBlock>
+  <FlexItem col='6'>
+    <TextField
+      label='Favoritfrukter (Valfritt)'
+      description='Kan lämnas tomt'
+    />
+  </FlexItem>
+</Flex>
 
 ### Undantag 1: Valfria fält är fler än de obligatoriska
 
@@ -38,3 +45,53 @@ Markera obligatoriska fält med svart asterisk och informera över formuläret a
 
 Markera valfria fält med ”(valfritt)” och obligatoriska fält med svart asterisk och informera över formuläret att obligatoriska fält
 markeras med en asterisk.
+
+## Position av felmeddelande
+
+### Standard
+
+Som standard visas eventuella felmeddelanden ovanför våra formulärelement.
+
+```jsx
+<TextField
+  label='Skriv ditt fullständiga namn'
+  description='Både för och efternamn'
+  isRequired
+  errorMessage='Detta är ett obligatoriskt fält'
+/>
+```
+
+<div className='card'>
+  <TextField
+    label='Skriv ditt fullständiga namn'
+    description='Både för och efternamn'
+    isInvalid
+    errorMessage='Detta är ett obligatoriskt fält'
+  />
+</div>
+
+### Felmeddelande under element
+
+För att visa felmeddelanden under elementet använd attributet `errorPosition` med värdet `bottom`, attributet accepteras av samtliga formulärkomponenter.
+
+```jsx
+<TextField
+  label='Skriv ditt fullständiga namn'
+  description='Både för och efternamn'
+  // highlight-start
+  errorPosition='bottom'
+  // highlight-end
+  isRequired
+  errorMessage='Detta är ett obligatoriskt fält'
+/>
+```
+
+<div className='card'>
+  <TextField
+    label='Skriv ditt fullständiga namn'
+    description='Både för och efternamn'
+    isInvalid
+    errorPosition='bottom'
+    errorMessage='Detta är ett obligatoriskt fält'
+  />
+</div>

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -144,7 +144,7 @@ const config: Config = {
         {
           href: 'https://github.com/migrationsverket/midas',
           className: 'navbar--github-link',
-          ariaLabel: 'GitHub Repository',
+          'aria-label': 'GitHub Repository',
           position: 'right',
         },
       ],

--- a/apps/docs/static/files/CHANGELOG.md
+++ b/apps/docs/static/files/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 7.1.0
+
+#### 🚀 Features
+
+- ✨💄 add semantic z-index tokens ([#401](https://github.com/migrationsverket/midas/pull/401))
+
+#### 🩹 Fixes
+
+- **date-picker:** add missing disabled styles ([10b394897](https://github.com/migrationsverket/midas/commit/10b394897))
+- **combobox:** fix background color to input ([997eac80b](https://github.com/migrationsverket/midas/commit/997eac80b))
+- **theme:** replace invalid text and border colors in dark mode ([3291a9cbd](https://github.com/migrationsverket/midas/commit/3291a9cbd))
+
 ## 7.0.0
 
 This was a version bump only for components to align it with other projects, there were no code changes.


### PR DESCRIPTION
## Description

Explain to our users how to use the `errorPosition` property on form elements

## Changes

* add documentation exampe
* remove live code block
* adjust the other examples to better fit different screen sizes (the text mass made the layout look funky)

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
