### PR TITLE
fix(checkbox): add in hight contrast the color activeText

### DIFF
--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -123,6 +123,10 @@
     border: none;
     background: --field-disabled;
   }
+
+  @media (forced-colors: active) {
+    color: activeText;
+  }
 }
 
 .checkboxGroup {


### PR DESCRIPTION
## Description

Checkboxens text value  in high contrast (dark theme) is difficult to see

## Changes

Add in hight contrast the color activeText

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
