### PR TITLE
docs: clarify use of global.css and disable switch functionality

### DIFF
--- a/apps/docs/docs/dev/dark-mode.mdx
+++ b/apps/docs/docs/dev/dark-mode.mdx
@@ -3,18 +3,21 @@ title: Mörkt läge
 description: Hantera mörkt i designsystemet
 ---
 
-import { Link, ColorSchemeSwitch } from '@midas-ds/components'
+import { ColorSchemeSwitch } from '@midas-ds/components'
 
 # Dark Mode / Mörkt läge
 
 Från och med version `5.0.0` finns våra komponenter både ljust och mörkt tema. Det innebär att designsystemets komponenter kan anpassa sig till användarens inställningar för mörkt läge i operativsystemet eller webbläsaren. Detta sker automatiskt om du använder vår globala stylesheet `global.css`.
 
-<Link
-  standalone
-  href='/get-started/use/#installera-inter-som-typsnitt'
->
-  {'Läs mer om hur du installerar global.css'}
-</Link>
+```tsx {1} title="App.tsx (rootfilen i din app)"
+import '@midas-ds/components/global.css'
+
+export default function App({ children }) {
+  return <main>{children}</main>
+}
+
+export default App
+```
 
 ## Kontrollera val av tema
 
@@ -47,7 +50,8 @@ import { ColorSchemeSwitch } from '@midas-ds/components'
 ```
 
 <div className='card'>
-  <ColorSchemeSwitch />
+  <ColorSchemeSwitch selector='#dark-mode-target' />
+  <div id='dark-mode-target' />
 </div>
 
 ColorSchemeSwitch justerar `color-scheme` värdet på body-elementet. Du kan justera vilken selector som skall användas om color-scheme i din applikation är definerad på en annan DOM-nod. Detta kan du göra genom att skcika in en egen selector i `selector`.
@@ -71,7 +75,7 @@ import { semantic, baseColors } from '@midas-ds/components/theme'
 ```
 
 ```tsx {1,2,5}
-<div style={{ backgroundColor: semantic.background01 }}>
+<div style={{ backgroundColor: semantic.background }}>
   <p style={{ color: semantic.textPrimary }}>
     En text som är mörk i ljust läge men ljus i mörkt läge på en bakgrund som gör tvärt om!
   </p>


### PR DESCRIPTION
## Description

- Copied global.css instructions from /get-started/use to dark-mode page
- Purposely "disabled" ColorSchemeSwitch on docweb, we just need to show how it looks.

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
