### PR TITLE
fix(textfield): merge textfield and input/textarea native dom props

### DIFF
--- a/packages/components/src/textfield/TextArea.stories.tsx
+++ b/packages/components/src/textfield/TextArea.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { TextArea } from './TextArea'
 import { RunOptions } from 'axe-core'
 import { expect, userEvent } from '@storybook/test'
-import { TextField } from '../textfield'
 import styles from './TextField.module.css'
 
 const stringOfLength = (length: number) => new Array(length + 1).join('x')
@@ -15,7 +14,7 @@ export default {
     description: 'Description',
     errorPosition: 'top',
   },
-} as Meta<typeof TextField>
+} as Meta<typeof TextArea>
 
 type Story = StoryObj<typeof TextArea>
 

--- a/packages/components/src/textfield/TextArea.stories.tsx
+++ b/packages/components/src/textfield/TextArea.stories.tsx
@@ -20,7 +20,9 @@ type Story = StoryObj<typeof TextArea>
 
 export const Primary: Story = {
   args: {
-    className: 'test-class',
+    inputProps: {
+      className: 'test-class',
+    },
   },
   play: async ({ canvas, step }) => {
     await step(

--- a/packages/components/src/textfield/TextArea.stories.tsx
+++ b/packages/components/src/textfield/TextArea.stories.tsx
@@ -20,9 +20,7 @@ type Story = StoryObj<typeof TextArea>
 
 export const Primary: Story = {
   args: {
-    inputProps: {
-      className: 'test-class',
-    },
+    className: 'test-class',
   },
   play: async ({ canvas, step }) => {
     await step(

--- a/packages/components/src/textfield/TextArea.tsx
+++ b/packages/components/src/textfield/TextArea.tsx
@@ -10,17 +10,26 @@ import clsx from 'clsx'
 import styles from './TextField.module.css'
 
 export interface TextAreaProps
-  extends Omit<TextFieldBaseProps, 'children' | 'type'> {
-  inputProps?: AriaTextAreaProps
+  extends Omit<TextFieldBaseProps, 'children' | 'type' | 'pattern'> {
+  className?: AriaTextAreaProps['className']
+  dir?: string
+  dirName?: string
+  form?: string
+  rows?: number
+  wrap?: string
 }
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ inputProps, ...rest }, ref) => (
+  ({ className, dir, dirName, form, rows, wrap, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <AriaTextArea
-        {...inputProps}
-        className={clsx(styles.textArea, inputProps?.className)}
+        className={clsx(styles.textArea, className)}
+        dir={dir}
+        dirName={dirName}
+        form={form}
         ref={ref}
+        rows={rows}
+        wrap={wrap}
       />
     </TextFieldBase>
   ),

--- a/packages/components/src/textfield/TextArea.tsx
+++ b/packages/components/src/textfield/TextArea.tsx
@@ -10,59 +10,16 @@ import clsx from 'clsx'
 import styles from './TextField.module.css'
 
 export interface TextAreaProps
-  extends Omit<TextFieldBaseProps, 'children' | 'type'>,
-    Omit<
-      AriaTextAreaProps,
-      | 'autoComplete'
-      | 'children'
-      | 'defaultValue'
-      | 'onBeforeInput'
-      | 'onBlur'
-      | 'onChange'
-      | 'onCompositionEnd'
-      | 'onCompositionStart'
-      | 'onCompositionUpdate'
-      | 'onCopy'
-      | 'onCut'
-      | 'onFocus'
-      | 'onInput'
-      | 'onKeyDown'
-      | 'onKeyUp'
-      | 'onPaste'
-      | 'onSelect'
-      | 'slot'
-      | 'spellCheck'
-      | 'style'
-      | 'type'
-      | 'value'
-    > {}
+  extends Omit<TextFieldBaseProps, 'children' | 'type'> {
+  inputProps?: AriaTextAreaProps
+}
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, ...props }, ref) => (
-    <TextFieldBase {...props}>
+  ({ inputProps, ...rest }, ref) => (
+    <TextFieldBase {...rest}>
       <AriaTextArea
-        {...props}
-        autoComplete={undefined}
-        defaultValue={undefined}
-        onBeforeInput={undefined}
-        onBlur={undefined}
-        onChange={undefined}
-        onCompositionEnd={undefined}
-        onCompositionStart={undefined}
-        onCompositionUpdate={undefined}
-        onCopy={undefined}
-        onCut={undefined}
-        onFocus={undefined}
-        onInput={undefined}
-        onKeyDown={undefined}
-        onKeyUp={undefined}
-        onPaste={undefined}
-        onSelect={undefined}
-        slot={undefined}
-        spellCheck={undefined}
-        style={undefined}
-        value={undefined}
-        className={clsx(styles.textArea, className)}
+        {...inputProps}
+        className={clsx(styles.textArea, inputProps?.className)}
         ref={ref}
       />
     </TextFieldBase>

--- a/packages/components/src/textfield/TextArea.tsx
+++ b/packages/components/src/textfield/TextArea.tsx
@@ -12,20 +12,16 @@ import styles from './TextField.module.css'
 export interface TextAreaProps
   extends Omit<TextFieldBaseProps, 'children' | 'type' | 'pattern'> {
   className?: AriaTextAreaProps['className']
-  dir?: string
-  dirName?: string
   form?: string
   rows?: number
   wrap?: string
 }
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, dir, dirName, form, rows, wrap, ...rest }, ref) => (
+  ({ className, form, rows, wrap, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <AriaTextArea
         className={clsx(styles.textArea, className)}
-        dir={dir}
-        dirName={dirName}
         form={form}
         ref={ref}
         rows={rows}

--- a/packages/components/src/textfield/TextArea.tsx
+++ b/packages/components/src/textfield/TextArea.tsx
@@ -10,14 +10,58 @@ import clsx from 'clsx'
 import styles from './TextField.module.css'
 
 export interface TextAreaProps
-  extends Omit<TextFieldBaseProps, 'children' | 'type'> {
-  className?: AriaTextAreaProps['className']
-}
+  extends Omit<TextFieldBaseProps, 'children' | 'type'>,
+    Omit<
+      AriaTextAreaProps,
+      | 'autoComplete'
+      | 'children'
+      | 'defaultValue'
+      | 'onBeforeInput'
+      | 'onBlur'
+      | 'onChange'
+      | 'onCompositionEnd'
+      | 'onCompositionStart'
+      | 'onCompositionUpdate'
+      | 'onCopy'
+      | 'onCut'
+      | 'onFocus'
+      | 'onInput'
+      | 'onKeyDown'
+      | 'onKeyUp'
+      | 'onPaste'
+      | 'onSelect'
+      | 'slot'
+      | 'spellCheck'
+      | 'style'
+      | 'type'
+      | 'value'
+    > {}
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, ...props }, ref) => (
     <TextFieldBase {...props}>
       <AriaTextArea
+        {...props}
+        autoComplete={undefined}
+        defaultValue={undefined}
+        onBeforeInput={undefined}
+        onBlur={undefined}
+        onChange={undefined}
+        onCompositionEnd={undefined}
+        onCompositionStart={undefined}
+        onCompositionUpdate={undefined}
+        onCopy={undefined}
+        onCut={undefined}
+        onFocus={undefined}
+        onInput={undefined}
+        onKeyDown={undefined}
+        onKeyUp={undefined}
+        onPaste={undefined}
+        onSelect={undefined}
+        slot={undefined}
+        spellCheck={undefined}
+        style={undefined}
+        value={undefined}
         className={clsx(styles.textArea, className)}
         ref={ref}
       />

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -23,7 +23,9 @@ type Story = StoryObj<typeof TextField>
 
 export const Primary: Story = {
   args: {
-    className: 'test-class',
+    inputProps: {
+      className: 'test-class',
+    },
   },
   play: async ({ canvas, step }) => {
     await step(

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -23,9 +23,7 @@ type Story = StoryObj<typeof TextField>
 
 export const Primary: Story = {
   args: {
-    inputProps: {
-      className: 'test-class',
-    },
+    className: 'test-class',
   },
   play: async ({ canvas, step }) => {
     await step(

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -4,14 +4,60 @@ import * as React from 'react'
 import { TextFieldBase, type TextFieldBaseProps } from './TextFieldBase'
 import { Input, type InputProps } from './Input'
 
-export interface TextFieldProps extends Omit<TextFieldBaseProps, 'children'> {
-  className?: InputProps['className']
-}
+export interface TextFieldProps
+  extends Omit<TextFieldBaseProps, 'children'>,
+    Omit<
+      InputProps,
+      | 'autoComplete'
+      | 'children'
+      | 'defaultValue'
+      | 'onBeforeInput'
+      | 'onBlur'
+      | 'onChange'
+      | 'onCompositionEnd'
+      | 'onCompositionStart'
+      | 'onCompositionUpdate'
+      | 'onCopy'
+      | 'onCut'
+      | 'onFocus'
+      | 'onInput'
+      | 'onKeyDown'
+      | 'onKeyUp'
+      | 'onPaste'
+      | 'onSelect'
+      | 'slot'
+      | 'spellCheck'
+      | 'style'
+      | 'type'
+      | 'value'
+    > {}
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   ({ className, ...props }, ref) => (
     <TextFieldBase {...props}>
       <Input
+        {...props}
+        autoComplete={undefined}
+        defaultValue={undefined}
+        onBeforeInput={undefined}
+        onBlur={undefined}
+        onChange={undefined}
+        onCompositionEnd={undefined}
+        onCompositionStart={undefined}
+        onCompositionUpdate={undefined}
+        onCopy={undefined}
+        onCut={undefined}
+        onFocus={undefined}
+        onInput={undefined}
+        onKeyDown={undefined}
+        onKeyUp={undefined}
+        onPaste={undefined}
+        onSelect={undefined}
+        slot={undefined}
+        spellCheck={undefined}
+        style={undefined}
+        type={undefined}
+        value={undefined}
         className={className}
         ref={ref}
       />

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -3,62 +3,18 @@
 import * as React from 'react'
 import { TextFieldBase, type TextFieldBaseProps } from './TextFieldBase'
 import { Input, type InputProps } from './Input'
+import clsx from 'clsx'
 
-export interface TextFieldProps
-  extends Omit<TextFieldBaseProps, 'children'>,
-    Omit<
-      InputProps,
-      | 'autoComplete'
-      | 'children'
-      | 'defaultValue'
-      | 'onBeforeInput'
-      | 'onBlur'
-      | 'onChange'
-      | 'onCompositionEnd'
-      | 'onCompositionStart'
-      | 'onCompositionUpdate'
-      | 'onCopy'
-      | 'onCut'
-      | 'onFocus'
-      | 'onInput'
-      | 'onKeyDown'
-      | 'onKeyUp'
-      | 'onPaste'
-      | 'onSelect'
-      | 'slot'
-      | 'spellCheck'
-      | 'style'
-      | 'type'
-      | 'value'
-    > {}
+export interface TextFieldProps extends Omit<TextFieldBaseProps, 'children'> {
+  inputProps?: InputProps
+}
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ className, ...props }, ref) => (
-    <TextFieldBase {...props}>
+  ({ inputProps, ...rest }, ref) => (
+    <TextFieldBase {...rest}>
       <Input
-        {...props}
-        autoComplete={undefined}
-        defaultValue={undefined}
-        onBeforeInput={undefined}
-        onBlur={undefined}
-        onChange={undefined}
-        onCompositionEnd={undefined}
-        onCompositionStart={undefined}
-        onCompositionUpdate={undefined}
-        onCopy={undefined}
-        onCut={undefined}
-        onFocus={undefined}
-        onInput={undefined}
-        onKeyDown={undefined}
-        onKeyUp={undefined}
-        onPaste={undefined}
-        onSelect={undefined}
-        slot={undefined}
-        spellCheck={undefined}
-        style={undefined}
-        type={undefined}
-        value={undefined}
-        className={className}
+        {...inputProps}
+        className={clsx(inputProps?.className)}
         ref={ref}
       />
     </TextFieldBase>

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -7,20 +7,15 @@ import clsx from 'clsx'
 
 export interface TextFieldProps extends Omit<TextFieldBaseProps, 'children'> {
   className?: InputProps['className']
-  dir?: string
-  dirName?: string
   form?: string
   list?: string
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ className, dir, dirName, form, list, ...rest }, ref) => (
+  ({ className, form, list, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <Input
         className={clsx(className)}
-        dir={dir}
-        // @ts-expect-error @types/react doesn't recognize this valid attribute
-        dirName={dirName}
         form={form}
         list={list}
         ref={ref}

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -6,15 +6,23 @@ import { Input, type InputProps } from './Input'
 import clsx from 'clsx'
 
 export interface TextFieldProps extends Omit<TextFieldBaseProps, 'children'> {
-  inputProps?: InputProps
+  className?: InputProps['className']
+  dir?: string
+  dirName?: string
+  form?: string
+  list?: string
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ inputProps, ...rest }, ref) => (
+  ({ className, dir, dirName, form, list, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <Input
-        {...inputProps}
-        className={clsx(inputProps?.className)}
+        className={clsx(className)}
+        dir={dir}
+        // @ts-expect-error @types/react doesn't recognize this valid attribute
+        dirName={dirName}
+        form={form}
+        list={list}
         ref={ref}
       />
     </TextFieldBase>


### PR DESCRIPTION
## Description

Native dom-egenskaper saknas på TextArea och TextField, komponenterna kan inte användas på samma sätt som HTMLs `<textarea>` och `<input>`. Som exempel accepteras inte autocapitalize, cols, dirname, form, placeholder, rows, wrap för `Textarea`.

## Changes

- Utöka våra interfaces med relevanta och användbara props och passa dem manuellt till respektive komponent

## Additional information

attributen `dir` och `dirName` verkar hanteras dåligt av react-aria respektive @types/react, om vi någonsin behöver dem får vi kika vidare på det

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
