### PR TITLE
fix(modal): make text in modal selectable

### DIFF
--- a/packages/components/src/modal/Dialog.tsx
+++ b/packages/components/src/modal/Dialog.tsx
@@ -164,7 +164,7 @@ export const Modal: React.FC<AriaModalOverlayProps & DialogProps> = ({
                 Stäng
               </Button>
             </div>
-            <div className={styles.modalBody}>
+            <div className={styles.modalBody} tabIndex={-1}>
               {title && <Heading level={2}>{title}</Heading>}
               {children}
             </div>


### PR DESCRIPTION
## Description

Text in modal body was not selectable by normal mouse action. This fixes that issue

## Changes

- add `tabIndex={-1}` to modalbody

