### PR TITLE
chore: add a specific eslint rule for '@deprecated' comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "docusaurus-plugin-react-docgen-typescript": "^1.3.0",
         "eslint-config-next": "14.2.3",
         "eslint-plugin-cypress": "^2.13.4",
+        "eslint-plugin-midas": "file:tools/eslint",
         "glob": "^11.0.1",
         "isbot": "^4.4.0",
         "jest": "29.7.0",
@@ -28920,6 +28921,10 @@
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
+    },
+    "node_modules/eslint-plugin-midas": {
+      "resolved": "tools/eslint",
+      "link": true
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -57803,6 +57808,24 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "tools/eslint": {
+      "name": "eslint-plugin-midas",
+      "version": "1.0.0",
+      "dev": true
+    },
+    "tools/eslint/eslint-plugin-midas": {
+      "extraneous": true
+    },
+    "tools/eslint/handle-deprecated-comments": {
+      "name": "eslint-plugin-handle-deprecated-comments",
+      "version": "1.0.0",
+      "extraneous": true
+    },
+    "tools/eslint/midas": {
+      "name": "eslint-plugin-midas",
+      "version": "1.0.0",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "docusaurus-plugin-react-docgen-typescript": "^1.3.0",
     "eslint-config-next": "14.2.3",
     "eslint-plugin-cypress": "^2.13.4",
+    "eslint-plugin-midas": "file:tools/eslint",
     "glob": "^11.0.1",
     "isbot": "^4.4.0",
     "jest": "29.7.0",

--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -6,7 +6,12 @@
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
-        "midas/handle-deprecated-comments": 1,
+        "midas/handle-deprecated-comments": [
+          1,
+          {
+            "version": "8.2.0"
+          }
+        ],
         "jsx-a11y/no-autofocus": "off"
       }
     },

--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -1,10 +1,12 @@
 {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
   "ignorePatterns": ["!**/*", "storybook-static"],
+  "plugins": ["midas"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "midas/handle-deprecated-comments": 1,
         "jsx-a11y/no-autofocus": "off"
       }
     },

