### PR TITLE
Add more Radiobutton guidelines

### DIFF
--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -5,7 +5,13 @@ description: Radio är en typ av inmatningsfält som används för att välja et
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { BasicExample, ControlledExample, HorizontalExample } from '@site/src/components/examples/radio/RadioExamples'
+import {
+  BasicExample,
+  ControlledExample,
+  HorizontalExample,
+  DefaultValueExample,
+  NoneOfTheAboveExample,
+} from '@site/src/components/examples/radio/RadioExamples'
 import { Radio, RadioGroup } from '@midas-ds/components'
 
 <ComponentHeader
@@ -95,43 +101,20 @@ Det finns två mönster för Radioknappar:
 1. Inget alternativ är valt från början. Detta alternativ kräver att användaren tar ställning för att kunna gå vidare, vilket de flesta fall är lämpligt. Välj detta mönster om det är svårt att förutse eller olämpligt att ge ett förval.
 
 <div className='card'>
-  <RadioGroup
-    label='Välj din favoritfrukt'
-    description='Du kan bara välja en'
-  >
-    <Radio value='apple'>Äpple</Radio>
-    <Radio value='banan'>Banan</Radio>
-    <Radio value='kiwi'>Kiwi</Radio>
-    <Radio value='apelsin'>Apelsin</Radio>
-  </RadioGroup>
+  <BasicExample />
 </div>
 
 2. Ett av alternativen är valt från början. Välj detta mönster om det finns ett val som är förväntat eller önskvärt och det inte ger stora konsekvenser för användaren att inte ta ställning.
 
 <div className='card'>
-  <RadioGroup
-    label='Vill du lägga till din favoritfrukt i fruktkorgen?'
-    description='Det blir gott!'
-    defaultValue='yes'
-  >
-    <Radio value='yes'>Ja</Radio>
-    <Radio value='no'>Nej</Radio>
-  </RadioGroup>
+  <DefaultValueExample />
 </div>
 
 Om användaren behöver kunna avstå från att välja ett alternativ, är rekommendationen att skapa ett sista alternativ som kallar "Inget av givna alternativ" eller liknande.
 
 <div className='card'>
-  <RadioGroup
-    label='Välj din favoritfrukt'
-    description='Du kan bara välja en'
-  >
-    <Radio value='apple'>Äpple</Radio>
-    <Radio value='banan'>Banan</Radio>
-    <Radio value='kiwi'>Kiwi</Radio>
-    <Radio value='apelsin'>Apelsin</Radio>
-    <Radio value='none'>Inget av givna alternativ</Radio>
-  </RadioGroup>
+<NoneOfTheAboveExample />
+
 </div>
 
 ### Val av komponent

--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -6,6 +6,7 @@ description: Radio är en typ av inmatningsfält som används för att välja et
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { BasicExample, ControlledExample, HorizontalExample } from '@site/src/components/examples/radio/RadioExamples'
+import { Radio, RadioGroup } from '@midas-ds/components'
 
 <ComponentHeader
   name={'Radio'}
@@ -19,10 +20,11 @@ Inmatningsfält som används för att välja exakt ett alternativ.
 <RadioGroup
   label='Välj din favoritfrukt'
   description='Du kan bara välja en'
-  defaultValue='apple'
 >
   <Radio value='apple'>Äpple</Radio>
   <Radio value='banan'>Banan</Radio>
+  <Radio value='kiwi'>Kiwi</Radio>
+  <Radio value='apelsin'>Apelsin</Radio>
 </RadioGroup>
 ```
 
@@ -50,7 +52,7 @@ import React from 'react'
 ```
 
 ```tsx
-const [selectedFruit, setSelectedFruit] = useState('banan')
+const [selectedFruit, setSelectedFruit] = useState('')
 
 return (
   <RadioGroup
@@ -63,6 +65,8 @@ return (
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>
+    <Radio value='kiwi'>Kiwi</Radio>
+    <Radio value='apelsin'>Apelsin</Radio>
   </RadioGroup>
 )
 ```
