### PR TITLE
refactor(select): 📝♻️

### DIFF
--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -2,40 +2,36 @@
 title: Select
 ---
 
-import { Select } from '@midas-ds/components'
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import LiveCodeBlock from '@site/src/components/CodeBlock/CodeBlock'
-
-export const Example = props => {
-  return (
-    <LiveCodeBlock
-      scope={{ Select }}
-      {...props}
-    >
-      {`<Select
-        label="Vad är din favoritfrukt?"
-        placeholder="Välj en frukt"
-        description="Beskrivning"
-        selectionMode={'single'}
-        isClearable={false}
-        isSelectableAll={false}
-        showTags={false}
-        defaultSelectedKeys={['kiwi']}
-        options={fruits.map(fruit => {return {id: fruit.value, name: fruit.name}})}
-      ></Select>`}
-    </LiveCodeBlock>
-  )
-}
+import { BasicExample } from '@site/src/components/examples/select/SelectExamples'
 
 <ComponentHeader
   name={'Select'}
-  friendlyName={'Flerval, väljare, dropdown'}
+  friendlyName={'Flerval, väljare, dropdown, rullgardin'}
 />
 
 Inmatningsfält som används för att välja ett eller flera fördefinerade alternativ.
 
-<Example hideCode />
+```tsx
+<Select
+  label='Favoritfrukt'
+  description='Välj vilken du vill'
+  placeholder='Välj en frukt'
+  selectionMode='single'
+  options={[
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
+  ]}
+/>
+```
+
+<div className='card'>
+  <BasicExample />
+</div>
 
 ## Installation
 
@@ -47,8 +43,6 @@ npm install @midas-ds/components
 import { Select } from '@midas-ds/components'
 ```
 
-<Example hideExample />
-
 ## Riktlinjer
 
 Om det är färre alternativ än fem bör [Radio](./radio.mdx) användas istället.
@@ -59,40 +53,96 @@ Om det är färre alternativ än fem bör [Radio](./radio.mdx) användas iställ
 
 Använd egenskapen `selectionMode="multiple"` för att slå på flervalsläget.
 
-<LiveCodeBlock
-  scope={{ Select }}
-  {...props}
->
-  {`
-    <Select
-      label='Vilka är dina favoritfrukter?'
-      placeholder='Välj en eller flera frukter'
-      description='Beskrivning'
-      selectionMode='multiple'
-      options={fruits.map(({ value, name }) => ({ id: value, name }))}
-    />
-  `}
-</LiveCodeBlock>
+```tsx
+<Select
+  label='Favoritfrukt'
+  description='Välj vilken du vill'
+  placeholder='Välj en frukt'
+  // highlight-start
+  selectionMode='multiple'
+  // highlight-end
+  options={[
+    {
+      id: 'banan',
+      name: 'Banan',
+    },
+    {
+      id: 'äpple',
+      name: 'Äpple',
+    },
+  ]}
+/>
+```
+
+<div className='card'>
+  <BasicExample selectionMode='multiple' />
+</div>
 
 #### Välj alla
 
 Egenskapen `isSelectableAll` kan användas för att lägga till en "Välj alla"-knapp.
 
-<LiveCodeBlock
-  scope={{ Select }}
-  {...props}
->
-  {`
-    <Select
-      label='Vilka är dina favoritfrukter?'
-      placeholder='Välj en eller flera frukter'
-      description='Beskrivning'
-      selectionMode='multiple'
-      options={fruits.map(({ value, name }) => ({ id: value, name }))}
-      isSelectableAll
-    />
-  `}
-</LiveCodeBlock>
+```tsx
+<Select
+  label='Favoritfrukt'
+  description='Välj vilken du vill'
+  placeholder='Välj en frukt'
+  // highlight-start
+  selectionMode='multiple'
+  isSelectableAll
+  // highlight-end
+  options={[
+    {
+      id: 'banan',
+      name: 'Banan',
+    },
+    {
+      id: 'äpple',
+      name: 'Äpple',
+    },
+  ]}
+/>
+```
+
+<div className='card'>
+  <BasicExample
+    selectionMode='multiple'
+    isSelectableAll
+  />
+</div>
+
+#### Visa etiketter
+
+Egenskapen `showTags` kan användas för att visa valen som etiketter under rullgardinen.
+
+```tsx
+<Select
+  label='Favoritfrukt'
+  description='Välj vilken du vill'
+  placeholder='Välj en frukt'
+  // highlight-start
+  selectionMode='multiple'
+  showTags
+  // highlight-end
+  options={[
+    {
+      id: 'banan',
+      name: 'Banan',
+    },
+    {
+      id: 'äpple',
+      name: 'Äpple',
+    },
+  ]}
+/>
+```
+
+<div className='card'>
+  <BasicExample
+    selectionMode='multiple'
+    showTags
+  />
+</div>
 
 ## API
 

--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -150,7 +150,7 @@ Använd egenskapen `defaultSelectedKeys` för att sätta ett initialt värde til
   placeholder='Välj en frukt'
   // highlight-start
   selectionMode='multiple'
-  defaultSelectedKeys={['banan', 'dadel']}
+  defaultSelectedKeys={new Set(['banan', 'dadel'])}
   // highlight-end
   options={[
     { id: 'apelsin', name: 'Apelsin' },
@@ -165,7 +165,7 @@ Använd egenskapen `defaultSelectedKeys` för att sätta ett initialt värde til
 <div className='card'>
   <BasicExample
     selectionMode='multiple'
-    defaultSelectedKeys={['banan', 'dadel']}
+    defaultSelectedKeys={new Set(['banan', 'dadel'])}
   />
 </div>
 
@@ -186,7 +186,7 @@ const options = [
   { id: 'fikon', name: 'Fikon' },
 ]
 
-const [selectedFruit, setSelectedFruit] = React.useState<Selection>()
+const [selectedFruit, setSelectedFruit] = React.useState<Selection>(new Set())
 
 const handleSelectionChange = (keys: Selection) => {
   if (keys === 'all') {

--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -176,9 +176,24 @@ Värdet för `id` skickas tillbaka i callbacken när användaren justerar sitt v
 
 ```tsx
 import React from 'react'
