### PR TITLE
fix(accordion): fix responsive content hiding when changing screen size

### DIFF
--- a/apps/docs/docs/components/accordion.mdx
+++ b/apps/docs/docs/components/accordion.mdx
@@ -123,15 +123,15 @@ En tydligare variant av layouten när det finns en tydlig gräns mellan varje se
 ### Multiple
 
 En accordion har som standard bara en öppet samtidigt och stänger automatiskt andra sektioner när en ny öppnas.
-Detta kan ändras genom att sätta `type` till `multiple`.
+Detta kan ändras genom att sätta prop `allowsMultipleExpanded`.
 
 ```tsx
-<Accordion type={'multiple'}>
+<Accordion allowsMultipleExpanded>
   <AccordionItem>...</AccordionItem>
 </Accordion>
 ```
 
-<AccordionExample type={'multiple'} />
+<AccordionExample allowsMultipleExpanded />
 
 ### Uncontrolled expanded
 

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -83,17 +83,6 @@
   background-color: var(--background);
 }
 
-/* safari can't calculate correct so we skip the animation there as a compriomise */
-.panel:not(.panel0) {
-  height: 0;
-  overflow: hidden;
-  transition: height 500ms cubic-bezier(0.16, 1, 0.3, 1);
-
-  &[aria-hidden='false'] {
-    height: var(--panel-height);
-  }
-}
-
 .content {
   padding: var(--content-padding);
 }

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -81,11 +81,13 @@
 
 .item {
   background-color: var(--background);
+
   @supports (interpolate-size: allow-keywords) {
     .panel {
       height: 0;
       transition: height 0.25s ease-in;
     }
+
     &[data-expanded] > .panel {
       height: calc-size(min-content, size);
       overflow-y: clip;

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -84,10 +84,11 @@
   transition: 0.25s ease-in-out allow-discrete;
   overflow-y: clip;
 }
+
 .panel[aria-hidden='false'] {
   transition: 0.25s ease-in-out allow-discrete;
   height: auto;
-  height: calc-size(min-content, size)
+  height: calc-size(min-content, size);
 }
 
 .item {

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -81,9 +81,20 @@
 
 .item {
   background-color: var(--background);
+  @supports (interpolate-size: allow-keywords) {
+    .panel {
+      height: 0;
+      transition: height 0.25s ease-in;
+    }
+    &[data-expanded] > .panel {
+      height: calc-size(min-content, size);
+      overflow-y: clip;
+    }
+  }
 }
 
 .content {
+  height: auto;
   padding: var(--content-padding);
 }
 

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -31,7 +31,7 @@
   padding: 0;
   font-size: 1rem;
   font-weight: 400;
-  flex: 1 0 0%;
+  flex: 1 0 0;
   text-align: left;
 }
 

--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -79,20 +79,19 @@
   }
 }
 
+.panel[aria-hidden='true'] {
+  height: 0;
+  transition: 0.25s ease-in-out allow-discrete;
+  overflow-y: clip;
+}
+.panel[aria-hidden='false'] {
+  transition: 0.25s ease-in-out allow-discrete;
+  height: auto;
+  height: calc-size(min-content, size)
+}
+
 .item {
   background-color: var(--background);
-
-  @supports (interpolate-size: allow-keywords) {
-    .panel {
-      height: 0;
-      transition: height 0.25s ease-in;
-    }
-
-    &[data-expanded] > .panel {
-      height: calc-size(min-content, size);
-      overflow-y: clip;
-    }
-  }
 }
 
 .content {

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -121,38 +121,56 @@ export const DynamicContent: Story = {
   args: {},
   render: () => (
     <Accordion>
-      <AccordionItem title={'Hello'} >
-        <span data-testid='item-0'>Hej</span>
+      <AccordionItem title={'AccordionItem with dynamic content'}>
+        Knowledge is knowing a tomato is a fruit; wisdom is not putting it in a
+        fruit salad.
         <ExpandableStuff />
       </AccordionItem>
-      <AccordionItem title={'Goodbye'}>
-        Hej här kan vara annan text som tar plats
+      <AccordionItem title={'Another AccordionItem'}>
+        More text about another subject...
       </AccordionItem>
     </Accordion>
   ),
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByTestId('item-0'))
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: 'AccordionItem with dynamic content',
+      }),
+    )
     await userEvent.click(canvas.getByTestId('btn-0'))
