### PR TITLE
fix(calendar): ♿️ add border for high contrast mode

### DIFF
--- a/apps/docs/docs/components/calendar.mdx
+++ b/apps/docs/docs/components/calendar.mdx
@@ -20,8 +20,7 @@ Kalender kan användas när användaren ska välja ett datum eller visualisera e
 behövs, inte ligger i direkt anslutning till kalendern, eller om kalendern inte ska presenteras som en popover.
 
 ```tsx
-import { Calendar } from '@midas-ds/components'
-;<Calendar />
+<Calendar />
 ```
 
 <div
@@ -35,6 +34,10 @@ import { Calendar } from '@midas-ds/components'
 
 ```bash npm2yarn
 npm install @midas-ds/components
+```
+
+```tsx
+import { Calendar } from '@midas-ds/components'
 ```
 
 ## Användning

--- a/apps/docs/docs/components/calendar.mdx
+++ b/apps/docs/docs/components/calendar.mdx
@@ -21,11 +21,14 @@ behövs, inte ligger i direkt anslutning till kalendern, eller om kalendern inte
 
 ```tsx
 import { Calendar } from '@midas-ds/components'
-
-<Calendar/>
+;<Calendar />
 ```
-<div className={'card'} style={{background: semantic.layer02}}>
-  <Calendar/>
+
+<div
+  className={'card'}
+  style={{ background: semantic.layer02 }}
+>
+  <Calendar />
 </div>
 
 ## Installation
@@ -43,7 +46,7 @@ uncontrolled value sätts med `defaultValue`.
 
 ### RangeCalendar
 
-Samma props som [DateRangePicker](../date-picker#date-range-picker), exempel nedan med controlled value:
+Samma props som [DateRangePicker](../date-picker#daterangepicker), exempel nedan med controlled value:
 
 ```tsx
 import { RangeCalendar } from '@midas-ds/components'
@@ -70,11 +73,13 @@ export const RangeCalendarExample = () => {
     </>
   )
 }
-
 ```
 
-<div className={'card'} style={{background: semantic.layer02}}>
-  <RangeCalendarExample/>
+<div
+  className={'card'}
+  style={{ background: semantic.layer02 }}
+>
+  <RangeCalendarExample />
 </div>
 
 ## API

--- a/packages/components/src/calendar/Calendar.module.css
+++ b/packages/components/src/calendar/Calendar.module.css
@@ -51,6 +51,10 @@
   &[data-disabled='true'] button {
     cursor: not-allowed;
   }
+
+  @media (forced-colors: active) {
+    border: 2px solid;
+  }
 }
 
 .header {

--- a/packages/components/src/calendar/Calendar.module.css
+++ b/packages/components/src/calendar/Calendar.module.css
@@ -107,6 +107,10 @@
     color: --text-on-color;
     background-color: --button-background-primary;
     border-color: --button-background-primary;
+
+    @media (forced-colors: active) {
+      background-color: highlight;
+    }
   }
 
   &.today {

--- a/packages/components/src/calendar/Calendar.tsx
+++ b/packages/components/src/calendar/Calendar.tsx
@@ -45,10 +45,7 @@ export function Calendar<T extends DateValue>({
           <ChevronRight />
         </Button>
       </header>
-      <CalendarGrid
-        className={styles.calendar}
-        weekdayStyle={weekdayStyle}
-      >
+      <CalendarGrid weekdayStyle={weekdayStyle}>
         {date => (
           <CalendarCell
             date={date}

--- a/packages/components/src/calendar/RangeCalendar.tsx
+++ b/packages/components/src/calendar/RangeCalendar.tsx
@@ -46,10 +46,7 @@ export function RangeCalendar<T extends DateValue>({
           <ChevronRight />
         </Button>
       </header>
-      <CalendarGrid
-        className={styles.calendar}
-        weekdayStyle={weekdayStyle}
-      >
+      <CalendarGrid weekdayStyle={weekdayStyle}>
         {date => (
           <CalendarCell
             date={date}


### PR DESCRIPTION
## Description

It's hard to see what's calendar and what's not in high contrast mode

## Changes

- add border for high contrast mode

## Additional Information

Remove the calendar class from the table, looked like it did nothing there

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