-import type { Key } from 'react-aria-components'
+import { Selection } from 'react-aria-components'
 
-const [selectedKeys, setSelectedKeys] = React.useState<Key>(['banan', 'dadel'])
+const options = [
+  { id: 'apelsin', name: 'Apelsin' },
+  { id: 'banan', name: 'Banan' },
+  { id: 'citron', name: 'Citron' },
+  { id: 'dadel', name: 'Dadel' },
+  { id: 'fikon', name: 'Fikon' },
+]
+
+const [selectedFruit, setSelectedFruit] = React.useState<Selection>()
+
+const handleSelectionChange = (keys: Selection) => {
+  if (keys === 'all') {
+    return setSelectedFruit(new Set(options.map(({ id }) => id)))
+  }
+  return setSelectedFruit(keys)
+}
 
 return (
   <Select
@@ -187,16 +202,11 @@ return (
     placeholder='Välj en frukt'
     // highlight-start
     selectionMode='multiple'
-    selectedKeys={selectedKeys}
-    onSelectionChange={setSelectedKeys}
+    selectedKeys={selectedFruit}
+    onSelectionChange={handleSelectionChanges}
+    isSelectableAll
     // highlight-end
-    options={[
-      { id: 'apelsin', name: 'Apelsin' },
-      { id: 'banan', name: 'Banan' },
-      { id: 'citron', name: 'Citron' },
-      { id: 'dadel', name: 'Dadel' },
-      { id: 'fikon', name: 'Fikon' },
-    ]}
+    options={options}
   />
 )
 ```

--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -4,7 +4,7 @@ title: Select
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { BasicExample } from '@site/src/components/examples/select/SelectExamples'
+import { BasicExample, ControlledExample } from '@site/src/components/examples/select/SelectExamples'
 
 <ComponentHeader
   name={'Select'}
@@ -47,6 +47,10 @@ import { Select } from '@midas-ds/components'
 
 Om det är färre alternativ än fem bör [Radio](./radio.mdx) användas istället.
 
+## Beskrivning
+
+Midas Select är en variant av React Aria `Select` med möjlighet till flerval.
+
 ## Varianter
 
 ### Flerval
@@ -62,14 +66,11 @@ Använd egenskapen `selectionMode="multiple"` för att slå på flervalsläget.
   selectionMode='multiple'
   // highlight-end
   options={[
-    {
-      id: 'banan',
-      name: 'Banan',
-    },
-    {
-      id: 'äpple',
-      name: 'Äpple',
-    },
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
   ]}
 />
 ```
@@ -92,14 +93,11 @@ Egenskapen `isSelectableAll` kan användas för att lägga till en "Välj alla"-
   isSelectableAll
   // highlight-end
   options={[
-    {
-      id: 'banan',
-      name: 'Banan',
-    },
-    {
-      id: 'äpple',
-      name: 'Äpple',
-    },
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
   ]}
 />
 ```
@@ -125,14 +123,11 @@ Egenskapen `showTags` kan användas för att visa valen som etiketter under rull
   showTags
   // highlight-end
   options={[
-    {
-      id: 'banan',
-      name: 'Banan',
-    },
-    {
-      id: 'äpple',
-      name: 'Äpple',
-    },
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
   ]}
 />
 ```
@@ -142,6 +137,72 @@ Egenskapen `showTags` kan användas för att visa valen som etiketter under rull
     selectionMode='multiple'
     showTags
   />
+</div>
+
+### Förvalda alternativ (okontrollerat)
+
+Använd egenskapen `defaultSelectedKeys` för att sätta ett initialt värde till komponenten.
+
+```tsx
+<Select
+  label='Favoritfrukt'
+  description='Välj vilken du vill'
+  placeholder='Välj en frukt'
+  // highlight-start
+  selectionMode='multiple'
+  defaultSelectedKeys={['banan', 'dadel']}
+  // highlight-end
+  options={[
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
+  ]}
+/>
+```
+
+<div className='card'>
+  <BasicExample
+    selectionMode='multiple'
+    defaultSelectedKeys={['banan', 'dadel']}
+  />
+</div>
+
+### Kontrollerade val
+
+Användarens val kan kontrolleras med hjälp av attributet `selectedKeys` tillsammans med eventet `onSelectionChange`.
+Värdet för `id` skickas tillbaka i callbacken när användaren justerar sitt val, så kan du använda det för att uppdatera ditt state.
+
+```tsx
+import React from 'react'
+import type { Key } from 'react-aria-components'
+
+const [selectedKeys, setSelectedKeys] = React.useState<Key>(['banan', 'dadel'])
+
+return (
+  <Select
+    label='Favoritfrukt'
+    description='Välj vilken du vill'
+    placeholder='Välj en frukt'
+    // highlight-start
+    selectionMode='multiple'
+    selectedKeys={selectedKeys}
+    onSelectionChange={setSelectedKeys}
+    // highlight-end
+    options={[
+      { id: 'apelsin', name: 'Apelsin' },
+      { id: 'banan', name: 'Banan' },
+      { id: 'citron', name: 'Citron' },
+      { id: 'dadel', name: 'Dadel' },
+      { id: 'fikon', name: 'Fikon' },
+    ]}
+  />
+)
+```
+
+<div className='card'>
+  <ControlledExample />
 </div>
 
 ## API

--- a/apps/docs/src/components/examples/select/SelectExamples.tsx
+++ b/apps/docs/src/components/examples/select/SelectExamples.tsx
@@ -28,7 +28,7 @@ export const ControlledExample = () => {
     { id: 'fikon', name: 'Fikon' },
   ]
 
-  const [selectedFruit, setSelectedFruit] = React.useState<Selection>()
+  const [selectedFruit, setSelectedFruit] = React.useState<Selection>(new Set())
 
   const handleSelectionChange = (keys: Selection) => {
     if (keys === 'all') {

--- a/apps/docs/src/components/examples/select/SelectExamples.tsx
+++ b/apps/docs/src/components/examples/select/SelectExamples.tsx
@@ -20,27 +20,38 @@ export const BasicExample: React.FC<Partial<SelectProps>> = props => (
 )
 
 export const ControlledExample = () => {
-  const [selectedKeys, setSelectedKeys] = React.useState<Selection>(
-    new Set(['banan', 'dadel']),
-  )
+  const options = [
+    { id: 'apelsin', name: 'Apelsin' },
+    { id: 'banan', name: 'Banan' },
+    { id: 'citron', name: 'Citron' },
+    { id: 'dadel', name: 'Dadel' },
+    { id: 'fikon', name: 'Fikon' },
+  ]
 
-  console.log(selectedKeys)
+  const [selectedFruit, setSelectedFruit] = React.useState<Selection>()
+
+  const handleSelectionChange = (keys: Selection) => {
+    if (keys === 'all') {
+      return setSelectedFruit(new Set(options.map(({ id }) => id)))
+    }
+    return setSelectedFruit(keys)
+  }
 
   return (
-    <Select
-      label='Favoritfrukt'
-      description='Välj vilken du vill'
-      placeholder='Välj en frukt'
-      selectionMode='single'
-      selectedKeys={selectedKeys}
-      onSelectionChange={setSelectedKeys}
-      options={[
-        { id: 'apelsin', name: 'Apelsin' },
-        { id: 'banan', name: 'Banan' },
-        { id: 'citron', name: 'Citron' },
-        { id: 'dadel', name: 'Dadel' },
-        { id: 'fikon', name: 'Fikon' },
-      ]}
-    />
+    <>
+      <Select
+        label='Favoritfrukt'
+        description='Välj vilken du vill'
+        placeholder='Välj en frukt'
+        selectionMode='multiple'
+        selectedKeys={selectedFruit}
+        onSelectionChange={handleSelectionChange}
+        isSelectableAll
+        options={options}
+      />
+      <pre>
+        Selected fruit: {selectedFruit && Array.from(selectedFruit).join(', ')}
+      </pre>
+    </>
   )
 }

--- a/apps/docs/src/components/examples/select/SelectExamples.tsx
+++ b/apps/docs/src/components/examples/select/SelectExamples.tsx
@@ -1,0 +1,18 @@
+import { Select, SelectProps } from '@midas-ds/components'
+
+export const BasicExample: React.FC<Partial<SelectProps>> = props => (
+  <Select
+    label='Favoritfrukt'
+    description='Välj vilken du vill'
+    placeholder='Välj en frukt'
+    selectionMode='single'
+    options={[
+      { id: 'apelsin', name: 'Apelsin' },
+      { id: 'banan', name: 'Banan' },
+      { id: 'citron', name: 'Citron' },
+      { id: 'dadel', name: 'Dadel' },
+      { id: 'fikon', name: 'Fikon' },
+    ]}
+    {...props}
+  />
+)

--- a/apps/docs/src/components/examples/select/SelectExamples.tsx
+++ b/apps/docs/src/components/examples/select/SelectExamples.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+import type { Selection } from 'react-aria-components'
 import { Select, SelectProps } from '@midas-ds/components'
 
 export const BasicExample: React.FC<Partial<SelectProps>> = props => (
@@ -16,3 +18,29 @@ export const BasicExample: React.FC<Partial<SelectProps>> = props => (
     {...props}
   />
 )
+
+export const ControlledExample = () => {
+  const [selectedKeys, setSelectedKeys] = React.useState<Selection>(
+    new Set(['banan', 'dadel']),
+  )
+
+  console.log(selectedKeys)
+
+  return (
+    <Select
+      label='Favoritfrukt'
+      description='Välj vilken du vill'
+      placeholder='Välj en frukt'
+      selectionMode='single'
+      selectedKeys={selectedKeys}
+      onSelectionChange={setSelectedKeys}
+      options={[
+        { id: 'apelsin', name: 'Apelsin' },
+        { id: 'banan', name: 'Banan' },
+        { id: 'citron', name: 'Citron' },
+        { id: 'dadel', name: 'Dadel' },
+        { id: 'fikon', name: 'Fikon' },
+      ]}
+    />
+  )
+}

--- a/packages/components/src/select/HiddenMultiSelect.tsx
+++ b/packages/components/src/select/HiddenMultiSelect.tsx
@@ -99,12 +99,10 @@ export function useHiddenMultiSelect<T>(
       disabled: isDisabled,
       required: isRequired,
       name,
-      value:
-        state.selectionMode === 'single'
-          ? state.selectedKey?.toString()
-          : Array.from(state.selectedKeys).map(key => key.toString()),
+      value: Array.from(state.selectedKeys).map(key => key.toString()),
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
         state.setSelectedKeys(e.target.value),
+      multiple: true,
     },
   }
 }
@@ -136,7 +134,6 @@ export function HiddenMultiSelect<T>(props: HiddenMultiSelectProps<T>) {
           <select
             {...selectProps}
             ref={selectRef}
-            multiple={state.selectionMode === 'multiple'}
           >
             <option />
             {[...state.collection.getKeys()].map(key => {
@@ -165,9 +162,7 @@ export function HiddenMultiSelect<T>(props: HiddenMultiSelectProps<T>) {
         name={name}
         disabled={isDisabled}
         value={
-          state.selectionMode === 'single'
-            ? (state.selectedKey?.toString() ?? '')
-            : (Array.from(state.selectedKeys).map(key => key.toString()) ?? '')
+          Array.from(state.selectedKeys).map(key => key.toString()) ?? ['']
         }
       />
     )

--- a/packages/components/src/select/Select.spec.tsx
+++ b/packages/components/src/select/Select.spec.tsx
@@ -43,7 +43,9 @@ describe('A single Select', () => {
     await user.keyboard('[ArrowDown]')
     await user.keyboard('[Enter]')
     await user.keyboard('[Esc]')
-    expect(onchange).toHaveBeenCalledWith('kiwi')
+    expect(onchange).toHaveBeenCalledWith(
+      expect.objectContaining(new Set(['kiwi'])),
+    )
   })
 })
 
@@ -91,6 +93,7 @@ describe('given a required single Select', () => {
 
 describe('A multi Select', () => {
   beforeEach(() => {
+    onchange.mockReset()
     baseElement = render(
       <Select
         label={label}
@@ -115,12 +118,16 @@ describe('A multi Select', () => {
     expect(selectButton).toHaveFocus()
     await user.keyboard('[Enter]')
     await user.keyboard('[Enter]')
-    expect(onchange).toHaveBeenCalledWith(['apple'])
+    expect(onchange).toHaveBeenCalledWith(
+      expect.objectContaining(new Set(['apple'])),
+    )
     expect(screen.getByDisplayValue('Apple')).toBeInTheDocument()
     expect(screen.queryByDisplayValue('Banana')).not.toBeInTheDocument()
     await user.keyboard('[ArrowDown]')
     await user.keyboard('[Enter]')
-    expect(onchange).toHaveBeenCalledWith(['apple', 'banana'])
+    expect(onchange).toHaveBeenCalledWith(
+      expect.objectContaining(new Set(['apple', 'banana'])),
+    )
     expect(screen.getByDisplayValue('Apple')).toBeInTheDocument()
     expect(screen.getByDisplayValue('Banana')).toBeInTheDocument()
   })

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -281,6 +281,56 @@ export const RequiredSingle: Story = {
   },
 }
 
+export const Controlled: Story = {
+  tags: ['!dev', '!autodocs'],
+  args: {
+    ...Normal.args,
+    selectionMode: 'multiple',
+    label: 'Controlled mode',
+    placeholder: 'Välj flera',
+  },
+  render: args => {
+    const options = [
+      { id: 'banan', name: 'Banan' },
+      { id: 'melon', name: 'Melon' },
+      { id: 'kiwi', name: 'Kiwi' },
+      { id: 'citron', name: 'Citron' },
+    ]
+
+    const [selectedFruit, setSelectedFruit] = useState<Selection>(new Set())
+
+    const handleSelectionChange = (keys: Selection) => {
+      if (keys === 'all') {
+        return setSelectedFruit(new Set(options.map(({ id }) => id)))
+      }
+      return setSelectedFruit(keys)
+    }
+
+    return (
+      <>
+        <Select
+          {...args}
+          selectedKeys={selectedFruit}
+          onSelectionChange={handleSelectionChange}
+          options={[
+            { id: 'banan', name: 'Banan' },
+            { id: 'melon', name: 'Melon' },
+            { id: 'kiwi', name: 'Kiwi' },
+            { id: 'citron', name: 'Citron' },
+          ]}
+          isSelectableAll
+        />
+        <pre>
+          Valda frukter:
+          {typeof selectedFruit === 'string'
+            ? selectedFruit
+            : selectedFruit && Array.from(selectedFruit).join(', ')}
+        </pre>
+      </>
+    )
+  },
+}
+
 export const DS872: Story = {
   tags: ['!dev', '!autodocs'],
   args: {

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -158,7 +158,7 @@ export const WithTags: Story = {
   args: {
     selectionMode: 'multiple',
     showTags: true,
-    defaultSelectedKeys: ['apple', 'kiwi'],
+    defaultSelectedKeys: new Set(['apple', 'kiwi']),
   },
   play: async ({ args, canvas, step }) => {
     await step(

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -281,56 +281,6 @@ export const RequiredSingle: Story = {
   },
 }
 
-export const Controlled: Story = {
-  // tags: ['!dev', '!autodocs'],
-  args: {
-    ...Normal.args,
-    selectionMode: 'multiple',
-    label: 'Controlled mode',
-    placeholder: 'Välj flera',
-  },
-  render: args => {
-    const options = [
-      { id: 'banan', name: 'Banan' },
-      { id: 'melon', name: 'Melon' },
-      { id: 'kiwi', name: 'Kiwi' },
-      { id: 'citron', name: 'Citron' },
-    ]
-
-    const [selectedFruit, setSelectedFruit] = useState<Selection>(new Set())
-
-    const handleSelectionChange = (keys: Selection) => {
-      if (keys === 'all') {
-        return setSelectedFruit(new Set(options.map(({ id }) => id)))
-      }
-      return setSelectedFruit(keys)
-    }
-
-    return (
-      <>
-        <Select
-          {...args}
-          selectedKeys={selectedFruit}
-          onSelectionChange={handleSelectionChange}
-          options={[
-            { id: 'banan', name: 'Banan' },
-            { id: 'melon', name: 'Melon' },
-            { id: 'kiwi', name: 'Kiwi' },
-            { id: 'citron', name: 'Citron' },
-          ]}
-          isSelectableAll
-        />
-        <pre>
-          Valda frukter:
-          {typeof selectedFruit === 'string'
-            ? selectedFruit
-            : selectedFruit && Array.from(selectedFruit).join(', ')}
-        </pre>
-      </>
-    )
-  },
-}
-
 export const DS872: Story = {
   tags: ['!dev', '!autodocs'],
   args: {

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -4,6 +4,7 @@ import { RunOptions } from 'axe-core'
 import { options } from './utils'
 import { expect, userEvent } from '@storybook/test'
 import React, { useState } from 'react'
+import { Selection } from 'react-stately'
 
 const meta: Meta<typeof Select> = {
   component: Select,
@@ -33,12 +34,10 @@ export const Normal: Story = {
         await userEvent.tab()
         await userEvent.keyboard('[Space]')
         await userEvent.keyboard('[Space]')
-
         const hiddenSelect = canvas.getByLabelText(`${args.label}-hidden`)
         const visibleValue = canvas.getByText(options[0].name, {
           selector: 'span',
         })
-
         expect(hiddenSelect).toHaveDisplayValue([options[0].name])
         expect(visibleValue).toBeVisible()
       },
@@ -49,21 +48,40 @@ export const Normal: Story = {
 export const DefaultSelectedKey: Story = {
   args: {
     description: 'Kiwi is pre-selected',
-    defaultSelectedKeys: ['kiwi'],
+    defaultSelectedKeys: new Set(['kiwi']),
   },
   play: async ({ args, canvas, step }) => {
     await step(
       'It should display and reflect the pre-selected value',
       async () => {
-        const selectedOptionName = options.find(
-          option => option.id === (args.defaultSelectedKeys as string[])[0],
-        )?.name as string
         const hiddenSelect = canvas.getByLabelText(`${args.label}-hidden`)
-        const visibleValue = canvas.getByText(selectedOptionName, {
+        const visibleValue = canvas.getByText('Kiwi', {
           selector: 'span',
         })
 
-        expect(hiddenSelect).toHaveDisplayValue([selectedOptionName])
+        expect(hiddenSelect).toHaveDisplayValue(['Kiwi'])
+        expect(visibleValue).toBeVisible()
+      },
+    )
+  },
+}
+
+export const DefaultSelectedKeys: Story = {
+  args: {
+    description: 'Kiwi and banana are pre-selected',
+    defaultSelectedKeys: new Set(['kiwi', 'banana']),
+    selectionMode: 'multiple',
+  },
+  play: async ({ args, canvas, step }) => {
+    await step(
+      'It should display and reflect the pre-selected value',
+      async () => {
+        const hiddenSelect = canvas.getByLabelText(`${args.label}-hidden`)
+        const visibleValue = canvas.getByText('2 valda', {
+          selector: 'span',
+        })
+
+        expect(hiddenSelect).toHaveDisplayValue(['Banana', 'Kiwi'])
         expect(visibleValue).toBeVisible()
       },
     )
@@ -273,13 +291,13 @@ export const DS872: Story = {
     placeholder: 'Välj ärende',
   },
   render: args => {
-    const [selectedItem, setSelectedItem] = useState('')
+    const [selectedKey, setSelectedKey] = useState<Selection>(new Set())
 
     return (
       <Select
         {...args}
-        selectedKeys={selectedItem}
-        onSelectionChange={item => setSelectedItem(item.toString())}
+        selectedKeys={selectedKey}
+        onSelectionChange={setSelectedKey}
         options={[
           { id: '12', name: 'tolv' },
           { id: '1', name: 'ett' },

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -282,7 +282,7 @@ export const RequiredSingle: Story = {
 }
 
 export const Controlled: Story = {
-  tags: ['!dev', '!autodocs'],
+  // tags: ['!dev', '!autodocs'],
   args: {
     ...Normal.args,
     selectionMode: 'multiple',

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -3,8 +3,8 @@ import { Select } from './Select'
 import { RunOptions } from 'axe-core'
 import { options } from './utils'
 import { expect, userEvent } from '@storybook/test'
-import React, { useState } from 'react'
-import { Selection } from 'react-stately'
+import { useState } from 'react'
+import { Selection } from 'react-aria-components'
 
 const meta: Meta<typeof Select> = {
   component: Select,

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -159,12 +159,11 @@ export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
       ref,
     )
 
-    const isActive = state.isOpen || state.selectedItems || state.selectedItem
+    const isActive = state.isOpen || state.selectedItems
     const isAllSelection = state.selectionManager.isSelectAll
     const isIndeterminateSelection =
       !isAllSelection && !state.selectionManager.isEmpty
-    const hasClearButton =
-      isClearable && (state.selectedItems || state.selectedItem)
+    const hasClearButton = isClearable && state.selectedItems
     const hasHeader = isSelectableAll
 
     const handleClear = () => state.selectionManager.clearSelection()
@@ -271,8 +270,7 @@ export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
                   {...mergeProps}
                   className={clsx(styles.button, {
                     [styles.buttonOpen]: state.isOpen,
-                    [styles.buttonActive]:
-                      state.selectedItems || state.selectedItem,
+                    [styles.buttonActive]: state.selectedItems,
                     [styles.buttonDisabled]: isDisabled,
                   })}
                   data-invalid={
@@ -288,8 +286,8 @@ export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
                   ) : null}
                   {state.selectionMode === 'single' ? (
                     <span>
-                      {state.selectedItem
-                        ? state.selectedItem.textValue
+                      {state.selectedItems
+                        ? state.selectedItems[0].textValue
                         : placeholder}
                     </span>
                   ) : null}

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -42,7 +42,7 @@ type OptionSection = {
 export type Option = OptionItem | OptionSection
 export type SelectionMode = 'single' | 'multiple'
 
-type SelectProps = {
+export type SelectProps = {
   /** Whether the element should receive focus on render. */
   autoFocus?: boolean
 
@@ -384,7 +384,7 @@ export const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
             <TagGroup
               aria-label={'Selected Items'}
               selectionBehavior={'toggle'}
-              onRemove={keys => handleRemove([...keys][0])}
+              onRemove={keys => handleRemove(Array.from(keys)[0])}
               className={styles.tagGroup}
               {...mergeProps}
             >

--- a/packages/components/src/select/useMultiSelectState.ts
+++ b/packages/components/src/select/useMultiSelectState.ts
@@ -1,6 +1,5 @@
 import { MenuTriggerState, useMenuTriggerState } from '@react-stately/menu'
 import { useEffect, useState } from 'react'
-import { Key } from 'react-aria'
 import {
   MultiSelectListState,
   useMultiSelectListState,
@@ -21,10 +20,6 @@ import {
   type FormValidationState,
 } from '@react-stately/form'
 
-interface ArraySelection extends Omit<MultipleSelection, 'onSelectionChange'> {
-  onSelectionChange?: (value: Set<Key>) => void
-}
-
 export interface MultiSelectProps<T>
   extends CollectionBase<T>,
     AsyncLoadable,
@@ -32,8 +27,7 @@ export interface MultiSelectProps<T>
     Validation,
     LabelableProps,
     TextInputBase,
-    ArraySelection,
-    // MultipleSelection,
+    MultipleSelection,
     FocusableProps,
     OverlayTriggerProps {
   /**
@@ -66,17 +60,7 @@ export function useMultiSelectState<T extends object>(
   const multiSelectListState = useMultiSelectListState({
     ...props,
     onSelectionChange: keys => {
-      const { onSelectionChange } = props
-
-      if (onSelectionChange != null) {
-        if (keys === 'all') {
-          // This may change back to "all" once we will implement async loading of additional
-          // items and differentiation between "select all" vs. "select visible".
-          onSelectionChange(new Set(multiSelectListState.collection.getKeys()))
-        } else {
-          onSelectionChange(keys)
-        }
-      }
+      props.onSelectionChange && props.onSelectionChange(keys)
 
       if (isSingleSelect) {
         triggerState.close()

--- a/packages/components/src/select/useMultiSelectState.ts
+++ b/packages/components/src/select/useMultiSelectState.ts
@@ -1,12 +1,10 @@
 import { MenuTriggerState, useMenuTriggerState } from '@react-stately/menu'
 import { useEffect, useState } from 'react'
 import { Key } from 'react-aria'
-
 import {
   MultiSelectListState,
   useMultiSelectListState,
 } from './useMultiSelectListState'
-
 import type { OverlayTriggerProps } from '@react-types/overlays'
 import type {
   AsyncLoadable,
@@ -17,18 +15,14 @@ import type {
   MultipleSelection,
   TextInputBase,
   Validation,
-  Selection,
 } from '@react-types/shared'
-
 import {
   useFormValidationState,
   type FormValidationState,
 } from '@react-stately/form'
-import { SingleSelectListState, useSingleSelectListState } from 'react-stately'
 
-/** Added this for a better output, will see how this plays out */
 interface ArraySelection extends Omit<MultipleSelection, 'onSelectionChange'> {
-  onSelectionChange?: (value: Selection | Key | Key[]) => void
+  onSelectionChange?: (value: Set<Key>) => void
 }
 
 export interface MultiSelectProps<T>
@@ -52,7 +46,6 @@ export interface MultiSelectProps<T>
 export interface MultiSelectState<T>
   extends MultiSelectListState<T>,
     MenuTriggerState,
-    SingleSelectListState<T>,
     FormValidationState {
   /** Whether the select is currently focused. */
   isFocused: boolean
@@ -79,36 +72,12 @@ export function useMultiSelectState<T extends object>(
         if (keys === 'all') {
           // This may change back to "all" once we will implement async loading of additional
           // items and differentiation between "select all" vs. "select visible".
-          onSelectionChange(
-            Array.from(multiSelectListState.collection.getKeys()),
-          )
+          onSelectionChange(new Set(multiSelectListState.collection.getKeys()))
         } else {
-          onSelectionChange(Array.from(keys))
-        }
-      }
-    },
-  })
-
-  const singleSelectListState = useSingleSelectListState({
-    ...props,
-    defaultSelectedKey: props.defaultSelectedKeys?.toString(),
-    selectedKey: props.selectedKeys?.toString(),
-    onSelectionChange: key => {
-      const { onSelectionChange } = props
-
-      if (onSelectionChange != null) {
-        if (key === 'all') {
-          // This may change back to "all" once we will implement async loading of additional
-          // items and differentiation between "select all" vs. "select visible".
-          onSelectionChange(
-            Array.from(singleSelectListState.collection.getKeys()),
-          )
-        } else {
-          onSelectionChange(key)
+          onSelectionChange(keys)
         }
       }
 
-      // Multi select stays open after item selection
       if (isSingleSelect) {
         triggerState.close()
       }
@@ -118,18 +87,11 @@ export function useMultiSelectState<T extends object>(
   const validationState = useFormValidationState({
     ...props,
     validationBehavior: 'native',
-    value: isSingleSelect
-      ? singleSelectListState.selectedKey
-      : multiSelectListState.selectedKeys,
+    value: multiSelectListState.selectedKeys,
   })
 
-  const isCollectionEmpty =
-    (!isSingleSelect && multiSelectListState.collection.size === 0) ||
-    (isSingleSelect && singleSelectListState.collection.size === 0)
-
-  const isAnyKeySelected =
-    !!singleSelectListState.selectedKey ||
-    !!multiSelectListState.selectedKeys.size
+  const isCollectionEmpty = multiSelectListState.collection.size === 0
+  const isAnyKeySelected = !!multiSelectListState.selectedKeys.size
 
   // Reset validation for single selects when the selected key changes.
   useEffect(() => {
@@ -140,11 +102,7 @@ export function useMultiSelectState<T extends object>(
   }, [isAnyKeySelected, isSingleSelect, validationState])
 
   return {
-    ...singleSelectListState,
     ...multiSelectListState,
-    selectionManager: isSingleSelect
-      ? singleSelectListState.selectionManager
-      : multiSelectListState.selectionManager,
     ...triggerState,
     close() {
       triggerState.close()


### PR DESCRIPTION
## Description

TL:DR; Documentation and refactoring, always get back `Selection` in controlled mode, for both `single` and `multiple` mode.

### Long description

When writing documentation for controlled mode I realised the signature of `selectedKeys` and `onSelectionChange` differed:

 `selectedKeys`: `"all" | Iterable<Key> | undefined`
`onSelectionChange`: `'all' | Set<Key> | Key | Key[]`

This PR proposes the same state, default values and return value from `onSelectionChange` for both `single` and `multiple` mode:

`selectedKeys?`: `"all" | Iterable<Key>`
`defaultSelectedKeys?`: `"all" | Iterable<Key>`
`onSelectionChange`: `Selection | undefined`

Usage would be:
`selectedKeys` = `new Set(['kiwi'])` or `new Set(['kiwi', 'banana'])`
`handleChange` = `(value?: Selection) => setSelectedKeys(value)` or if you will: `handleChange` = `setSelectedKeys`

We could also handle the 'all' option ourselves, and say that the callback will always return a set of keys, now  the developer needs to do it. See docs

## Changes

- refactor(select): export props type, use older syntax for handleRemove
- docs(select): remove live code and add showtags example

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