-
-    await expect(
-      canvas.getByTestId('hidden-content'),
-    ).toBeInTheDocument()
-    await expect(
-      canvas.getByTestId('hidden-content')
-    ).toHaveTextContent('more info')
-  }
+    await expect(canvas.getByTestId('hidden-content')).toBeVisible()
+  },
 }
 
 const ExpandableStuff = () => {
   const [isVisible, setIsVisible] = React.useState(false)
   return (
     <div>
-      <button onClick={() => setIsVisible(p => !p)} data-testid={'btn-0'}>show</button>
-      Normal text on the panel
-      {isVisible ? <div style={{background: 'green', height: '10rem'}} data-testid={'hidden-content'}>
-        more info
-      </div> : null}
+      <button
+        onClick={() => setIsVisible(p => !p)}
+        data-testid={'btn-0'}
+      >
+        {isVisible ? 'hide' : 'show'}
+      </button>
+      {isVisible ? (
+        <div
+          style={{
+            background: 'lightblue',
+            color: 'white',
+            height: 'auto',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '2rem',
+          }}
+          data-testid={'hidden-content'}
+        >
+          🍍 Pineapples were once so rare and expensive in Europe that people
+          used them as a status symbol—even renting them for parties to show off
+          wealth, without ever eating them!
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Accordion, AccordionItem } from './'
 import { File } from 'lucide-react'
-import { expect, userEvent, within } from '@storybook/test'
+import { expect, userEvent } from '@storybook/test'
 import { ACCORDION_TEST_ID } from './Accordion'
 import styles from './Accordion.module.css'
 import React from 'react'
@@ -119,6 +119,7 @@ export const CustomTriggerElements: Story = {
 
 export const DynamicContent: Story = {
   args: {},
+  tags: ['!dev', '!autodocs'],
   render: () => (
     <Accordion>
       <AccordionItem title={'AccordionItem with dynamic content'}>
@@ -131,8 +132,7 @@ export const DynamicContent: Story = {
       </AccordionItem>
     </Accordion>
   ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
+  play: async ({ canvas }) => {
     await userEvent.click(
       canvas.getByRole('button', {
         name: 'AccordionItem with dynamic content',
@@ -156,7 +156,7 @@ const ExpandableStuff = () => {
       {isVisible ? (
         <div
           style={{
-            background: 'lightblue',
+            background: 'black',
             color: 'white',
             height: 'auto',
             display: 'flex',
@@ -166,7 +166,7 @@ const ExpandableStuff = () => {
           }}
           data-testid={'hidden-content'}
         >
-          🍍 Pineapples were once so rare and expensive in Europe that people
+          Pineapples were once so rare and expensive in Europe that people
           used them as a status symbol—even renting them for parties to show off
           wealth, without ever eating them!
         </div>

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Accordion, AccordionItem } from './'
 import { File } from 'lucide-react'
-import { expect, getByText, userEvent, within } from '@storybook/test'
+import { expect, userEvent, within } from '@storybook/test'
 import { ACCORDION_TEST_ID } from './Accordion'
 import styles from './Accordion.module.css'
 import React from 'react'

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Accordion, AccordionItem } from './'
 import { File } from 'lucide-react'
-import { expect } from '@storybook/test'
+import { expect, getByText, userEvent, within } from '@storybook/test'
 import { ACCORDION_TEST_ID } from './Accordion'
 import styles from './Accordion.module.css'
+import React from 'react'
 
 const ITEMS = ['Ett', 'Två', 'Tre', 'Fyra']
 
@@ -114,4 +115,44 @@ export const CustomTriggerElements: Story = {
       </AccordionItem>
     )),
   },
+}
+
+export const DynamicContent: Story = {
+  args: {},
+  render: () => (
+    <Accordion>
+      <AccordionItem title={'Hello'} >
+        <span data-testid='item-0'>Hej</span>
+        <ExpandableStuff />
+      </AccordionItem>
+      <AccordionItem title={'Goodbye'}>
+        Hej här kan vara annan text som tar plats
+      </AccordionItem>
+    </Accordion>
+  ),
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId('item-0'))
+    await userEvent.click(canvas.getByTestId('btn-0'))
+
+    await expect(
+      canvas.getByTestId('hidden-content'),
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByTestId('hidden-content')
+    ).toHaveTextContent('more info')
+  }
+}
+
+const ExpandableStuff = () => {
+  const [isVisible, setIsVisible] = React.useState(false)
+  return (
+    <div>
+      <button onClick={() => setIsVisible(p => !p)} data-testid={'btn-0'}>show</button>
+      Normal text on the panel
+      {isVisible ? <div style={{background: 'green', height: '10rem'}} data-testid={'hidden-content'}>
+        more info
+      </div> : null}
+    </div>
+  )
 }

--- a/packages/components/src/accordion/Accordion.tsx
+++ b/packages/components/src/accordion/Accordion.tsx
@@ -10,7 +10,7 @@ export const ACCORDION_TEST_ID = 'accordion'
 interface MidasAccordion extends DisclosureGroupProps {
   /** Display either the larger contained variant or a smaller uncontained variant */
   variant?: 'uncontained' | 'contained'
-  /** Weither to allow the user to have multiple accordions open at the same time */
+  /** @deprecated Use 'allowsMultipleExpanded' instead */
   type?: 'single' | 'multiple'
 }
 
@@ -28,7 +28,7 @@ export const Accordion: React.FC<MidasAccordion> = ({
   return (
     <DisclosureGroup
       data-testid={ACCORDION_TEST_ID}
-      allowsMultipleExpanded={type === 'multiple'}
+      allowsMultipleExpanded={props.allowsMultipleExpanded || type === 'multiple'}
       className={clsx(
         styles.root,
         variant === 'contained' ? styles.contained : styles.uncontained,

--- a/packages/components/src/accordion/Accordion.tsx
+++ b/packages/components/src/accordion/Accordion.tsx
@@ -28,7 +28,9 @@ export const Accordion: React.FC<MidasAccordion> = ({
   return (
     <DisclosureGroup
       data-testid={ACCORDION_TEST_ID}
-      allowsMultipleExpanded={props.allowsMultipleExpanded || type === 'multiple'}
+      allowsMultipleExpanded={
+        props.allowsMultipleExpanded || type === 'multiple'
+      }
       className={clsx(
         styles.root,
         variant === 'contained' ? styles.contained : styles.uncontained,

--- a/packages/components/src/accordion/AccordionItem.tsx
+++ b/packages/components/src/accordion/AccordionItem.tsx
@@ -28,22 +28,7 @@ export const AccordionItem: React.FC<MidasAccordionItem> = ({
   headingLevel = 3,
   ...props
 }) => {
-  const panelRef = React.useRef<HTMLDivElement>(null)
-  const [panelHeight, setPanelHeight] = React.useState(0)
-
   const titleIsReactNode = typeof title === 'object'
-
-  /**
-   * There might be a better way to do this.
-   * Normally this shouldn't be used without a dependency array
-   * we found no way to get around it without doing like this.
-   */
-  // eslint-disable-next-line
-  React.useLayoutEffect(() => {
-    if (panelRef.current) {
-      setPanelHeight(panelRef.current.clientHeight)
-    }
-  })
 
   return (
     <Disclosure
@@ -81,11 +66,9 @@ export const AccordionItem: React.FC<MidasAccordionItem> = ({
         </Heading>
       )}
       <DisclosurePanel
-        style={{ '--panel-height': `${panelHeight}px` } as React.CSSProperties}
-        className={clsx(styles.panel, panelHeight === 0 && styles.panel0)}
+        className={clsx(styles.panel)}
       >
         <div
-          ref={panelRef}
           className={styles.content}
         >
           {children}


### PR DESCRIPTION
## Description

- fixes responsive bug and uses css for animations (chrome only)

## Changes

- remove useEffect
- add calc-size for height of panel

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
