### PR TITLE
chore: 🤡 mock dates globally in storybook

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -9,11 +9,11 @@ import {
 import React from 'react'
 import MockDate from 'mockdate'
 import { getLocalTimeZone } from '@internationalized/date'
-import { now } from '../src/utils/storybook'
+import { mockedNow } from '../src/utils/storybook'
 
 const preview: Preview = {
   async beforeEach() {
-    MockDate.set(now.toDate(getLocalTimeZone()))
+    MockDate.set(mockedNow.toDate(getLocalTimeZone()))
     return () => {
       MockDate.reset()
     }

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -7,8 +7,17 @@ import {
   getPreferredColorScheme,
 } from './custom-theme'
 import React from 'react'
+import MockDate from 'mockdate'
+import { getLocalTimeZone } from '@internationalized/date'
+import { now } from '../src/utils/storybook'
 
 const preview: Preview = {
+  async beforeEach() {
+    MockDate.set(now.toDate(getLocalTimeZone()))
+    return () => {
+      MockDate.reset()
+    }
+  },
   parameters: {
     backgrounds: {
       default: getPreferredColorScheme() === 'dark' ? 'Dark' : 'Light',

--- a/packages/components/src/calendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/calendar/RangeCalendar.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { RangeCalendar } from './RangeCalendar'
 import { expect, userEvent } from '@storybook/test'
-import { parseDate, getLocalTimeZone } from '@internationalized/date'
-import MockDate from 'mockdate'
-
-const now = parseDate('2025-05-29')
+import { now } from '../utils/storybook'
 
 type Story = StoryObj<typeof RangeCalendar>
 
@@ -12,12 +9,6 @@ export default {
   component: RangeCalendar,
   title: 'Components/Calendar/RangeCalendar',
   tags: ['autodocs'],
-  async beforeEach() {
-    MockDate.set(now.toDate(getLocalTimeZone()))
-    return () => {
-      MockDate.reset()
-    }
-  },
 } as Meta<typeof RangeCalendar>
 
 export const Primary: Story = {}

--- a/packages/components/src/calendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/calendar/RangeCalendar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { RangeCalendar } from './RangeCalendar'
 import { expect, userEvent } from '@storybook/test'
-import { now } from '../utils/storybook'
+import { mockedNow } from '../utils/storybook'
 
 type Story = StoryObj<typeof RangeCalendar>
 
@@ -25,9 +25,9 @@ export const KeyboardTest: Story = {
     await step(
       'it should be possible to select today and two days ahead with the keyboard',
       async () => {
-        const todaysDate = now.day.toString()
-        const tomorrow = now.add({ days: 1 }).day.toString()
-        const dayAfterTomorrow = now.add({ days: 2 }).day.toString()
+        const todaysDate = mockedNow.day.toString()
+        const tomorrow = mockedNow.add({ days: 1 }).day.toString()
+        const dayAfterTomorrow = mockedNow.add({ days: 2 }).day.toString()
 
         await userEvent.tab()
         await userEvent.tab()

--- a/packages/components/src/utils/storybook.ts
+++ b/packages/components/src/utils/storybook.ts
@@ -1,3 +1,5 @@
+import { parseDate } from '@internationalized/date'
+
 export const options = [
   'Apple',
   'Banana',
@@ -29,3 +31,5 @@ export const options = [
   'Starfruit',
   'Passionfruit',
 ].map(fruit => ({ name: fruit, id: fruit.toLocaleLowerCase() }))
+
+export const now = parseDate('2025-05-29')

--- a/packages/components/src/utils/storybook.ts
+++ b/packages/components/src/utils/storybook.ts
@@ -32,4 +32,4 @@ export const options = [
   'Passionfruit',
 ].map(fruit => ({ name: fruit, id: fruit.toLocaleLowerCase() }))
 
-export const now = parseDate('2025-05-29')
+export const mockedNow = parseDate('2025-05-29')


### PR DESCRIPTION
## Description

We get visual diffs in chromatic because the date changes in our components

## Changes

- Mock dates in every story

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
