### PR TITLE
fix(accordion): 🐛 remove disabled styling if component has disabled children

### DIFF
--- a/packages/components/src/accordion/Accordion.module.css
+++ b/packages/components/src/accordion/Accordion.module.css
@@ -34,13 +34,13 @@
         --border-color: --support-border-warning;
       }
 
-      &:has(button[data-disabled]) {
+      &[data-disabled] {
         --border-color: --border-disabled;
       }
     }
   }
 
-  &:has(button[data-disabled]) {
+  &[data-disabled] {
     --heading-color: --text-disabled;
 
     .triggerButton {

--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -5,6 +5,8 @@ import { expect, userEvent } from '@storybook/test'
 import { ACCORDION_TEST_ID } from './Accordion'
 import styles from './Accordion.module.css'
 import React from 'react'
+import { Button } from '../button'
+import { hexToRgb, lightDark } from '../utils/test'
 
 const ITEMS = ['Ett', 'Två', 'Tre', 'Fyra']
 
@@ -75,6 +77,22 @@ export const MultipleSubtle: Story = {
   },
 }
 
+export const MultipleSubtleDisabled: Story = {
+  args: {
+    ...MultipleSubtle.args,
+    isDisabled: true,
+  },
+  play: async ({ canvas, step }) => {
+    await step('it should have the disabled style', async () => {
+      await expect(canvas.getAllByRole('heading', { level: 2 })[0]).toHaveStyle(
+        {
+          color: lightDark(hexToRgb('#bfbfbf'), hexToRgb('#525252')),
+        },
+      )
+    })
+  },
+}
+
 export const MultipleBoxed: Story = {
   args: {
     ...SingleBoxed.args,
@@ -140,6 +158,29 @@ export const DynamicContent: Story = {
     )
     await userEvent.click(canvas.getByTestId('btn-0'))
     await expect(canvas.getByTestId('hidden-content')).toBeVisible()
+  },
+}
+
+export const DS1060: Story = {
+  tags: ['!dev', '!autodocs'],
+  render: () => (
+    <Accordion>
+      <AccordionItem title='Test'>
+        <Button isDisabled>Test</Button>
+      </AccordionItem>
+    </Accordion>
+  ),
+  play: async ({ canvas, step }) => {
+    await step(
+      'it should not have the disabled style even if it contains disabled children',
+      async () => {
+        await expect(
+          canvas.getByRole('heading', { level: 2, name: 'Test' }),
+        ).toHaveStyle({
+          color: lightDark(hexToRgb('#171717'), hexToRgb('#f2f2f2')),
+        })
+      },
+    )
   },
 }
 

--- a/packages/components/src/utils/test.ts
+++ b/packages/components/src/utils/test.ts
@@ -5,3 +5,17 @@ export const lightDark = (light: string, dark: string) =>
   window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
     ? dark
     : light
+
+/**
+ * Convert a CSS hex color to CSS rgb color
+ * ```
+ * '#f2f2f2' => 'rgb(242, 242, 242)'
+ * ```
+ */
+export const hexToRgb = (hex: string) => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+
+  return result
+    ? `rgb(${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)})`
+    : ''
+}


### PR DESCRIPTION
## Description

Using disabled children inside Accordion caused the Accordion to look disabled

## Changes

- Remove the CSS :has pseudo class

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
