### PR TITLE
fix(checkbox): add in hight contrast the color activeText

### DIFF
--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -16,7 +16,6 @@
   transition: all 200ms;
   align-items: center;
   justify-content: center;
-  forced-color-adjust: none;
   display: flex;
 
   @media (forced-colors: active) {
@@ -41,7 +40,6 @@
   font-weight: 400;
   gap: 0.5rem;
   align-items: center;
-  forced-color-adjust: none;
   display: flex;
   width: max-content;
   cursor: pointer;
@@ -122,10 +120,6 @@
     pointer-events: none;
     border: none;
     background: --field-disabled;
-  }
-
-  @media (forced-colors: active) {
-    color: activeText;
   }
 }
 

--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -123,6 +123,10 @@
     border: none;
     background: --field-disabled;
   }
+
+  @media (forced-colors: active) {
+    color: activeText;
+  }
 }
 
 .checkboxGroup {

--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --text-primary, --text-disabled, --border-primary, --layer-hover-01, --border-disabled, --breakpoint-sm, --border-invalid, --icon-on-color, --layer-hover-01, --button-background-primary, --button-background-primary-active, --button-background-primary-hover, --border-invalid, --field-disabled, --focus from tokens;
+@value --font-family, --text-primary, --text-disabled, --border-primary, --layer-hover-01, --border-disabled, --breakpoint-sm, --border-invalid, --icon-on-color, --layer-hover-01, --button-background-primary, --button-background-primary-active, --button-background-primary-hover, --border-invalid, --field-disabled, --focus, --line-height-03 from tokens;
 
 .wrap {
   grid-area: Input;
@@ -44,6 +44,7 @@
   width: max-content;
   cursor: pointer;
   color: --text-primary;
+  line-height: --line-height-03;
 
   &[data-hovered] div {
     border-color: --button-background-primary-hover;


### PR DESCRIPTION
## Description

the text in checkbox is difficult to see in high contrast mode(dark theme)
line-height is missing in checkbox
_issue number: DS-1038_ and _DS-1056_
## Changes

List the changes you have made.

Add to the color activeText in high contrast mode 
Add line height to checkbox
Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
