### PR TITLE
fix(theme): add to focus dark mode

### DIFF
--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -85,7 +85,7 @@
 @value --spacing-12: 6rem;
 
 /* States */
-@value --focus: 0 0 0 2px white, 0 0 0 4px black;
+@value --focus: 0 0 0 2px light-dark(white, black), 0 0 0 4px light-dark(black, white);
 
 /* Transitions */
 @value --slow-transition: 500ms;

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -104,8 +104,15 @@ export const spacing = {
 }
 
 export const states = {
-  focus: '0 0 0 2px white, 0 0 0 4px black',
+  focus:
+    '0 0 0 2px light-dark(white, black), 0 0 0 4px light-dark(black, white)',
 }
+/*
+export const states1 = {
+  focusr: `light-dark(${states.focusLight}, ${states1.focusDark})`,
+  
+}
+  */
 
 export const transitions = {
   slow: '500ms',


### PR DESCRIPTION
## Description

In dark mode the focus has wrong box-shadow
_ref number: DS-999_

## Changes

Add dark mode to focus which is in token file

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
