### PR TITLE
fix(radio): add support for horizontal orientation

### DIFF
--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -15,7 +15,7 @@ export const Example = props => {
       {...props}
     >
       {`<RadioGroup label={'Välj din favoritfrukt'} description={'Du kan bara välja en'} defaultValue={fruits[0].value}>
-        {fruits.slice(0,3).map(fruit => (
+        {fruits.slice(0,2).map(fruit => (
           <Radio key={fruit.value} value={fruit.value}>{fruit.name}</Radio>
         )))</RadioGroup>`}
     </LiveCodeBlock>

--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -5,7 +5,7 @@ description: Radio är en typ av inmatningsfält som används för att välja et
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { BasicExample, ControlledExample } from '@site/src/components/examples/radio/RadioExamples'
+import { BasicExample, ControlledExample, HorizontalExample } from '@site/src/components/examples/radio/RadioExamples'
 
 <ComponentHeader
   name={'Radio'}
@@ -77,6 +77,11 @@ return (
   skapa ett sista alternativ som du kallar "Inget av ovanstående" eller liknande.
 - Radioknapparna placeras som regel vertikalt för att underlätta avläsning. Om antalet alternativ för en given fråga är
   begränsat till två (2) och det är ont om vertikalt utrymme så kan en horisontell orientering användas.
+
+<div className='card'>
+  <HorizontalExample />
+</div>
+
 - Fältetiketten ska inledas med stor bokstav och inte följas av punkt.
 - Om alternativen inte utesluter varandra, använd [Checkbox](/components/checkbox).
 - Om det är fler alternativ än fem bör [Select](/components/select) användas istället.

--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -5,6 +5,7 @@ description: Radio är en typ av inmatningsfält som används för att välja et
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+import { BasicExample, ControlledExample } from '@site/src/components/examples/radio/RadioExamples'
 
 <ComponentHeader
   name={'Radio'}

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -9,8 +9,6 @@ export const BasicExample: React.FC = () => (
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>
-    <Radio value='kiwi'>Kiwi</Radio>
-    <Radio value='aplesin'>Apelsin</Radio>
   </RadioGroup>
 )
 
@@ -27,8 +25,6 @@ export const ControlledExample = () => {
       >
         <Radio value='apple'>Äpple</Radio>
         <Radio value='banan'>Banan</Radio>
-        <Radio value='kiwi'>Kiwi</Radio>
-        <Radio value='aplesin'>Apelsin</Radio>
       </RadioGroup>
       <div style={{ marginTop: '1rem' }}>selectedFruit: {selectedFruit}</div>
     </>

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -40,6 +40,7 @@ export const HorizontalExample = () => (
     label='Välj din favoritfrukt'
     description='Max 2 val vid horisontellt läge'
     orientation='horizontal'
+    defaultValue='apple'
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -9,6 +9,8 @@ export const BasicExample: React.FC = () => (
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>
+    <Radio value='kiwi'>Kiwi</Radio>
+    <Radio value='aplesin'>Apelsin</Radio>
   </RadioGroup>
 )
 
@@ -25,8 +27,21 @@ export const ControlledExample = () => {
       >
         <Radio value='apple'>Äpple</Radio>
         <Radio value='banan'>Banan</Radio>
+        <Radio value='kiwi'>Kiwi</Radio>
+        <Radio value='aplesin'>Apelsin</Radio>
       </RadioGroup>
       <div style={{ marginTop: '1rem' }}>selectedFruit: {selectedFruit}</div>
     </>
   )
 }
+
+export const HorizontalExample = () => (
+  <RadioGroup
+    label='Välj din favoritfrukt'
+    description='Max 2 val vid horisontellt läge'
+    orientation='horizontal'
+  >
+    <Radio value='apple'>Äpple</Radio>
+    <Radio value='banan'>Banan</Radio>
+  </RadioGroup>
+)

--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -11,12 +11,17 @@
     opacity: 1;
     color: --text-disabled;
   }
-}
 
-.wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  .wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &[aria-orientation='horizontal'] .wrap {
+    flex-direction: row;
+    gap: 1rem;
+  }
 }
 
 .radio {

--- a/packages/components/src/radio/Radio.stories.tsx
+++ b/packages/components/src/radio/Radio.stories.tsx
@@ -35,7 +35,7 @@ export default meta
 
 type Story = StoryObj<typeof RadioGroup>
 
-const fruits = ['Äpple', 'Banan', 'Kiwi', 'Apelsin']
+const fruits = ['Äpple', 'Banan']
 const items = fruits.map(fruit => (
   <Radio
     key={fruit}
@@ -48,23 +48,17 @@ const items = fruits.map(fruit => (
 
 const radioItemsOneDisabled = [
   <Radio
+    key='radio-apple'
+    value='apple'
+    isDisabled={true}
+  >
+    Äpple
+  </Radio>,
+  <Radio
     key='radio-banan'
     value='banan'
   >
     Banan
-  </Radio>,
-  <Radio
-    key='radio-apelsin'
-    value='apelsin'
-    isDisabled={true}
-  >
-    Apelsin
-  </Radio>,
-  <Radio
-    key='radio-kiwi'
-    value='kiwi'
-  >
-    Kiwi
   </Radio>,
 ]
 

--- a/packages/components/src/radio/Radio.stories.tsx
+++ b/packages/components/src/radio/Radio.stories.tsx
@@ -35,7 +35,7 @@ export default meta
 
 type Story = StoryObj<typeof RadioGroup>
 
-const fruits = ['Äpple', 'Banan']
+const fruits = ['Äpple', 'Banan', 'Kiwi', 'Apelsin']
 const items = fruits.map(fruit => (
   <Radio
     key={fruit}
@@ -48,17 +48,23 @@ const items = fruits.map(fruit => (
 
 const radioItemsOneDisabled = [
   <Radio
-    key='radio-apple'
-    value='apple'
-    isDisabled={true}
-  >
-    Äpple
-  </Radio>,
-  <Radio
     key='radio-banan'
     value='banan'
   >
     Banan
+  </Radio>,
+  <Radio
+    key='radio-apelsin'
+    value='apelsin'
+    isDisabled={true}
+  >
+    Apelsin
+  </Radio>,
+  <Radio
+    key='radio-kiwi'
+    value='kiwi'
+  >
+    Kiwi
   </Radio>,
 ]
 
@@ -167,6 +173,22 @@ export const CustomValidation: Story = {
 export const Horizontal: Story = {
   args: {
     ...Normal.args,
+    children: (
+      <>
+        <Radio
+          key='radio-apple'
+          value='apple'
+        >
+          Äpple
+        </Radio>
+        <Radio
+          key='radio-banan'
+          value='banan'
+        >
+          Banan
+        </Radio>
+      </>
+    ),
     orientation: 'horizontal',
   },
 }

--- a/packages/components/src/radio/Radio.stories.tsx
+++ b/packages/components/src/radio/Radio.stories.tsx
@@ -169,3 +169,10 @@ export const CustomValidation: Story = {
     )
   },
 }
+
+export const Horizontal: Story = {
+  args: {
+    ...Normal.args,
+    orientation: 'horizontal',
+  },
+}


### PR DESCRIPTION
## Description

Add missing support for horizontal orientation on radiogroup.
Update docs to exemplify that we use max 2 radio options

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