--- a/packages/components/src/accordion/Accordion.tsx
+++ b/packages/components/src/accordion/Accordion.tsx
@@ -10,7 +10,7 @@ export const ACCORDION_TEST_ID = 'accordion'
 interface MidasAccordion extends DisclosureGroupProps {
   /** Display either the larger contained variant or a smaller uncontained variant */
   variant?: 'uncontained' | 'contained'
-  /** @deprecated Use 'allowsMultipleExpanded' instead */
+  /** @deprecated since v8.0.0 Use 'allowsMultipleExpanded' instead */
   type?: 'single' | 'multiple'
 }
 

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -24,7 +24,7 @@ export interface MidasButtonProps {
    */
   fullwidth?: boolean
   /** Choose between different button sizes */
-  /** @deprecated This variant will be replaced with a new scaling api accross all components. */
+  /** @deprecated since v4.0.0 This variant will be replaced with a new scaling api accross all components. */
   size?: 'small'
   /** Add an icon from lucide-react
    *

--- a/packages/components/src/card/Card.tsx
+++ b/packages/components/src/card/Card.tsx
@@ -11,7 +11,7 @@ export interface CardProps<C extends React.ElementType = typeof Link>
   image?: { source: string; description: string }
   /** Sets background to predetermined color
    *  @default false
-   *  @deprecated Not supported since v5.0.0
+   *  @deprecated since v5.0.0
    * */
   background?: boolean
   /** Header as h1 for the component rendered below image if there is one */

--- a/packages/components/src/label/Label.tsx
+++ b/packages/components/src/label/Label.tsx
@@ -8,7 +8,7 @@ import styles from './Label.module.css'
 
 export interface LabelProps extends AriaLabelProps {
   /**
-   *  @deprecated Please use Label without variant for label-02, and for label-01 use Text component with slot: 'description'
+   *  @deprecated since v8.2.0 Please use Label without variant for label-02, and for label-01 use Text component with slot: 'description'
    */
   variant?: 'label-01' | 'label-02'
 }

--- a/packages/components/src/modal/Dialog.tsx
+++ b/packages/components/src/modal/Dialog.tsx
@@ -31,7 +31,7 @@ interface DialogProps extends AriaDialogProps {
   title?: React.ReactNode
   children: React.ReactNode
 }
-/** @deprecated since 6.0.0 use Modal instead.
+/** @deprecated since v6.0.0 use Modal instead.
  * See docs {@link https://designsystem.migrationsverket.se/|Midas}
  */
 export const Dialog: React.FC<DialogProps> = ({
@@ -92,7 +92,7 @@ const MidasModal: React.FC<MidasModalProps> = ({
     </Overlay>
   )
 }
-/** @deprecated since version 6.0.0, use DialogTrigger instead.
+/** @deprecated since v6.0.0, use DialogTrigger instead.
  * See docs {@link https://designsystem.migrationsverket.se/|Midas}
  */
 export const ModalTrigger: React.FC<
@@ -164,7 +164,10 @@ export const Modal: React.FC<AriaModalOverlayProps & DialogProps> = ({
                 Stäng
               </Button>
             </div>
-            <div className={styles.modalBody} tabIndex={-1}>
+            <div
+              className={styles.modalBody}
+              tabIndex={-1}
+            >
               {title && <Heading level={2}>{title}</Heading>}
               {children}
             </div>

--- a/packages/components/src/spinner/Spinner.tsx
+++ b/packages/components/src/spinner/Spinner.tsx
@@ -13,7 +13,7 @@ export interface SpinnerProps {
   isOnColor?: boolean
   /** For use on dark background
    * @default false
-   * @deprecated please use `isOnColor` instead
+   * @deprecated since v8.0.0 please use `isOnColor` instead
    */
   dark?: boolean
 }

--- a/packages/components/src/table/Table.tsx
+++ b/packages/components/src/table/Table.tsx
@@ -31,7 +31,7 @@ import clsx from 'clsx'
 
 export interface TableProps extends AriaTableProps {
   /**
-   *  @deprecated This variant will be replaced with a new scaling api accross all components.
+   *  @deprecated since v8.0.0 This variant will be replaced with a new scaling api accross all components.
    */
   narrow?: boolean
   /**

--- a/packages/components/src/tabs/Tabs.tsx
+++ b/packages/components/src/tabs/Tabs.tsx
@@ -27,7 +27,7 @@ export interface TabsProps extends Omit<AriaTabsProps, 'orientation'> {
    */
   children: React.ReactNode
   /**
-   * @deprecated
+   * @deprecated since v8.0.0
    * Please use `defaultSelectedKey` instead
    */
   defaultSelected?: string

--- a/packages/components/src/utils/intl/useMessageFormatter.ts
+++ b/packages/components/src/utils/intl/useMessageFormatter.ts
@@ -39,7 +39,7 @@ function getCachedDictionary(strings: LocalizedStrings) {
  * Handles formatting ICU Message strings to create localized strings for the current locale.
  * Automatically updates when the locale changes, and handles caching of messages for performance.
  * @param strings - A mapping of languages to strings by key.
- * @deprecated - use useLocalizedStringFormatter instead.
+ * @deprecated since v7.0.0 - use useLocalizedStringFormatter instead.
  */
 export function useMessageFormatter(strings: LocalizedStrings): FormatMessage {
   const { locale } = useLocale()

--- a/tools/eslint/handle-deprecated-comments.js
+++ b/tools/eslint/handle-deprecated-comments.js
@@ -26,12 +26,12 @@ module.exports = {
 
       if (currentVersion && deprecatedVersion) {
         const currentMajor = getMajor(currentVersion)
-        const foundMajor = getMajor(deprecatedVersion)
+        const deprecatedMajor = getMajor(deprecatedVersion)
 
-        if (foundMajor < currentMajor) {
+        if (deprecatedMajor < currentMajor) {
           return context.report({
             loc: comment.loc,
-            message: `You can remove this deprecated code, it has been around since version ${foundMajor}, next major version will be ${currentMajor + 1}`,
+            message: `You can remove this deprecated code, it has been around since version ${deprecatedMajor}, next major version will be ${currentMajor + 1}`,
             node: null,
           })
         }

--- a/tools/eslint/handle-deprecated-comments.js
+++ b/tools/eslint/handle-deprecated-comments.js
@@ -1,0 +1,57 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'A hint that the source code exports deprecated features',
+    },
+  },
+  create(context) {
+    const version = context?.options?.[0]?.version
+
+    const getSemver = str => str.match(new RegExp(/\d\.\d\.\d/))
+
+    const getMajor = matchArray => parseInt(matchArray[0][0], 10)
+
+    const processComment = comment => {
+      if (
+        !comment ||
+        (comment && !comment.value.includes('@deprecated')) ||
+        typeof version === 'undefined'
+      ) {
+        return
+      }
+
+      const currentVersion = getSemver(version)
+      const deprecatedVersion = getSemver(comment.value)
+
+      if (currentVersion && deprecatedVersion) {
+        const currentMajor = getMajor(currentVersion)
+        const foundMajor = getMajor(deprecatedVersion)
+
+        if (foundMajor < currentMajor) {
+          return context.report({
+            loc: comment.loc,
+            message: `You can remove this deprecated code, it has been around since version ${foundMajor}, next major version will be ${currentMajor + 1}`,
+            node: null,
+          })
+        }
+        return
+      }
+
+      return context.report({
+        loc: comment.loc,
+        message:
+          'Please provide a semantic version to this comment "@deprecated since vn.n.n"',
+        node: null,
+      })
+    }
+
+    return {
+      Program() {
+        const sourceCode = context.getSourceCode()
+        const comments = sourceCode.getAllComments()
+        comments.forEach(processComment)
+      },
+    }
+  },
+}

--- a/tools/eslint/handle-deprecated-comments.test.js
+++ b/tools/eslint/handle-deprecated-comments.test.js
@@ -1,0 +1,37 @@
+const { RuleTester } = require('eslint')
+const rule = require('./handle-deprecated-comments')
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('handle-deprecated-comments', rule, {
+  valid: [
+    {
+      options: [{ version: '8.0.0' }],
+      code: '// @deprecated since v8.0.0',
+    },
+    {
+      code: '// @deprecated should pass if no version was configured',
+    },
+    {
+      code: '// any comment',
+    },
+  ],
+  invalid: [
+    {
+      options: [{ version: '8.0.0' }],
+      code: '// @deprecated since v5.0.0',
+      errors: [
+        'You can remove this deprecated code, it has been around since version 5, next major version will be 9',
+      ],
+    },
+    {
+      options: [{ version: '8.2.0' }],
+      code: '// @deprecated derp',
+      errors: [
+        'Please provide a semantic version to this comment "@deprecated since vn.n.n"',
+      ],
+    },
+  ],
+})
+
+console.log('All tests passed!')

--- a/tools/eslint/index.js
+++ b/tools/eslint/index.js
@@ -1,0 +1,33 @@
+module.exports = {
+  rules: {
+    'handle-deprecated-comments': {
+      meta: {
+        type: 'suggestion',
+        docs: {
+          description:
+            'A hint that the source code exports deprecated features',
+        },
+      },
+      create(context) {
+        const sourceCode = context.getSourceCode()
+
+        function processComment(comment) {
+          if (comment && comment.value.includes('@deprecated')) {
+            context.report({
+              loc: comment.loc,
+              message: 'Consider removing this code',
+              node: null,
+            })
+          }
+        }
+
+        return {
+          Program() {
+            const comments = sourceCode.getAllComments()
+            comments.forEach(processComment)
+          },
+        }
+      },
+    },
+  },
+}

--- a/tools/eslint/index.js
+++ b/tools/eslint/index.js
@@ -1,62 +1,7 @@
-module.exports = {
-  rules: {
-    'handle-deprecated-comments': {
-      meta: {
-        type: 'suggestion',
-        docs: {
-          description:
-            'A hint that the source code exports deprecated features',
-        },
-      },
-      create(context) {
-        const version = context?.options?.[0]?.version
+const handleDeprecatedComments = require('./handle-deprecated-comments')
 
-        const getSemver = str => str.match(new RegExp(/\d\.\d\.\d/))
-
-        const getMajor = matchArray => parseInt(matchArray[0][0], 10)
-
-        const processComment = comment => {
-          if (
-            !comment ||
-            (comment && !comment.value.includes('@deprecated')) ||
-            typeof version === 'undefined'
-          ) {
-            return
-          }
-
-          const currentVersion = getSemver(version)
-          const deprecatedVersion = getSemver(comment.value)
-
-          if (currentVersion && deprecatedVersion) {
-            const currentMajor = getMajor(currentVersion)
-            const foundMajor = getMajor(deprecatedVersion)
-
-            if (foundMajor < currentMajor) {
-              return context.report({
-                loc: comment.loc,
-                message: `You can remove this deprecated code, it has been around since version ${foundMajor}, next major version will be ${currentMajor + 1}`,
-                node: null,
-              })
-            }
-            return
-          }
-
-          return context.report({
-            loc: comment.loc,
-            message:
-              'Please provide a semantic version to this comment "@deprecated since vn.n.n"',
-            node: null,
-          })
-        }
-
-        return {
-          Program() {
-            const sourceCode = context.getSourceCode()
-            const comments = sourceCode.getAllComments()
-            comments.forEach(processComment)
-          },
-        }
-      },
-    },
-  },
+const plugin = {
+  rules: { 'handle-deprecated-comments': handleDeprecatedComments },
 }
+
+module.exports = plugin

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-midas",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -1,5 +1,8 @@
 {
   "name": "eslint-plugin-midas",
   "version": "1.0.0",
-  "main": "index.js"
+  "main": "index.js",
+  "scripts": {
+    "test": "node handle-deprecated-comments.test.js"
+  }
 }


### PR DESCRIPTION
## Description

We should batch remove our deprecated features to minimize major version bumps

## Changes

Add two different warnings
![Skärmbild 2025-04-30 110614](https://github.com/user-attachments/assets/dda336a9-373f-408d-9b03-1e06de592b90)

![Skärmbild 2025-04-30 110628](https://github.com/user-attachments/assets/b6b62cf9-c734-4ee4-9576-71329c645fef)


## Additional Information

The only backside is that we have to manually edit the eslint-config with our version number to get this to work. If we used the eslint flat config we could read package.json.config

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
