### PR TITLE
feat(textfield): add medium size option to input padding

### DIFF
--- a/apps/docs/docs/components/textfield.mdx
+++ b/apps/docs/docs/components/textfield.mdx
@@ -117,6 +117,25 @@ Läs mer om validering i [React Arias dokumentation](https://react-spectrum.adob
 
 ## Varianter
 
+### Storlek
+
+För att minska höjden på TextField, använd `size={'medium'}` som minskar padding i inputfältet.
+
+```tsx
+<TextField label={'Large'}/> // default is size={'large'}
+//highlight-next-line
+<TextField label={'Medium'} size={'medium'}/>
+```
+
+<div className={'card'}>
+  <span style={{
+    display: 'flex', gap: '1rem', flexDirection: 'row'
+  }}>
+  <TextField label={'Large'} size={'large'} defaultValue={'large textfield'}/>
+  <TextField label={'Medium'} size={'medium'} defaultValue={'medium textfield'}/>
+  </span>
+</div>
+
 Varianterna är tillägg till React Arias ursprungliga implementation.
 
 ### Character counter

--- a/apps/playground/src/app/app.tsx
+++ b/apps/playground/src/app/app.tsx
@@ -1,37 +1,23 @@
 import styles from './app.module.css'
-import { TextArea, TextField } from '@midas-ds/components'
-import { I18nProvider } from 'react-aria-components'
+import { TextField } from '@midas-ds/components'
 
 export function App() {
   return (
     <div className={styles.container}>
-      <TextField
-        label='Label'
-        description='Description'
-        showCounter
-        type='email'
-        maxLength={4}
-      />
-      <TextField
-        label='Label'
-        description='Description'
-        type='password'
-        validate={value => (value === 'Skriv inte hej' ? 'error' : true)}
-      />
-      <TextArea
-        label='Label'
-        description='Skriv hej'
-        validate={value => (value === 'Skriv inte hej' ? 'error' : true)}
-      />
-      <I18nProvider locale={'de-DE'}>
-        <TextField type={'password'}></TextField>
-      </I18nProvider>
-      <I18nProvider locale={'ko'}>
-        <TextField type={'password'}></TextField>
-      </I18nProvider>
-      <I18nProvider locale={'ar'}>
-        <TextField type={'password'}></TextField>
-      </I18nProvider>
+      <div style={{ display: 'flex', alignItems: 'start', gap: '2rem', border: '1px solid salmon' }}>
+        <TextField
+          label='Medium'
+          description='size component'
+          size={'medium'}
+          defaultValue={'this is medium'}
+        />
+        <TextField
+          size={'large'}
+          label='Large'
+          defaultValue={'this is large'}
+          description='size component'
+        />
+      </div>
     </div>
   )
 }

--- a/packages/components/src/textfield/TextField.module.css
+++ b/packages/components/src/textfield/TextField.module.css
@@ -1,5 +1,5 @@
 @value tokens: "../theme/tokens.css";
-@value --focus, --border-disabled, --field-disabled, --text-primary, --border-invalid, --border-primary, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
+@value --focus, --size-50, --size-70, --border-disabled, --field-disabled, --text-primary, --border-invalid, --border-primary, --field-01, --field-hover-01, --font-family, --text-disabled, --z-index-base, --z-index-above from tokens;
 
 .textField {
   display: grid;
@@ -82,13 +82,19 @@
   grid-area: Input;
 }
 
+.medium {
+  .input {
+    padding-top: --size-50;
+    padding-bottom: --size-50;
+  }
+}
+
 .input {
   all: unset;
   font-family: --font-family;
   grid-area: Input;
   color: --text-primary;
   border-bottom: 1px solid --border-primary;
-  min-height: 48px;
   font-size: 1rem;
   padding-left: 1rem;
   line-height: 1;
@@ -96,6 +102,8 @@
   border-radius: 0;
   box-sizing: border-box;
   width: 100%;
+  padding-top: --size-70;
+  padding-bottom: --size-70;
 
   &[data-hovered] {
     background-color: --field-hover-01;

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -209,7 +209,7 @@ export const MediumSizeInput: Story = {
   render: args => (
     <TextField {...args}/>
   ),
-  play: async ({ canvas, step, args: { defaultValue } }) => {
+  play: async ({ canvas, step }) => {
     await step(
       'it should have an input field with top/bottom padding of 10px',
       async () => {

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -196,3 +196,27 @@ export const ShowCounterWithDefaultValue: Story = {
     )
   },
 }
+
+export const MediumSizeInput: Story = {
+  tags: [
+    '!autodocs'
+  ],
+  args: {
+    defaultValue: 'Medium size input',
+    size: 'medium',
+    label: 'Medium size textfield'
+  },
+  render: args => (
+    <TextField {...args}/>
+  ),
+  play: async ({ canvas, step, args: { defaultValue } }) => {
+    await step(
+      'it should have an input field with top/bottom padding of 10px',
+      async () => {
+        expect(
+          canvas.getByLabelText('Medium size textfield'),
+        ).toHaveStyle('padding-bottom: 10px; padding-top: 10px')
+      },
+    )
+  },
+}

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -206,9 +206,6 @@ export const MediumSizeInput: Story = {
     size: 'medium',
     label: 'Medium size textfield'
   },
-  render: args => (
-    <TextField {...args}/>
-  ),
   play: async ({ canvas, step }) => {
     await step(
       'it should have an input field with top/bottom padding of 10px',

--- a/packages/components/src/textfield/TextFieldBase.tsx
+++ b/packages/components/src/textfield/TextFieldBase.tsx
@@ -4,13 +4,16 @@ import {
   useContextProps,
   TextField as AriaTextField,
   TextFieldProps,
-  ValidationResult,
+  ValidationResult
 } from 'react-aria-components'
 import styles from './TextField.module.css'
 import { Label } from '../label'
 import { Text } from '../text/Text'
 import { FieldError } from '../field-error'
 import { CharacterCounter } from '../character-counter'
+import { clsx } from 'clsx'
+
+export type Size = 'medium' | 'large'
 
 export interface TextFieldBaseProps extends Omit<TextFieldProps, 'className'> {
   children?: React.ReactNode
@@ -27,6 +30,10 @@ export interface TextFieldBaseProps extends Omit<TextFieldProps, 'className'> {
    * false
    */
   showCounter?: boolean
+  /** Component size (large: height 48px, medium: height 40px)
+   *  @default 'large'
+   * */
+  size?: Size
 }
 
 export const TextFieldBase = React.forwardRef<
@@ -41,14 +48,17 @@ export const TextFieldBase = React.forwardRef<
     errorMessage,
     showCounter,
     errorPosition = 'top',
+    size = 'large',
   } = props
 
   return (
     <AriaTextField
       {...props}
-      className={styles.textField}
+      className={clsx(styles.textField, {
+        [styles.medium]: size === 'medium',
+      })}
     >
-      {label && <Label variant='label-02'>{label}</Label>}
+      {label && <Label>{label}</Label>}
       {description && <Text slot='description'>{description}</Text>}
       {showCounter && <CharacterCounter isLonely={!description} />}
       {errorPosition === 'top' && (

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -224,3 +224,7 @@
 @value --z-index-modal: 1000;
 @value --z-index-toast: 1100;
 @value --z-index-skip-to-content: 1200;
+
+/* Sizing */
+@value --size-50: 0.625rem; /* 10px */
+@value --size-70: 0.875rem; /* 14px */


### PR DESCRIPTION
## Description

New setting for textfield to make it smaller

## Changes

- add size prop and set padding to correct size

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
