### PR TITLE
docs:📝define ErrorPosition and ErrorMessage at component level

### DIFF
--- a/packages/components/src/checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/checkbox/CheckboxGroup.tsx
@@ -6,16 +6,13 @@ import {
   CheckboxGroupProps as AriaCheckboxGroupProps,
   CheckboxGroupStateContext,
   Group,
+  ValidationResult,
 } from 'react-aria-components'
 import styles from './Checkbox.module.css'
 import { Checkbox } from './Checkbox'
 import { Label } from '../label'
 import { Text } from '../text'
-import {
-  FieldError,
-  type ErrorPosition,
-  type ErrorMessage,
-} from '../field-error'
+import { FieldError } from '../field-error'
 
 export interface CheckboxGroupProps
   extends Omit<AriaCheckboxGroupProps, 'children'> {
@@ -23,8 +20,8 @@ export interface CheckboxGroupProps
   label?: string
   description?: string
   showSelectAll?: boolean
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
 }
 
 export const CheckboxGroup = ({

--- a/packages/components/src/combobox/ComboBox.tsx
+++ b/packages/components/src/combobox/ComboBox.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import type {
   ComboBoxProps as AriaComboBoxProps,
   ListBoxItemProps,
+  ValidationResult,
 } from 'react-aria-components'
 import {
   Button,
@@ -17,21 +18,17 @@ import { ChevronDown } from 'lucide-react'
 import clsx from 'clsx'
 import { Label } from '../label'
 import { Text } from '../text'
-import {
-  FieldError,
-  type ErrorPosition,
-  type ErrorMessage,
-} from '../field-error'
+import { FieldError } from '../field-error'
 
 export interface ComboBoxProps<T extends object>
   extends Omit<AriaComboBoxProps<T>, 'children'> {
   label?: string
   description?: string
-  errorMessage?: ErrorMessage
+  errorMessage?: string | ((validation: ValidationResult) => string)
   items?: Iterable<T>
   children: React.ReactNode | ((item: T) => React.ReactNode)
   placeholder?: string
-  errorPosition?: ErrorPosition
+  errorPosition?: 'top' | 'bottom'
 }
 
 export function ComboBox<T extends object>({

--- a/packages/components/src/date-field/DateField.tsx
+++ b/packages/components/src/date-field/DateField.tsx
@@ -5,22 +5,19 @@ import {
   DateInput,
   DateSegment,
   DateValue,
+  ValidationResult,
 } from 'react-aria-components'
 import { Text } from '../text'
 import { Label } from '../label'
-import {
-  type ErrorMessage,
-  FieldError,
-  type ErrorPosition,
-} from '../field-error'
+import { FieldError } from '../field-error'
 import styles from './DateField.module.css'
 import clsx from 'clsx'
 
 interface DateFieldProps<T extends DateValue> extends AriaDateFieldProps<T> {
   label?: string
   description?: string
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
 }
 
 export function DateField<T extends DateValue>({

--- a/packages/components/src/date-picker/DatePicker.tsx
+++ b/packages/components/src/date-picker/DatePicker.tsx
@@ -12,17 +12,14 @@ import {
   Dialog,
   Group,
   Popover,
+  ValidationResult,
 } from 'react-aria-components'
 import { CalendarDays } from 'lucide-react'
 import { clsx } from 'clsx'
 import styles from './DatePicker.module.css'
 import React from 'react'
 import { Calendar, RangeCalendar } from '../calendar'
-import {
-  FieldError,
-  type ErrorMessage,
-  type ErrorPosition,
-} from '../field-error'
+import { FieldError } from '../field-error'
 import { Text } from '../text'
 import { Label } from '../label'
 
@@ -30,8 +27,8 @@ interface MidasDateRangePickerProps<T extends DateValue>
   extends DateRangePickerProps<T> {
   label?: string
   description?: string
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
 }
 
 export const DateRangePicker = <T extends DateValue>({
@@ -105,8 +102,8 @@ export const DateRangePicker = <T extends DateValue>({
 interface MidasDatePickerProps<T extends DateValue> extends DatePickerProps<T> {
   label?: string
   description?: string
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
 }
 
 export const DatePicker = <T extends DateValue>({

--- a/packages/components/src/field-error/FieldError.tsx
+++ b/packages/components/src/field-error/FieldError.tsx
@@ -1,16 +1,11 @@
 import {
   FieldError as AriaFieldError,
   FieldErrorProps,
-  ValidationResult,
 } from 'react-aria-components'
 import * as React from 'react'
 import clsx from 'clsx'
 import styles from './FieldError.module.css'
 import { FieldErrorContext } from 'react-aria-components'
-
-export type ErrorPosition = 'top' | 'bottom'
-
-export type ErrorMessage = string | ((validation: ValidationResult) => string)
 
 export const FieldError = React.forwardRef(
   (props: FieldErrorProps, ref: React.ForwardedRef<HTMLElement>) => {

--- a/packages/components/src/radio/Radio.tsx
+++ b/packages/components/src/radio/Radio.tsx
@@ -9,15 +9,12 @@ import {
   RadioProps,
   Radio as AriaRadio,
   Group,
+  ValidationResult,
 } from 'react-aria-components'
 import clsx from 'clsx'
 import { Label } from '../label'
 import { Text } from '../text'
-import {
-  type ErrorMessage,
-  type ErrorPosition,
-  FieldError,
-} from '../field-error'
+import { FieldError } from '../field-error'
 
 interface MVDSRadioGroupProps extends Omit<RadioGroupProps, 'children'> {
   children?: React.ReactNode
@@ -26,8 +23,8 @@ interface MVDSRadioGroupProps extends Omit<RadioGroupProps, 'children'> {
   /** Additional description rendered below the label */
   description?: string
   /** String to display as error message or function to handle the result and produce the error message */
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
 }
 
 /**

--- a/packages/components/src/search-field/SearchField.tsx
+++ b/packages/components/src/search-field/SearchField.tsx
@@ -10,7 +10,6 @@ import * as React from 'react'
 import { useSearchFieldState } from 'react-stately'
 import { useSearchField } from 'react-aria'
 import type { ValidationError } from '@react-types/shared'
-import { type ErrorPosition } from '../field-error'
 
 export interface SearchFieldProps
   extends Omit<AriaSearchFieldProps, 'isRequired'> {
@@ -26,7 +25,7 @@ export interface SearchFieldProps
    * A custom error message if using the isInvalid prop.
    */
   errorMessage?: string
-  errorPosition?: ErrorPosition
+  errorPosition?: 'top' | 'bottom'
 }
 
 function isValidationError(

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -14,7 +14,7 @@ import { useMultiSelectState, MultiSelectState } from './useMultiSelectState'
 import styles from './Select.module.css'
 import { ChevronDown, X } from 'lucide-react'
 import { TagGroup, Tag } from '../tag'
-import { type ErrorPosition, FieldError } from '../field-error'
+import { FieldError } from '../field-error'
 import useObserveElement from '../utils/useObserveElement'
 import { HiddenMultiSelect } from './HiddenMultiSelect'
 import { Label } from '../label'
@@ -111,7 +111,7 @@ type SelectProps = {
   isRequired?: boolean
   /** Name of the field, for uncontrolled use */
   name?: string
-  errorPosition?: ErrorPosition
+  errorPosition?: 'top' | 'bottom'
 }
 
 export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(

--- a/packages/components/src/textfield/TextFieldBase.tsx
+++ b/packages/components/src/textfield/TextFieldBase.tsx
@@ -4,15 +4,12 @@ import {
   useContextProps,
   TextField as AriaTextField,
   TextFieldProps,
+  ValidationResult,
 } from 'react-aria-components'
 import styles from './TextField.module.css'
 import { Label } from '../label'
 import { Text } from '../text/Text'
-import {
-  type ErrorMessage,
-  type ErrorPosition,
-  FieldError,
-} from '../field-error'
+import { FieldError } from '../field-error'
 import { CharacterCounter } from '../character-counter'
 
 export interface TextFieldBaseProps extends Omit<TextFieldProps, 'className'> {
@@ -22,8 +19,8 @@ export interface TextFieldBaseProps extends Omit<TextFieldProps, 'className'> {
   /** Specify description displayed below the label */
   description?: string
   /** Custom error messages */
-  errorMessage?: ErrorMessage
-  errorPosition?: ErrorPosition
+  errorMessage?: string | ((validation: ValidationResult) => string)
+  errorPosition?: 'top' | 'bottom'
   /**
    * Whether to show the character counter or not
    * @default


### PR DESCRIPTION
## Description

Definition of types `ErrorPosition` and `ErrorMessage` wasn't visible in docs prop table

## Changes

Define types at  component level

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
