### PR TITLE
:memo: :fire: Remove a radio button guideline

### DIFF
--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -73,8 +73,6 @@ return (
 
 ## Riktlinjer
 
-- En av radioknapparna ska alltid vara ifylld. Om du misstänker att användaren vill kunna avstå från att välja något,
-  skapa ett sista alternativ som du kallar "Inget av ovanstående" eller liknande.
 - Radioknapparna placeras som regel vertikalt för att underlätta avläsning. Om antalet alternativ för en given fråga är
   begränsat till två (2) och det är ont om vertikalt utrymme så kan en horisontell orientering användas.
 


### PR DESCRIPTION
## Description

We no longer want to recommend our users to always have one radio button selected by default. 

## Changes

Removed the guideline

## Additional Information

Guidance regarding when to have a radio button selected by default will be added later

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
