### PR TITLE
fix(textfield): add border bottom in disabled and change ivalid borde…

### DIFF
--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -73,7 +73,6 @@
     cursor: not-allowed;
     background-color: --field-disabled;
     border: none;
-    opacity: 0.7;
     border-bottom: 1px solid --border-disabled;
   }
 }
@@ -124,7 +123,6 @@
     cursor: not-allowed;
     background-color: --field-disabled;
     border: none;
-    opacity: 0.7;
     border-bottom: 1px solid --border-disabled;
   }
 }

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --focus, --field-disabled, --text-primary, --border-invalid, --border-primary, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
+@value --focus, --border-disabled, --field-disabled, --text-primary, --border-invalid, --border-primary, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
 
 .textField {
   display: grid;
@@ -66,7 +66,7 @@
 
   &[data-invalid] {
     border: none;
-    box-shadow: inset 0 0 0 3px --border-invalid;
+    box-shadow: inset 0 0 0 2px --border-invalid;
   }
 
   &[data-disabled] {
@@ -74,6 +74,7 @@
     background-color: --field-disabled;
     border: none;
     opacity: 0.7;
+    border-bottom: 1px solid --border-disabled;
   }
 }
 
@@ -116,7 +117,7 @@
 
   &[data-invalid] {
     border: none;
-    box-shadow: inset 0 0 0 3px --border-invalid;
+    box-shadow: inset 0 0 0 2px --border-invalid;
   }
 
   &[data-disabled] {
@@ -124,6 +125,7 @@
     background-color: --field-disabled;
     border: none;
     opacity: 0.7;
+    border-bottom: 1px solid --border-disabled;
   }
 }
 


### PR DESCRIPTION
…r to 2px

## Description

Missing  border- bottom in disabled state
invalid state has 3px

_issue number: DS-1069_

## Changes

add --border-disabled  and remove opacity to disabled state
change the thickness to border from 3px to 2px in invalid state

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