@@ -73,6 +77,10 @@ return (
 
 ## Riktlinjer
 
+### Generella riktlinjer
+
+- Fältetiketten ska inledas med stor bokstav och inte följas av punkt.
+- Lägg valen i bokstavsordning om ingen annan given ordning är mer lämplig, t.ex. det mest populära valet först.
 - Radioknapparna placeras som regel vertikalt för att underlätta avläsning. Om antalet alternativ för en given fråga är
   begränsat till två (2) och det är ont om vertikalt utrymme så kan en horisontell orientering användas.
 
@@ -80,9 +88,56 @@ return (
   <HorizontalExample />
 </div>
 
-- Fältetiketten ska inledas med stor bokstav och inte följas av punkt.
-- Om alternativen inte utesluter varandra, använd [Checkbox](/components/checkbox).
-- Om det är fler alternativ än fem bör [Select](/components/select) användas istället.
+### Mönster
+
+Det finns två mönster för Radioknappar:
+
+1. Inget alternativ är valt från början. Detta alternativ kräver att användaren tar ställning för att kunna gå vidare, vilket de flesta fall är lämpligt. Välj detta mönster om det är svårt att förutse eller olämpligt att ge ett förval.
+
+<div className='card'>
+  <RadioGroup
+    label='Välj din favoritfrukt'
+    description='Du kan bara välja en'
+  >
+    <Radio value='apple'>Äpple</Radio>
+    <Radio value='banan'>Banan</Radio>
+    <Radio value='kiwi'>Kiwi</Radio>
+    <Radio value='apelsin'>Apelsin</Radio>
+  </RadioGroup>
+</div>
+
+2. Ett av alternativen är valt från början. Välj detta mönster om det finns ett val som är förväntat eller önskvärt och det inte ger stora konsekvenser för användaren att inte ta ställning.
+
+<div className='card'>
+  <RadioGroup
+    label='Vill du lägga till din favoritfrukt i fruktkorgen?'
+    description='Det blir gott!'
+    defaultValue='yes'
+  >
+    <Radio value='yes'>Ja</Radio>
+    <Radio value='no'>Nej</Radio>
+  </RadioGroup>
+</div>
+
+Om användaren behöver kunna avstå från att välja ett alternativ, är rekommendationen att skapa ett sista alternativ som kallar "Inget av givna alternativ" eller liknande.
+
+<div className='card'>
+  <RadioGroup
+    label='Välj din favoritfrukt'
+    description='Du kan bara välja en'
+  >
+    <Radio value='apple'>Äpple</Radio>
+    <Radio value='banan'>Banan</Radio>
+    <Radio value='kiwi'>Kiwi</Radio>
+    <Radio value='apelsin'>Apelsin</Radio>
+    <Radio value='none'>Inget av givna alternativ</Radio>
+  </RadioGroup>
+</div>
+
+### Val av komponent
+
+- Använd Radioknappar när användaren bara ska göra ett av flera val i en lista. Använd [Checkbox](/components/checkbox) om flera val ska kunna göras.
+- Om det är fler alternativ än fem (5) bör [Select](/components/select) användas istället.
 
 ## API
 

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -39,7 +39,6 @@ export const HorizontalExample = () => (
     label='Välj din favoritfrukt'
     description='Max 2 val vid horisontellt läge'
     orientation='horizontal'
-    defaultValue='apple'
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -44,3 +44,27 @@ export const HorizontalExample = () => (
     <Radio value='banan'>Banan</Radio>
   </RadioGroup>
 )
+
+export const DefaultValueExample = () => (
+  <RadioGroup
+    label='Vill du lägga till din favoritfrukt i fruktkorgen?'
+    description='Det blir gott!'
+    defaultValue='yes'
+  >
+    <Radio value='yes'>Ja</Radio>
+    <Radio value='no'>Nej</Radio>
+  </RadioGroup>
+)
+
+export const NoneOfTheAboveExample = () => (
+  <RadioGroup
+    label='Välj din favoritfrukt'
+    description='Du kan bara välja en'
+  >
+    <Radio value='apple'>Äpple</Radio>
+    <Radio value='banan'>Banan</Radio>
+    <Radio value='kiwi'>Kiwi</Radio>
+    <Radio value='apelsin'>Apelsin</Radio>
+    <Radio value='none'>Inget av givna alternativ</Radio>
+  </RadioGroup>
+)

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -5,17 +5,16 @@ export const BasicExample: React.FC = () => (
   <RadioGroup
     label='Välj din favoritfrukt'
     description='Du kan bara välja en'
-    defaultValue='apple'
   >
     <Radio value='apple'>Äpple</Radio>
     <Radio value='banan'>Banan</Radio>
     <Radio value='kiwi'>Kiwi</Radio>
-    <Radio value='aplesin'>Apelsin</Radio>
+    <Radio value='apelsin'>Apelsin</Radio>
   </RadioGroup>
 )
 
 export const ControlledExample = () => {
-  const [selectedFruit, setSelectedFruit] = useState('banan')
+  const [selectedFruit, setSelectedFruit] = useState('')
 
   return (
     <>
@@ -28,7 +27,7 @@ export const ControlledExample = () => {
         <Radio value='apple'>Äpple</Radio>
         <Radio value='banan'>Banan</Radio>
         <Radio value='kiwi'>Kiwi</Radio>
-        <Radio value='aplesin'>Apelsin</Radio>
+        <Radio value='apelsin'>Apelsin</Radio>
       </RadioGroup>
       <div style={{ marginTop: '1rem' }}>selectedFruit: {selectedFruit}</div>
     </>


### PR DESCRIPTION
## Description

Add better guidelines and examples in radio button documentation

## Changes

Changed current examples so that tsx matches the example
Changed current examples to that they don't have a preselected radiobutton
Added `DefaultValueExample`, `NoneOfTheAboveExample` to RadioExamples.tsx
Added guidelines to radio docs page


## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
