### PR TITLE
docs: improvements to preview 💅 🔍 ✨ 

### DIFF
--- a/apps/docs/docs/components/accordion.mdx
+++ b/apps/docs/docs/components/accordion.mdx
@@ -5,13 +5,12 @@ description: Dragspelskomponenten låter användare visa och dölja delar av rel
 ---
 
 import { PropTable } from '@site/src/components/propsTable'
-import { Accordion, AccordionItem } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { AccordionExample, AccordionExampleControlled } from '@site/src/components/examples/accordion/AccordionExamples'
+import { Example, ExampleControlled, StatusExample } from '@site/src/components/examples/accordion/AccordionExamples'
 
 <ComponentHeader
-  name={'Accordion'}
-  friendlyName={'Dragspel'}
+  name='Accordion'
+  friendlyName='Dragspel'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/DisclosureGroup.html'
 />
 
@@ -20,48 +19,27 @@ Utfällbar komponent som används för att minska informationsmängden som direk
 ```tsx
 <Accordion>
   <AccordionItem
-    id={'mandarin'}
-    title={'Mandarin'}
+    id='mandarin'
+    title='Mandarin'
   >
     Liten orange citrusfrukt
   </AccordionItem>
   <AccordionItem
-    id={'sharon'}
-    title={'Sharon'}
+    id='sharon'
+    title='Sharon'
   >
     Persikoliknande frukt med fast kött
   </AccordionItem>
   <AccordionItem
-    id={'watermelon'}
-    title={'Vattenmelon'}
+    id='watermelon'
+    title='Vattenmelon'
   >
     Stor frukt med rött, saftigt kött
   </AccordionItem>
 </Accordion>
 ```
 
-<div className={'card'}>
-  <Accordion>
-    <AccordionItem
-      id={'mandarin'}
-      title={'Mandarin'}
-    >
-      Liten orange citrusfrukt
-    </AccordionItem>
-    <AccordionItem
-      id={'sharon'}
-      title={'Sharon'}
-    >
-      Persikoliknande frukt med fast kött
-    </AccordionItem>
-    <AccordionItem
-      id={'watermelon'}
-      title={'Vattenmelon'}
-    >
-      Stor frukt med rött, saftigt kött
-    </AccordionItem>
-  </Accordion>
-</div>
+<Example />
 
 ## Installation
 
@@ -88,37 +66,18 @@ Accordion har flertalet varianter och egenskaper.
 En tydligare variant av layouten när det finns en tydlig gräns mellan varje sektion.
 
 ```tsx
-<Accordion variant={'contained'}>
+<Accordion variant='contained'>
   {/* more items */}
   <AccordionItem
-    id={'mandarin'}
-    title={'Mandarin'}
+    id='mandarin'
+    title='Mandarin'
   >
     Liten orange citrusfrukt
   </AccordionItem>
 </Accordion>
 ```
 
-<Accordion variant={'contained'}>
-  <AccordionItem
-    id={'mandarin'}
-    title={'Mandarin'}
-  >
-    Liten orange citrusfrukt
-  </AccordionItem>
-  <AccordionItem
-    id={'sharon'}
-    title={'Sharon'}
-  >
-    Persikoliknande frukt med fast kött
-  </AccordionItem>
-  <AccordionItem
-    id={'watermelon'}
-    title={'Vattenmelon'}
-  >
-    Stor frukt med rött, saftigt kött
-  </AccordionItem>
-</Accordion>
+<Example variant='contained' />
 
 ### Status
 
@@ -144,29 +103,7 @@ AccordionItems kan ha en status för att förtydliga för användaren att hen an
 </Accordion>
 ```
 
-<Accordion variant='contained'>
-  <AccordionItem
-    id='mandarin'
-    title='Mandarin'
-    type='success'
-  >
-    Liten orange citrusfrukt
-  </AccordionItem>
-  <AccordionItem
-    id='sharon'
-    title='Sharon'
-    type='warning'
-  >
-    Persikoliknande frukt med fast kött
-  </AccordionItem>
-  <AccordionItem
-    id='watermelon'
-    title='Vattenmelon'
-    type='default'
-  >
-    Stor frukt med rött, saftigt kött
-  </AccordionItem>
-</Accordion>
+<StatusExample />
 
 ### Multiple
 
@@ -179,7 +116,7 @@ Detta kan ändras genom att sätta prop `allowsMultipleExpanded`.
 </Accordion>
 ```
 
-<AccordionExample allowsMultipleExpanded />
+<Example allowsMultipleExpanded />
 
 ### Uncontrolled expanded
 
@@ -189,27 +126,27 @@ på `Accordion`. Värdena i defaultExpandedKeys måste matcha `id` på de Accord
 ```tsx
 <Accordion defaultExpandedKeys={['sharon']}>
   <AccordionItem
-    id={'mandarin'}
-    title={'Mandarin'}
+    id='mandarin'
+    title='Mandarin'
   >
     Liten orange citrusfrukt
   </AccordionItem>
   <AccordionItem
-    id={'sharon'}
-    title={'Sharon'}
+    id='sharon'
+    title='Sharon'
   >
     Persikoliknande frukt med fast kött
   </AccordionItem>
   <AccordionItem
-    id={'watermelon'}
-    title={'Vattenmelon'}
+    id='watermelon'
+    title='Vattenmelon'
   >
     Stor frukt med rött, saftigt kött
   </AccordionItem>
 </Accordion>
 ```
 
-<AccordionExample defaultExpandedKeys={['sharon']} />
+<Example defaultExpandedKeys={['sharon']} />
 
 ### Controlled expanded
 
@@ -218,52 +155,51 @@ Värdena i `expandedKeys` måste matcha `id` på de AccordionItem-komponenter du
 
 ```tsx
 //highlight-next-line
-const [expandedKeys, setExpandedKeys] =
-React.useState<Set<Key>>(new Set(['mandarin']))
+const [expandedKeys, setExpandedKeys] = React.useState<Set<Key>>(new Set(['mandarin']))
 
 <Accordion
 //highlight-start
   expandedKeys={expandedKeys}
   onExpandedChange={setExpandedKeys}
 //highlight-end
-  type={'multiple'}
+  allowsMultipleExpanded
 >
   <AccordionItem
-    {...props}
-    id={'mandarin'}
-    title={'Mandarin'}
+    id="mandarin"
+    title="Mandarin"
   >
     Liten orange citrusfrukt
   </AccordionItem>
   <AccordionItem
-    id={'sharon'}
-    title={'Sharon'}
+    id="sharon"
+    title="Sharon"
   >
     Persikoliknande frukt med fast kött
   </AccordionItem>
   <AccordionItem
-    id={'watermelon'}
-    title={'Vattenmelon'}
+    id="watermelon"
+    title="Vattenmelon"
   >
     Stor frukt med rött, saftigt kött
   </AccordionItem>
 </Accordion>
+
 <pre>
-Följande AccordionItems är öppna: {Array.from(expandedKeys).join(', ')}
+  Följande AccordionItems är öppna: {Array.from(expandedKeys).join(', ')}
 </pre>
 ```
 
-<AccordionExampleControlled type={'multiple'} />
+<ExampleControlled allowsMultipleExpanded />
 
 ## API
 
 ### Accordion
 
-<PropTable name={'Accordion'} />
+<PropTable name='Accordion' />
 
 ### AccordionItem
 
 <PropTable
-  name={'AccordionItem'}
+  name='AccordionItem'
   defaultOpen={false}
 />

--- a/apps/docs/docs/components/badge.mdx
+++ b/apps/docs/docs/components/badge.mdx
@@ -8,7 +8,7 @@ import { Button, BadgeContainer, Badge } from '@midas-ds/components'
 import { Bell } from 'lucide-react'
 
 <ComponentHeader
-  name={'Badge'}
+  name='Badge'
   friendlyName='Notisindikator, Statusindikator'
   overrideHeadlessLink=''
 />

--- a/apps/docs/docs/components/breadcrumbs.mdx
+++ b/apps/docs/docs/components/breadcrumbs.mdx
@@ -8,8 +8,8 @@ import { Breadcrumbs } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'Breadcrumbs'}
-  friendlyName={'Brödsmulor'}
+  name='Breadcrumbs'
+  friendlyName='Brödsmulor'
   overrideHeadlessLink=''
 />
 

--- a/apps/docs/docs/components/button.mdx
+++ b/apps/docs/docs/components/button.mdx
@@ -10,8 +10,8 @@ import { Plus } from 'lucide-react'
 import { ButtonContext } from 'react-aria-components'
 
 <ComponentHeader
-  name={'Button'}
-  friendlyName={'Knapp'}
+  name='Button'
+  friendlyName='Knapp'
 />
 
 Komponent som används för att låta användaren utföra en handling t.ex. spara ifylld information eller öppna ett formulär.
@@ -54,7 +54,10 @@ En primär knapp används för den primära eller positiva handlingen i ett flö
 <Button>Slutför</Button>
 ```
 
-<div className='card'>
+<div
+  className='card'
+  style={{ display: 'block' }}
+>
   <Button>Slutför</Button>
 </div>
 
@@ -111,7 +114,10 @@ Du kan välja vilken sida av texten ikonen ska vara på med `iconPlacement`.
 </Button>
 ```
 
-<div className='card'>
+<div
+  className='card'
+  style={{ display: 'block' }}
+>
   <Button
     icon={Plus}
     variant='tertiary'

--- a/apps/docs/docs/components/calendar.mdx
+++ b/apps/docs/docs/components/calendar.mdx
@@ -7,7 +7,6 @@ import { PropTable } from '@site/src/components/propsTable'
 import { Calendar } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { RangeCalendarExample } from '@site/src/components/examples/calendar/CalendarExamples'
-import { semantic } from '../../../../packages/components/src/theme'
 
 <ComponentHeader
   name='Calendar'
@@ -24,8 +23,8 @@ behövs, inte ligger i direkt anslutning till kalendern, eller om kalendern inte
 ```
 
 <div
-  className={'card'}
-  style={{ background: semantic.layer02 }}
+  className='card'
+  style={{ display: 'block' }}
 >
   <Calendar />
 </div>
@@ -79,8 +78,8 @@ export const RangeCalendarExample = () => {
 ```
 
 <div
-  className={'card'}
-  style={{ background: semantic.layer02 }}
+  className='card'
+  style={{ display: 'block' }}
 >
   <RangeCalendarExample />
 </div>

--- a/apps/docs/docs/components/checkbox.mdx
+++ b/apps/docs/docs/components/checkbox.mdx
@@ -9,8 +9,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Checkbox, CheckboxGroup } from '@midas-ds/components'
 
 <ComponentHeader
-  name={'Checkbox'}
-  friendlyName={'Kryssruta'}
+  name='Checkbox'
+  friendlyName='Kryssruta'
 />
 
 Inmatningsfält för att låta användaren välja inget, ett eller flera av ett antal förvalda alternativ.
@@ -112,8 +112,8 @@ Om detta används på en sida med paginerat innehåll så skall endast de kryssr
 
 ```tsx
 <CheckboxGroup
-  label={'Godkänner du våra villkor'}
-  description={'Läs texten först'}
+  label='Godkänner du våra villkor'
+  description='Läs texten först'
   // highlight-start
   showSelectAll
   // highlight-end
@@ -125,8 +125,8 @@ Om detta används på en sida med paginerat innehåll så skall endast de kryssr
 
 <div className='card'>
   <CheckboxGroup
-    label={'Godkänner du våra villkor'}
-    description={'Läs texten först'}
+    label="Godkänner du våra villkor"
+    description="Läs texten först"
     showSelectAll
   >
     <Checkbox value='1'>Jag har läst texten</Checkbox>
@@ -204,8 +204,11 @@ return (
 
 ### Checkbox
 
-<PropTable name={'Checkbox'} />
+<PropTable name='Checkbox' />
 
 ### CheckboxGroup
 
-<PropTable name={'Checkbox'} />
+<PropTable
+  name='CheckboxGroup'
+  defaultOpen={false}
+/>

--- a/apps/docs/docs/components/combobox.mdx
+++ b/apps/docs/docs/components/combobox.mdx
@@ -12,7 +12,7 @@ import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'Combobox'}
+  name='Combobox'
   friendlyName='Flerval med sök, väljare med sök, dropdown med sök'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/ComboBox.html'
 />

--- a/apps/docs/docs/components/date-picker.mdx
+++ b/apps/docs/docs/components/date-picker.mdx
@@ -10,13 +10,18 @@ import { DatePicker, DateRangePicker } from '@midas-ds/components'
 
 export const Example = props => {
   return (
-      <DatePicker label="Välj ett datum" aria-label="Välj datum" />
+    <div className='card'>
+      <DatePicker
+        label='Välj ett datum'
+        aria-label='Välj datum'
+      />
+    </div>
   )
 }
 
 <ComponentHeader
-  name={'DatePicker'}
-  friendlyName={'Datumväljare'}
+  name='DatePicker'
+  friendlyName='Datumväljare'
 />
 
 Inmatningsfält för att välja ett eller flera datum. Består av två komponenter `DatePicker`
@@ -35,9 +40,7 @@ import { DatePicker } from '@midas-ds/components'
 // import { DateRangePicker } from '@midas-ds/components'
 ```
 
-<div className={'card'}>
-  <Example />
-</div>
+<Example />
 
 ## Användning
 
@@ -48,16 +51,15 @@ som i sin tur består av andra komponenter som [Calendar](https://react-spectrum
 [DateField](https://react-spectrum.adobe.com/react-aria/DateField.html). För fullständig
 dokumentation och ytterligare varianter hänvisas till den dokumentationen.
 
-
 ### DatePicker
+
 ```tsx
 import { parseDate, CalendarDate } from '@internationalized/date'
 import { DatePicker } from '@midas-ds/components'
 
 export const DatePickerExample = () => {
-  const [value, setValue] = React.useState<CalendarDate | null>(
-    parseDate('2026-05-29'),
-  )
+  const [value, setValue] = React.useState<CalendarDate | null>(parseDate('2026-05-29'))
+
   return (
     <>
       <DatePicker
@@ -74,17 +76,22 @@ export const DatePickerExample = () => {
   )
 }
 ```
-<div className={'card'} style={{display: 'flex', gap: '1rem'}}>
-  <DatePickerExample/>
+
+<div
+  className='card'
+  style={{ display: 'flex', gap: '1rem' }}
+>
+  <DatePickerExample />
 </div>
 
-
 ### DateRangePicker
+
 ```tsx
-<DateRangePicker label="Ange din semesterperiod" />
+<DateRangePicker label='Ange din semesterperiod' />
 ```
-<div className={'card'}>
-  <DateRangePicker label="Ange din semesterperiod" />
+
+<div className='card'>
+  <DateRangePicker label='Ange din semesterperiod' />
 </div>
 
 ### Begränsa val
@@ -93,27 +100,26 @@ Använd callback `isDateUnavailable` för att markera datum som inte valbara. An
 för att begränsa datum före dagens datum.
 
 ```tsx
-import {
-  today,
-  getLocalTimeZone,
-} from '@internationalized/date'
+import { today, getLocalTimeZone } from '@internationalized/date'
 
 export const UnavailableDateExample = () => {
   const now = today(getLocalTimeZone())
   const isDateUnavailable = (date: DateValue) => {
     return date.compare(now.add({ weeks: 1 })) < 0
   }
+
   return (
     <DatePicker
       label='Välj ett datum'
-      description={'Fast inte förrän om en vecka'}
+      description='Fast inte förrän om en vecka'
       isDateUnavailable={isDateUnavailable}
       minValue={now}
     />
   )
 }
 ```
-<div className={'card'}>
+
+<div className='card'>
   <UnavailableDateExample />
 </div>
 

--- a/apps/docs/docs/components/datefield.mdx
+++ b/apps/docs/docs/components/datefield.mdx
@@ -9,26 +9,29 @@ import { DateField } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { DateFieldControlled } from '@site/src/components/examples/date-field/DateFieldExamples'
 import { CalendarDate } from '@internationalized/date'
-export const christmas = new CalendarDate(2025, 12, 25)
 
 export const Example = props => {
   return (
-    <DateField
-      label='Etikett'
-      description='Beskrivning'
-      {...props}
-    />
+    <div className='card'>
+      <DateField
+        label='Etikett'
+        description='Beskrivning'
+        {...props}
+      />
+    </div>
   )
 }
 
 export const I18nExample = props => {
   return (
-    <I18nProvider locale={'fr-Fr'}>
-      <DateField
-        label='Välj ett datum'
-        description='vilket datum som helst'
-      />
-    </I18nProvider>
+    <div className='card'>
+      <I18nProvider locale='fr-Fr'>
+        <DateField
+          label='Välj ett datum'
+          description='vilket datum som helst'
+        />
+      </I18nProvider>
+    </div>
   )
 }
 
@@ -44,9 +47,7 @@ In- och utdata till DateField liksom andra tidsrelaterade komponenter bygger på
 [@internationalized/date](https://react-spectrum.adobe.com/internationalized/date/index.html) så ytterligare referens
 till hur värden ska formateras hittas där.
 
-<div className={'card'}>
-  <Example />
-</div>
+<Example />
 
 ## Installation
 
@@ -55,17 +56,17 @@ npm install @midas-ds/components
 ```
 
 ```tsx
-import { DateField } from '@midas-ds/components';
+import { DateField } from '@midas-ds/components'
+```
 
+```tsx
 <DateField
   label='Etikett'
   description='Beskrivning'
 />
 ```
 
-<div className={'card'}>
-  <Example />
-</div>
+<Example />
 
 ## Användning
 
@@ -78,7 +79,7 @@ Tänk på att formatet för inmatning (exempelvis YYYY/MM/DD) beror av användar
 det i etikett eller hjälptext.
 
 ```tsx
-<I18nProvider locale={'fr-Fr'}>
+<I18nProvider locale='fr-Fr'>
   <DateField
     label='Välj ett datum'
     description='vilket datum som helst'
@@ -86,9 +87,7 @@ det i etikett eller hjälptext.
 </I18nProvider>
 ```
 
-<div className={'card'}>
-  <I18nExample />
-</div>
+<I18nExample />
 
 DateField stödjer också olika kalendrar, se
 [React Aria](https://react-spectrum.adobe.com/react-aria/DateField.html#international-calendars)
@@ -96,22 +95,20 @@ och [mdm web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 för referens om hur du går till väga för att konvertera datum mellan olika kalendrar.
 
 ```tsx
-<I18nProvider locale={'fr-Fr-u-ca-buddhist'}>
+<I18nProvider locale='fr-Fr-u-ca-buddhist'>
   <Example
-    label={'Välj ett datum'}
-    description={'Calendrier bouddhiste français'}
+    label='Välj ett datum'
+    description='Calendrier bouddhiste français'
   />
 </I18nProvider>
 ```
 
-<div className={'card'}>
-  <I18nProvider locale={'fr-Fr-u-ca-buddhist'}>
-    <Example
-      label={'Välj ett datum'}
-      description={'Calendrier bouddhiste français'}
-    />
-  </I18nProvider>
-</div>
+<I18nProvider locale='fr-Fr-u-ca-buddhist'>
+  <Example
+    label='Välj ett datum'
+    description='Calendrier bouddhiste français'
+  />
+</I18nProvider>
 
 ### Förvalt värde (uncontrolled)
 
@@ -120,17 +117,17 @@ ett datum utan tidskomponent.
 
 ```tsx
 import { CalendarDate } from '@internationalized/date'
+```
 
+```tsx
 <DateField defaultValue={new CalendarDate(2025, 12, 25)} />
 ```
 
-<div className={'card'}>
-  <Example
-    defaultValue={christmas}
-    label={'Happy Kwanza'}
-    description={''}
-  />
-</div>
+<Example
+  defaultValue={new CalendarDate(2025, 12, 25)}
+  label='Happy Kwanza'
+  description=''
+/>
 
 ### Controlled value
 
@@ -157,9 +154,7 @@ export const DateFieldControlled = () => {
 }
 ```
 
-<div className={'card'}>
-  <DateFieldControlled />
-</div>
+<DateFieldControlled />
 
 ## API
 

--- a/apps/docs/docs/components/dropdown.mdx
+++ b/apps/docs/docs/components/dropdown.mdx
@@ -24,14 +24,19 @@ export const Example = props => {
 }
 
 <ComponentHeader
-  name={'Dropdown'}
+  name='Dropdown'
   friendlyName='Meny, menylist, kontextmeny'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/Menu.html'
 />
 
 En dropdown kan användas för att samla ihop funktioner som sällan används eller som kompletterar nuvarande funktion.
 
-<Example />
+<div
+  className='card'
+  style={{ display: 'block' }}
+>
+  <Example />
+</div>
 
 ## Installation
 
@@ -40,8 +45,10 @@ npm install @midas-ds/components
 ```
 
 ```tsx
-import { Dropdown, DropdownItem, Button } from '@midas-ds/components';
+import { Dropdown, DropdownItem, Button } from '@midas-ds/components'
+```
 
+```tsx
 <Dropdown title='Meny'>
   <DropdownItem>
     <Button variant='tertiary'>Skriv ut</Button>
@@ -56,7 +63,7 @@ import { Dropdown, DropdownItem, Button } from '@midas-ds/components';
 ```
 
 <div
-  className={'card'}
+  className='card'
   style={{ display: 'block' }}
 >
   <Example />
@@ -75,11 +82,11 @@ Dropdown bygger på [React Aria Menu](https://react-spectrum.adobe.com/react-ari
 
 ### Dropdown
 
-<PropTable name={'Dropdown'} />
+<PropTable name='Dropdown' />
 
 ### DropdownItem
 
 <PropTable
-  name={'DropdownItem'}
+  name='DropdownItem'
   defaultOpen={false}
 />

--- a/apps/docs/docs/components/fileupload.mdx
+++ b/apps/docs/docs/components/fileupload.mdx
@@ -9,8 +9,8 @@ import { ControlledExample } from '@site/src/components/examples/file-upload/Fil
 import { PropTable } from '@site/src/components/propsTable'
 
 <ComponentHeader
-  name={'FileUpload'}
-  friendlyName={'Filuppladdning'}
+  name='FileUpload'
+  friendlyName='Filuppladdning, filväljare'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/FileTrigger.html'
 />
 

--- a/apps/docs/docs/components/flex.mdx
+++ b/apps/docs/docs/components/flex.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Example } from '@site/src/components/examples/flex/FlexExamples.tsx'
 
 <ComponentHeader
-  name={'Flex'}
-  friendlyName={'Rutnät'}
+  name='Flex'
+  friendlyName='Rutnät'
   overrideHeadlessLink=''
 />
 
@@ -25,7 +25,7 @@ Komponenterna Grid och Flex har samma innebörd, använd den vars teknik du är 
   <FlexItem>
     <span>not set</span>
   </FlexItem>
-  <FlexItem col={'auto'}>
+  <FlexItem col='auto'>
     <span>col=auto</span>
   </FlexItem>
   <FlexItem col={6}>

--- a/apps/docs/docs/components/grid.mdx
+++ b/apps/docs/docs/components/grid.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Example } from '@site/src/components/examples/grid/GridExamples'
 
 <ComponentHeader
-  name={'Grid'}
-  friendlyName={'Rutnät'}
+  name='Grid'
+  friendlyName='Rutnät'
   overrideHeadlessLink=''
 />
 
@@ -27,7 +27,9 @@ npm install @midas-ds/components
 
 ```tsx
 import { Grid, GridItem } from '@midas-ds/components'
+```
 
+```tsx
 <Grid>
   <GridItem col={12}>
     <span>col=12</span>

--- a/apps/docs/docs/components/heading.mdx
+++ b/apps/docs/docs/components/heading.mdx
@@ -7,8 +7,8 @@ import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'typography-heading'}
-  friendlyName={'Rubrik, h1, h2, h3, h4, h5, h6'}
+  name='typography-heading'
+  friendlyName='Rubrik, h1, h2, h3, h4, h5, h6'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-spectrum/Heading.html'
 />
 

--- a/apps/docs/docs/components/info-banner.mdx
+++ b/apps/docs/docs/components/info-banner.mdx
@@ -8,38 +8,40 @@ import { InfoBanner, Tabs as MidasTabs } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'info-banner'}
-  friendlyName={'Informationsmeddelande'}
+  name='info-banner'
+  friendlyName='Informationsmeddelande'
   overrideHeadlessLink=''
 />
 
 Komponent för att visa viktiga och aktuella meddelanden om händelser eller förändringar, som till exempel systemnotiser.
 
-<MidasTabs
-  label={'Välj typ'}
-  tabs={['Success', 'Info', 'Important', 'Warning']}
->
-  <InfoBanner
-    type={'success'}
-    title={'Formuläret har skickats'}
-    message={'Allt gick bra. Du kan nu stänga fönstret.'}
-  />
-  <InfoBanner
-    type={'info'}
-    title={'Kom ihåg att fylla i din semesterplan'}
-    message={'Vi behöver din semesterplan för att kunna gå vidare.'}
-  />
-  <InfoBanner
-    type={'important'}
-    title={'Du behöver komplettera!'}
-    message={'Vi saknar din semesterplan.'}
-  />
-  <InfoBanner
-    type={'warning'}
-    title={'Formuläret kunde inte skickas!'}
-    message={'Vi kunde inte skicka formuläret. Semesterplanen måste vara i pdf-format!'}
-  />
-</MidasTabs>
+<div className='card'>
+  <MidasTabs
+    label='Välj typ'
+    tabs={['Success', 'Info', 'Important', 'Warning']}
+  >
+    <InfoBanner
+      type='success'
+      title='Formuläret har skickats'
+      message='Allt gick bra. Du kan nu stänga fönstret.'
+    />
+    <InfoBanner
+      type='info'
+      title='Kom ihåg att fylla i din semesterplan'
+      message='Vi behöver din semesterplan för att kunna gå vidare.'
+    />
+    <InfoBanner
+      type='important'
+      title='Du behöver komplettera!'
+      message='Vi saknar din semesterplan.'
+    />
+    <InfoBanner
+      type='warning'
+      title='Formuläret kunde inte skickas!'
+      message='Vi kunde inte skicka formuläret. Semesterplanen måste vara i pdf-format!'
+    />
+  </MidasTabs>
+</div>
 
 ## Installation
 
@@ -58,71 +60,80 @@ import { InfoBanner } from '@midas-ds/components'
 ```tsx
 <InfoBanner
   // highlight-start
-  type={'success'}
+  type='success'
   // highlight-end
-  title={'Det gick bra!'}
-  message={'Detta är ett meddelande om att allt gick bra.'}
+  title='Det gick bra!'
+  message='Detta är ett meddelande om att allt gick bra.'
 />
 ```
 
-<InfoBanner
-  type={'success'}
-  title={'Det gick bra!'}
-  message={'Detta är ett meddelande om att allt gick bra.'}
-/>
+<div className='card'>
+  <InfoBanner
+    type='success'
+    title='Det gick bra!'
+    message='Detta är ett meddelande om att allt gick bra.'
+  />
+</div>
+
 ### Info
 
 ```tsx
 <InfoBanner
   // highlight-start
-  type={'info'}
+  type='info'
   // highlight-end
-  title={'Information'}
-  message={'Detta är ett meddelande med information.'}
+  title='Information'
+  message='Detta är ett meddelande med information.'
 />
 ```
 
-<InfoBanner
-  type={'info'}
-  title={'Information'}
-  message={'Detta är ett meddelande med information.'}
-/>
+<div className='card'>
+  <InfoBanner
+    type='info'
+    title='Information'
+    message='Detta är ett meddelande med information.'
+  />
+</div>
 
 ### Important
 
 ```tsx
 <InfoBanner
   // highlight-start
-  type={'important'}
+  type='important'
   // highlight-end
-  title={'Viktig information'}
-  message={'Detta är ett meddelande med viktig information.'}
+  title='Viktig information'
+  message='Detta är ett meddelande med viktig information.'
 />
 ```
 
-<InfoBanner
-  type={'important'}
-  title={'Viktig information'}
-  message={'Detta är ett meddelande med viktig information.'}
-/>
+<div className='card'>
+  <InfoBanner
+    type='important'
+    title='Viktig information'
+    message='Detta är ett meddelande med viktig information.'
+  />
+</div>
 
 ### Warning
 
 ```tsx
 <InfoBanner
   // highlight-start
-  type={'warning'}
+  type='warning'
   // highlight-end
-  title={'Varning'}
-  message={'Detta är en varning som används när något gått fel.'}
+  title='Varning'
+  message='Detta är en varning som används när något gått fel.'
 />
 ```
 
-<InfoBanner
-  type={'warning'}
-  title={'Varning'}
-  message={'Detta är en varning som används när något gått fel.'}
-/>
+<div className='card'>
+  <InfoBanner
+    type='warning'
+    title='Varning'
+    message='Detta är en varning som används när något gått fel.'
+  />
+</div>
 
 ## Dismissable
 
@@ -133,19 +144,21 @@ Det går att göra det möjligt för användaren att stänga informationsmeddela
   // highlight-start
   dismissable
   // highlight-end
-  type={'success'}
-  title={'Det gick bra!'}
-  message={'Detta är ett meddelande om att allt gick bra.'}
+  type='success'
+  title='Det gick bra!'
+  message='Detta är ett meddelande om att allt gick bra.'
 />
 ```
 
-<InfoBanner
-  dismissable
-  type={'success'}
-  title={'Det gick bra!'}
-  message={'Detta är ett meddelande om att allt gick bra.'}
-/>
+<div className='card'>
+  <InfoBanner
+    dismissable
+    type='success'
+    title='Det gick bra!'
+    message='Detta är ett meddelande om att allt gick bra.'
+  />
+</div>
 
 ## API
 
-<PropTable name={'InfoBanner'} />
+<PropTable name='InfoBanner' />

--- a/apps/docs/docs/components/layout.mdx
+++ b/apps/docs/docs/components/layout.mdx
@@ -5,7 +5,7 @@ description: En skalkomponent för att få en simpel sidomeny och sidhuvud.
 
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { BasicExample } from '@site/src/components/examples/layout/LayoutExamples'
+import { BasicExample, ExternalExample } from '@site/src/components/examples/layout/LayoutExamples'
 
 <ComponentHeader
   name='Layout'
@@ -101,24 +101,31 @@ Använd `variant="external"` för en förenklad version av Layout med Navbar i b
     {
       items: [
         {
-          title: 'Översikt',
+          title: 'Hem',
           href: '#',
           icon: House,
+          active: true,
         },
-      ],
-    },
-    {
-      title: 'Ansökan',
-      items: [
         {
-          title: 'Skapa ansökan',
+          title: 'Ansökan',
+          href: '#',
+          icon: Search,
+        },
+        {
+          title: 'Boka',
+          href: '#',
+          icon: Calendar,
+          hasBadge: true,
+        },
+        {
+          title: 'Profil',
+          href: '#',
+          icon: User,
+        },
+        {
+          title: 'Kontakt',
           href: '#',
           icon: Plus,
-        },
-        {
-          title: 'Beslut',
-          href: '#',
-          icon: Gavel,
         },
       ],
     },
@@ -155,7 +162,7 @@ Använd `variant="external"` för en förenklad version av Layout med Navbar i b
 </Layout>
 ```
 
-<BasicExample variant='external' />
+<ExternalExample />
 
 ## Separat användning
 

--- a/apps/docs/docs/components/layout.mdx
+++ b/apps/docs/docs/components/layout.mdx
@@ -8,7 +8,7 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { BasicExample } from '@site/src/components/examples/layout/LayoutExamples'
 
 <ComponentHeader
-  name={'Layout'}
+  name='Layout'
   friendlyName='Meny, baslayout, sidomeny, sidhuvud'
   overrideHeadlessLink=''
 />

--- a/apps/docs/docs/components/link-button.mdx
+++ b/apps/docs/docs/components/link-button.mdx
@@ -11,19 +11,14 @@ import { Example } from '@site/src/components/examples/link-button/LinkButtonExa
 import ExampleSrc from '!!raw-loader!@site/src/components/examples/link-button/LinkButtonExamples'
 
 <ComponentHeader
-  name={'LinkButton'}
-  friendlyName={'Länkknapp'}
+  name='LinkButton'
+  friendlyName='Länkknapp'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/Link.html'
 />
 
 Komponent med samma utseende och beteende som [Button](/components/button) men avsedd att använda som länk internt eller externt i en applikation.
 
-<div
-  className={'card'}
-  style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}
->
-  <Example />
-</div>
+<Example />
 
 ## Installation
 
@@ -31,13 +26,9 @@ Komponent med samma utseende och beteende som [Button](/components/button) men a
 npm install @midas-ds/components
 ```
 
-<CodeBlock language={'tsx'}>{ExampleSrc}</CodeBlock>
-<div
-  className={'card'}
-  style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}
->
-  <Example />
-</div>
+<CodeBlock language='tsx'>{ExampleSrc}</CodeBlock>
+
+<Example />
 
 ## Riktlinjer
 

--- a/apps/docs/docs/components/link.mdx
+++ b/apps/docs/docs/components/link.mdx
@@ -9,8 +9,8 @@ import { Link } from '@midas-ds/components'
 import { semantic } from '@midas-ds/components/theme'
 
 <ComponentHeader
-  name={'Link'}
-  friendlyName={'Länk'}
+  name='Link'
+  friendlyName='Länk'
 />
 
 Komponenten Link skapar en länk som kan vara i ett textstycke eller fristående.
@@ -23,7 +23,7 @@ Komponenten Link skapar en länk som kan vara i ett textstycke eller fristående
 </p>
 ```
 
-<div className={'card'}>
+<div className='card'>
   I vår <Link href='/changelog'>Changelog</Link> dokumenterar vi de senaste ändringarna i komponenterna.
 </div>
 
@@ -49,7 +49,7 @@ import { Link } from '@midas-ds/components'
 </p>
 ```
 
-<div className={'card'}>
+<div className='card'>
   Designsystemet utvecklas ständigt, <Link href='/changelog'>vilket du kan kan se i vår Changelog</Link>. Vi släpper
   kontinuerligt nya versioner med buggfixar, nya komponenter och nya funktioner.
 </div>
@@ -72,7 +72,7 @@ Använd `standalone` för att använda komponenten som en fristående länk unde
 </Link>
 ```
 
-<div className={'card'}>
+<div className='card'>
   Designsystemet utvecklas ständigt. Vi släpper kontinuerligt nya versioner med buggfixar, nya komponenter och nya
   funktioner på befintliga komponenter.
   <Link
@@ -106,11 +106,11 @@ Använd `stretched` för att låta hela föräldraelementet vara klickbart till 
 </div>
 ```
 
-<div className={'card'}>
+<div className='card'>
   <div
     style={{
       position: 'relative',
-      background: semantic.layer02,
+      background: semantic.layer01,
       padding: '1rem',
     }}
   >

--- a/apps/docs/docs/components/logo.mdx
+++ b/apps/docs/docs/components/logo.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Link, Logo } from '@midas-ds/components'
 
 <ComponentHeader
-  name={'Logo'}
-  friendlyName={'Logotyp'}
+  name='Logo'
+  friendlyName='Logotyp'
   overrideHeadlessLink=''
 />
 
@@ -123,4 +123,4 @@ För de fall där komponenten inte kan användas tilhandahåller vi även logoty
 
 ## API
 
-<PropTable name={'Logo'} />
+<PropTable name='Logo' />

--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -8,7 +8,7 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { FormExample, ConfirmationExample } from '@site/src/components/examples/ModalExamples'
 
 <ComponentHeader
-  name={'Modal'}
+  name='Modal'
   friendlyName='Modal, Dialog, Dialogruta'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-spectrum/Dialog.html#dialog'
 />
@@ -52,7 +52,7 @@ För att stänga modal via klick utanför modalens yta, använd `isDismissable` 
     //highlight-start
     isDismissable
     //highlight-end
-    title={'Modal Title'}
+    title='Modal Title'
   >
     /* Modal content */
   </Modal>
@@ -67,9 +67,9 @@ element kan användas för att öppna modalen. För att stänga modalen med en k
 ```tsx title='Uncontrolled Modal'
 <DialogTrigger>
   <Button>Open</Button>
-  <Modal title={'Modal Title'}>
+  <Modal title='Modal Title'>
     //highlight-start
-    <Button slot={'close'}>Close</Button>
+    <Button slot='close'>Close</Button>
     //highlight-end
   </Modal>
 </DialogTrigger>
@@ -82,13 +82,15 @@ Använd `isOpen` och `onOpenChange()` för att via state kontrollera om modalen 
 ```tsx title='Controlled Modal'
 /* imports and rest of app */
 const [open, setOpen] = React.useState<boolean>(false)
+
 /* trigger modal from anywhere */
 <Button onPress={() => setOpen(true))}>Open</Button>
+
 //highlight-start
 <DialogTrigger isOpen={open} onOpenChange={setOpen}>
 //highlight-end
   <Modal
-    title={'Modal Title'}
+    title="Modal Title"
   >
     /* Modal content */
   </Modal>
@@ -102,10 +104,10 @@ Modaler kan även innehålla mer avancerat innehåll som ett formulär. Använd 
 ```tsx title=AutoFocus
 <DialogTrigger>
   <Button>Open</Button>
-  <Modal title={'Modal Title'}>
-//highlight-start
-    <TextField label={'Name'} autoFocus>
-//highlight-end
+  <Modal title="Modal Title">
+    //highlight-start
+    <TextField label="Name" autoFocus>
+    //highlight-end
   </Modal>
 </DialogTrigger>
 ```

--- a/apps/docs/docs/components/progress-bar.mdx
+++ b/apps/docs/docs/components/progress-bar.mdx
@@ -6,7 +6,12 @@ import { ProgressBar } from '@midas-ds/components'
 import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
-<ComponentHeader name='ProgressBar' />
+<ComponentHeader
+  name='ProgressBar'
+  friendlyName='Progressindikator, progresstatus'
+/>
+
+Progress bar med fördefinerad stil, använder `role="progressbar"` under huven
 
 ```tsx
 <ProgressBar
@@ -23,8 +28,6 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
     value={30}
   />
 </div>
-
-Progress bar med fördefinerad stil, använder `role="progressbar"` under huven
 
 ## Installation
 

--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { BasicExample, ControlledExample, HorizontalExample } from '@site/src/components/examples/radio/RadioExamples'
 
 <ComponentHeader
-  name={'Radio'}
-  friendlyName={'Radioknappar'}
+  name='Radio'
+  friendlyName='Radioknappar'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/RadioGroup.html'
 />
 

--- a/apps/docs/docs/components/search-field.mdx
+++ b/apps/docs/docs/components/search-field.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { SearchField } from '@midas-ds/components'
 
 <ComponentHeader
-  name={'SearchField'}
-  friendlyName={'Sökfält'}
+  name='SearchField'
+  friendlyName='Sökfält'
 />
 
 Inmatningsfält anpassat för sökning.
@@ -34,4 +34,4 @@ import { SearchField } from '@midas-ds/components'
 
 ## API
 
-<PropTable name={'SearchField'} />
+<PropTable name='SearchField' />

--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -7,8 +7,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { BasicExample, ControlledExample, SectionedExample } from '@site/src/components/examples/select/SelectExamples'
 
 <ComponentHeader
-  name={'Select'}
-  friendlyName={'Flerval, väljare, dropdown, rullgardin'}
+  name='Select'
+  friendlyName='Flerval, väljare, dropdown, rullgardin'
 />
 
 Inmatningsfält som används för att välja ett eller flera fördefinerade alternativ.

--- a/apps/docs/docs/components/skeleton.mdx
+++ b/apps/docs/docs/components/skeleton.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Skeleton } from '@midas-ds/components'
 
 <ComponentHeader
-  name={'Skeleton'}
-  friendlyName={'Laddningsindikator'}
+  name='Skeleton'
+  friendlyName='Laddningsindikator'
   overrideHeadlessLink=''
 />
 
@@ -89,4 +89,4 @@ För val av laddningsindikator se [Mönster för laddningsindikatorer](/design-p
 
 ## API
 
-<PropTable name={'Skeleton'} />
+<PropTable name='Skeleton' />

--- a/apps/docs/docs/components/spinner.mdx
+++ b/apps/docs/docs/components/spinner.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Spinner, Button } from '@midas-ds/components'
 
 <ComponentHeader
-  name={'Spinner'}
-  friendlyName={'Laddningsindikator'}
+  name='Spinner'
+  friendlyName='Laddningsindikator'
   overrideHeadlessLink=''
 />
 
@@ -82,4 +82,4 @@ För val av laddningsindikator se [Mönster för laddningsindikatorer](/design-p
 
 ## API
 
-<PropTable name={'Spinner'} />
+<PropTable name='Spinner' />

--- a/apps/docs/docs/components/table.mdx
+++ b/apps/docs/docs/components/table.mdx
@@ -8,8 +8,8 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { BasicExample, FullExample, ControlledExample } from '@site/src/components/examples/table/TableExamples'
 
 <ComponentHeader
-  name={'Table'}
-  friendlyName={'Tabell'}
+  name='Table'
+  friendlyName='Tabell'
 />
 
 Komponent för att visualisera data. Kan kombineras med andra komponenter, till exemepel [Select](/components/select),

--- a/apps/docs/docs/components/tabs.mdx
+++ b/apps/docs/docs/components/tabs.mdx
@@ -9,8 +9,8 @@ import { Tabs as MidasTabs, Text } from '@midas-ds/components'
 import { ControlledExample } from '@site/src/components/examples/tabs/TabsExamples'
 
 <ComponentHeader
-  name={'Tabs'}
-  friendlyName={'Flikar'}
+  name='Tabs'
+  friendlyName='Flikar'
 />
 
 Komponent för att segmentera information. Används för att minska informationsmängden som direkt presenteras för användaren.

--- a/apps/docs/docs/components/text.mdx
+++ b/apps/docs/docs/components/text.mdx
@@ -7,8 +7,8 @@ import { PropTable } from '@site/src/components/propsTable'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'typography-text'}
-  friendlyName={'Brödtext, p, span, i, em, strong'}
+  name='typography-text'
+  friendlyName='Brödtext, p, span, i, em, strong'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-spectrum/Text.html'
 />
 

--- a/apps/docs/docs/components/textfield.mdx
+++ b/apps/docs/docs/components/textfield.mdx
@@ -65,15 +65,17 @@ Använd `defaultValue` för att sätta ett uncontrolled value på ett TextField.
 
 ```tsx
 <TextField
-  label={'Skriv din favoritfrukt'}
-  defaultValue={'Banan'}
+  label='Skriv din favoritfrukt'
+  defaultValue='Banan'
 />
 ```
 
-<TextField
-  label={'Skriv din favoritfrukt'}
-  defaultValue={'Banan'}
-/>
+<div className='card'>
+  <TextField
+    label='Skriv din favoritfrukt'
+    defaultValue='Banan'
+  />
+</div>
 
 ### Controlled value
 
@@ -85,7 +87,7 @@ const ControlledValue = () => {
   const [text, setText] = React.useState('')
   return (
     <>
-      <TextField value={text} onChange={setText} label={'Controlled value'}/>
+      <TextField value={text} onChange={setText} label="Controlled value" />
       <Text>Text value: {text}</Text>
     </>
 )
@@ -119,20 +121,32 @@ Läs mer om validering i [React Arias dokumentation](https://react-spectrum.adob
 
 ### Storlek
 
-För att minska höjden på TextField, använd `size={'medium'}` som minskar padding i inputfältet.
+För att minska höjden på TextField, använd `size="medium"` som minskar padding i inputfältet.
 
 ```tsx
-<TextField label={'Large'}/> // default is size={'large'}
+<TextField label="Large" /> // default is size="large"
 //highlight-next-line
-<TextField label={'Medium'} size={'medium'}/>
+<TextField label="Medium" size="medium" />
 ```
 
-<div className={'card'}>
-  <span style={{
-    display: 'flex', gap: '1rem', flexDirection: 'row'
-  }}>
-  <TextField label={'Large'} size={'large'} defaultValue={'large textfield'}/>
-  <TextField label={'Medium'} size={'medium'} defaultValue={'medium textfield'}/>
+<div className='card'>
+  <span
+    style={{
+      display: 'flex',
+      gap: '1rem',
+      flexDirection: 'row',
+    }}
+  >
+    <TextField
+      label='Large'
+      size='large'
+      defaultValue='large textfield'
+    />
+    <TextField
+      label='Medium'
+      size='medium'
+      defaultValue='medium textfield'
+    />
   </span>
 </div>
 
@@ -152,32 +166,36 @@ Använd `showCounter` för att visa antalet tecken som skrivits in i fältet.
 />
 ```
 
-<TextField
-  label='Skriv in frukt'
-  description={'Max 10 tecken'}
-  maxLength={10}
-  showCounter
-/>
+<div className='card'>
+  <TextField
+    label='Skriv in frukt'
+    description='Max 10 tecken'
+    maxLength={10}
+    showCounter
+  />
+</div>
 
 ### Lösenord
 
-Använd `type={'password'}` för att aktivera en knapp för att visa/dölja inmatat värde.
+Använd `type="password"` för att aktivera en knapp för att visa/dölja inmatat värde.
 
 ```tsx
 <TextField
   label='Lösenord'
   //highlight-start
-  type={'password'}
+  type='password'
   //highlight-end
 />
 ```
 
-<TextField
-  defaultValue={'super-secret'}
-  label='Lösenord'
-  autoComplete={'off'}
-  type={'password'}
-/>
+<div className='card'>
+  <TextField
+    defaultValue='super-secret'
+    label='Lösenord'
+    autoComplete='off'
+    type='password'
+  />
+</div>
 
 ## API
 

--- a/apps/docs/docs/components/toast.mdx
+++ b/apps/docs/docs/components/toast.mdx
@@ -8,26 +8,31 @@ import { GlobalToastRegion, toastQueue, Button, Flex, FlexItem } from '@midas-ds
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 <ComponentHeader
-  name={'Toast'}
-  friendlyName={'Notifiering, notiser'}
+  name='Toast'
+  friendlyName='Notifiering, notiser'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/useToast.html'
 />
 
 Komponent för att visa ett kort, tillfälligt meddelanden om åtgärder, fel eller andra händelser i en applikation.
 
-<GlobalToastRegion />
-<Button
-  onPress={() =>
-    toastQueue.add(
-      { type: 'success', message: 'Allt funkar som det ska!' },
-      {
-        timeout: 5000
-      }
-    )
-  }
+<div
+  className='card'
+  style={{ display: 'block' }}
 >
-  {'Tryck här för en notifiering'}
-</Button>
+  <GlobalToastRegion />
+  <Button
+    onPress={() =>
+      toastQueue.add(
+        { type: 'success', message: 'Allt funkar som det ska!' },
+        {
+          timeout: 5000,
+        },
+      )
+    }
+  >
+    {'Tryck här för en notifiering'}
+  </Button>
+</div>
 
 ## Installation
 
@@ -43,39 +48,43 @@ import { ToastProvider } from '@midas-ds/components'
 
 Toast har fyra olika varianter som matchar InfoBanner: `success`, `info`, `important` och `warning`.
 
-<Flex fluid={true}>
-  <FlexItem col={3}>
-    <Button onPress={() => toastQueue.add({ type: 'success', message: 'Allt funkar som det ska!' }, { timeout: 5000 })}>
-      {'Success'}
-    </Button>
-  </FlexItem>
-  <FlexItem col={3}>
-    <Button
-      onPress={() =>
-        toastQueue.add(
-          { type: 'info', message: 'Här kommer ett meddelande' },
-          {
-            timeout: 5000
-          }
-        )
-      }
-    >
-      {'Info'}
-    </Button>
-  </FlexItem>
-  <FlexItem col={3}>
-    <Button onPress={() => toastQueue.add({ message: 'Viktigt meddelande', type: 'important' }, { timeout: 5000 })}>
-      {'Important'}
-    </Button>
-  </FlexItem>
-  <FlexItem col={3}>
-    <Button
-      onPress={() => toastQueue.add({ message: 'Farlig varning!', type: 'warning' }, { timeout: 5000, priority: 1 })}
-    >
-      {'Warning'}
-    </Button>
-  </FlexItem>
-</Flex>
+<div className='card'>
+  <Flex fluid={true}>
+    <FlexItem col={3}>
+      <Button
+        onPress={() => toastQueue.add({ type: 'success', message: 'Allt funkar som det ska!' }, { timeout: 5000 })}
+      >
+        {'Success'}
+      </Button>
+    </FlexItem>
+    <FlexItem col={3}>
+      <Button
+        onPress={() =>
+          toastQueue.add(
+            { type: 'info', message: 'Här kommer ett meddelande' },
+            {
+              timeout: 5000,
+            },
+          )
+        }
+      >
+        {'Info'}
+      </Button>
+    </FlexItem>
+    <FlexItem col={3}>
+      <Button onPress={() => toastQueue.add({ message: 'Viktigt meddelande', type: 'important' }, { timeout: 5000 })}>
+        {'Important'}
+      </Button>
+    </FlexItem>
+    <FlexItem col={3}>
+      <Button
+        onPress={() => toastQueue.add({ message: 'Farlig varning!', type: 'warning' }, { timeout: 5000, priority: 1 })}
+      >
+        {'Warning'}
+      </Button>
+    </FlexItem>
+  </Flex>
+</div>
 
 ## Implementationer
 

--- a/apps/docs/docs/components/tooltip.mdx
+++ b/apps/docs/docs/components/tooltip.mdx
@@ -148,7 +148,10 @@ såsom tredjepartskomponenter och andra DOM-element, stöds också genom att de 
 
 ```tsx
 import { Focusable } from 'react-aria-components'
-;<TooltipTrigger>
+```
+
+```tsx
+<TooltipTrigger>
   <Focusable>
     <span role='button'>Trigger</span>
   </Focusable>

--- a/apps/docs/docs/components/tooltip.mdx
+++ b/apps/docs/docs/components/tooltip.mdx
@@ -29,7 +29,7 @@ export const Example = props => {
 }
 
 <ComponentHeader
-  name={'Tooltip'}
+  name='Tooltip'
   friendlyName='Hjälptext'
 />
 
@@ -48,7 +48,7 @@ Tooltip kan användas för att förklara en knapp eller annan interaktion när d
 ```
 
 <div
-  className={'card'}
+  className='card'
   style={{ display: 'block' }}
 >
   <Example />
@@ -120,6 +120,7 @@ Tooltipens placering i förhållande till dess trigger-element kan justeras med 
 ```tsx
 export const ControlledTooltip = () => {
   const [isOpen, setOpen] = React.useState(false)
+
   return (
     <>
       <TooltipTrigger
@@ -136,50 +137,52 @@ export const ControlledTooltip = () => {
 }
 ```
 
-<div className={'card'}>
+<div className='card'>
   <ControlledTooltip />
 </div>
 
 ### Valfritt element som Trigger
+
 TooltipTrigger fungerar direkt med alla **focusable** React Aria-komponenter (t.ex. Button, Link, etc.). Anpassade trigger-element,
 såsom tredjepartskomponenter och andra DOM-element, stöds också genom att de omsluts med `<Focusable>`-komponenten.
 
 ```tsx
 import { Focusable } from 'react-aria-components'
-<TooltipTrigger>
+;<TooltipTrigger>
   <Focusable>
     <span role='button'>Trigger</span>
   </Focusable>
-  <Tooltip>
-  Med hjälp av Focusable kan vilket
-  element som helst bli en trigger!
-  </Tooltip>
+  <Tooltip>Med hjälp av Focusable kan vilket element som helst bli en trigger!</Tooltip>
 </TooltipTrigger>
 ```
-<div className={'card'} style={{display: 'block'}}>
+
+<div
+  className='card'
+  style={{ display: 'block' }}
+>
   <CustomTriggerTooltip />
 </div>
 
 Observera att element under `<Focusable>` måste ha en ARIA-roll eller använda ett lämpligt semantiskt HTML-element
-så att skärmläsare kan läsa upp innehållet i verktygstipset. Detta gäller bara element som inte redan är *focusable*
-eller *pressable*. Se [React Aria Tooltip Custom trigger](https://react-spectrum.adobe.com/react-aria/Tooltip.html#custom-trigger)
+så att skärmläsare kan läsa upp innehållet i verktygstipset. Detta gäller bara element som inte redan är _focusable_
+eller _pressable_. Se [React Aria Tooltip Custom trigger](https://react-spectrum.adobe.com/react-aria/Tooltip.html#custom-trigger)
 för referens.
 
 ## Riktlinjer
 
 - I första hand skall elementet vara tydligt nog så användaren förstår innebörden. Tooltip är till för en design där detta
-inte är möjligt och vi måste gömma undan informationen.
+  inte är möjligt och vi måste gömma undan informationen.
 - Tooltips kan också användas för att berätta mer information än vad som framkommer visuellt på knappen.
 
 ## API
 
 ### Tooltip
 
-<PropTable name={'Tooltip'} />
+<PropTable name='Tooltip' />
 
 ### TooltipTrigger
 
 <PropTable
-  name={'TooltipTrigger'}
-  defaultOpen={true}
+  name='TooltipTrigger'
+  defaultOpen={false}
 />

--- a/apps/docs/src/components/examples/LocalizationExamples.tsx
+++ b/apps/docs/src/components/examples/LocalizationExamples.tsx
@@ -74,8 +74,8 @@ function CurrentDate() {
   return (
     <DateField
       defaultValue={parseDate('2025-02-28')}
-      label={'Datumväljare'}
-      description={'Format kan styras med i18nProvider'}
+      label='Datumväljare'
+      description='Format kan styras med i18nProvider'
     ></DateField>
   )
 }
@@ -83,11 +83,9 @@ function CurrentDate() {
 export const ErrorMessageExample = () => {
   return (
     <TextField
-      label={'Skriv e-post'}
-      type={'email'}
-      description={
-        'Validering/Felmeddelanden beror av inställningarna i browser'
-      }
+      label='Skriv e-post'
+      type='email'
+      description='Validering/Felmeddelanden beror av inställningarna i browser'
     />
   )
 }

--- a/apps/docs/src/components/examples/ModalExamples.tsx
+++ b/apps/docs/src/components/examples/ModalExamples.tsx
@@ -10,58 +10,68 @@ import {
 } from '@midas-ds/components'
 
 export const ConfirmationExample = () => (
-  <DialogTrigger>
-    <Button>Ta bort Kiwi</Button>
-    <Modal title='Ta bort saker ur fruktkorgen'>
-      <Text elementType='p'>
-        Är du säker att du vill plocka bort "Kiwi" från fruktkorgen?
-      </Text>
-      <ButtonGroup>
-        <Button
-          variant='danger'
-          slot='close'
-        >
-          Ja, ta bort
-        </Button>
-        <Button
-          autoFocus
-          slot='close'
-          variant='secondary'
-        >
-          Nej, ha kvar
-        </Button>
-      </ButtonGroup>
-    </Modal>
-  </DialogTrigger>
-)
-
-export const FormExample = () => (
-  <DialogTrigger>
-    <Button>Gör din egen fruktkorg</Button>
-    <Modal title='Gör din egen fruktkorg'>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <TextField
-          autoFocus
-          label='Namnge din fruktkorg'
-          description='Skriv valfritt namn'
-        />
-        <RadioGroup
-          defaultValue='ja'
-          label='Vill du ha fruktkorgen hemskickad till din hemadress?'
-        >
-          <Radio value='ja'>Ja</Radio>
-          <Radio value='nej'>Nej</Radio>
-        </RadioGroup>
+  <div
+    className='card'
+    style={{ display: 'block' }}
+  >
+    <DialogTrigger>
+      <Button>Ta bort Kiwi</Button>
+      <Modal title='Ta bort saker ur fruktkorgen'>
+        <Text elementType='p'>
+          Är du säker att du vill plocka bort "Kiwi" från fruktkorgen?
+        </Text>
         <ButtonGroup>
-          <Button slot='close'>Skicka</Button>
           <Button
+            variant='danger'
+            slot='close'
+          >
+            Ja, ta bort
+          </Button>
+          <Button
+            autoFocus
             slot='close'
             variant='secondary'
           >
-            Avbryt
+            Nej, ha kvar
           </Button>
         </ButtonGroup>
-      </div>
-    </Modal>
-  </DialogTrigger>
+      </Modal>
+    </DialogTrigger>
+  </div>
+)
+
+export const FormExample = () => (
+  <div
+    className='card'
+    style={{ display: 'block' }}
+  >
+    <DialogTrigger>
+      <Button>Gör din egen fruktkorg</Button>
+      <Modal title='Gör din egen fruktkorg'>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <TextField
+            autoFocus
+            label='Namnge din fruktkorg'
+            description='Skriv valfritt namn'
+          />
+          <RadioGroup
+            defaultValue='ja'
+            label='Vill du ha fruktkorgen hemskickad till din hemadress?'
+          >
+            <Radio value='ja'>Ja</Radio>
+            <Radio value='nej'>Nej</Radio>
+          </RadioGroup>
+          <ButtonGroup>
+            <Button slot='close'>Skicka</Button>
+            <Button
+              slot='close'
+              variant='secondary'
+            >
+              Avbryt
+            </Button>
+          </ButtonGroup>
+        </div>
+      </Modal>
+    </DialogTrigger>
+  </div>
 )

--- a/apps/docs/src/components/examples/accordion/AccordionExamples.tsx
+++ b/apps/docs/src/components/examples/accordion/AccordionExamples.tsx
@@ -2,28 +2,25 @@ import { AccordionItem, Accordion } from '@midas-ds/components'
 import React from 'react'
 import { Key } from 'react-aria-components'
 
-export const AccordionExample = (
-  props: typeof AccordionItem & typeof Accordion,
-) => {
+export const Example = (props: typeof AccordionItem & typeof Accordion) => {
   return (
-    <div className={'card'}>
+    <div className='card'>
       <Accordion {...props}>
         <AccordionItem
-          {...props}
-          id={'mandarin'}
-          title={'Mandarin'}
+          id='mandarin'
+          title='Mandarin'
         >
           Liten orange citrusfrukt
         </AccordionItem>
         <AccordionItem
-          id={'sharon'}
-          title={'Sharon'}
+          id='sharon'
+          title='Sharon'
         >
           Persikoliknande frukt med fast kött
         </AccordionItem>
         <AccordionItem
-          id={'watermelon'}
-          title={'Vattenmelon'}
+          id='watermelon'
+          title='Vattenmelon'
         >
           Stor frukt med rött, saftigt kött
         </AccordionItem>
@@ -32,13 +29,41 @@ export const AccordionExample = (
   )
 }
 
-export const AccordionExampleControlled = (props: typeof Accordion) => {
+export const StatusExample = () => (
+  <div className='card'>
+    <Accordion variant='contained'>
+      <AccordionItem
+        id='mandarin'
+        title='Mandarin'
+        type='success'
+      >
+        Liten orange citrusfrukt
+      </AccordionItem>
+      <AccordionItem
+        id='sharon'
+        title='Sharon'
+        type='warning'
+      >
+        Persikoliknande frukt med fast kött
+      </AccordionItem>
+      <AccordionItem
+        id='watermelon'
+        title='Vattenmelon'
+        type='default'
+      >
+        Stor frukt med rött, saftigt kött
+      </AccordionItem>
+    </Accordion>
+  </div>
+)
+
+export const ExampleControlled = (props: typeof Accordion) => {
   const [expandedKeys, setExpandedKeys] = React.useState<Set<Key>>(
     new Set(['mandarin']),
   )
   return (
     <div
-      className={'card'}
+      className='card'
       style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}
     >
       <Accordion
@@ -48,20 +73,20 @@ export const AccordionExampleControlled = (props: typeof Accordion) => {
       >
         <AccordionItem
           {...props}
-          id={'mandarin'}
-          title={'Mandarin'}
+          id='mandarin'
+          title='Mandarin'
         >
           Liten orange citrusfrukt
         </AccordionItem>
         <AccordionItem
-          id={'sharon'}
-          title={'Sharon'}
+          id='sharon'
+          title='Sharon'
         >
           Persikoliknande frukt med fast kött
         </AccordionItem>
         <AccordionItem
-          id={'watermelon'}
-          title={'Vattenmelon'}
+          id='watermelon'
+          title='Vattenmelon'
         >
           Stor frukt med rött, saftigt kött
         </AccordionItem>

--- a/apps/docs/src/components/examples/date-field/DateFieldExamples.tsx
+++ b/apps/docs/src/components/examples/date-field/DateFieldExamples.tsx
@@ -1,17 +1,22 @@
 import React from 'react'
 import { DateField } from '@midas-ds/components'
-import { now, toCalendarDate, getLocalTimeZone, CalendarDate } from '@internationalized/date'
+import {
+  now,
+  toCalendarDate,
+  getLocalTimeZone,
+  CalendarDate,
+} from '@internationalized/date'
 
 export const DateFieldControlled = () => {
   const today = toCalendarDate(now(getLocalTimeZone()))
-  const [date, setDate] = React.useState<CalendarDate | null>(today)
+  const [date, setDate] = React.useState<CalendarDate>(today)
   return (
-    <>
+    <div className='card'>
       <DateField
         value={date}
-        onChange={setDate}
-      ></DateField>
+        onChange={value => value && setDate(value as CalendarDate)}
+      />
       <pre>Du har valt datumet: {date?.toString()}</pre>
-    </>
+    </div>
   )
 }

--- a/apps/docs/src/components/examples/date-picker/DatePickerExamples.tsx
+++ b/apps/docs/src/components/examples/date-picker/DatePickerExamples.tsx
@@ -21,7 +21,9 @@ export const DatePickerExample = () => {
       <DatePicker
         label='Date (controlled)'
         value={value}
-        onChange={setValue}
+        onChange={newValue =>
+          setValue(newValue ? parseDate(newValue.toString()) : null)
+        }
       />
       <pre>Du valde datum: {value?.toString()}</pre>
     </>
@@ -36,7 +38,7 @@ export const UnavailableDateExample = () => {
   return (
     <DatePicker
       label='Välj ett datum'
-      description={'Fast inte förrän om en vecka'}
+      description='Fast inte förrän om en vecka'
       isDateUnavailable={isDateUnavailable}
       minValue={now}
     />

--- a/apps/docs/src/components/examples/flex/FlexExamples.tsx
+++ b/apps/docs/src/components/examples/flex/FlexExamples.tsx
@@ -1,21 +1,50 @@
-import {Flex, FlexItem} from '@midas-ds/components'
-import {semantic} from '@midas-ds/components/theme'
+import { Flex, FlexItem } from '@midas-ds/components'
+import { semantic } from '@midas-ds/components/theme'
 
 export const Example = () => {
   return (
-    <Flex style={{ paddingLeft: 0, paddingRight: 0 }}>
-      <FlexItem col={12} style={{background: semantic.brandPrimary, height: '6rem', padding: '1rem'}}>
-        <span style={{fontFamily: 'Fira Code'}}>col=12</span>
-      </FlexItem>
-      <FlexItem style={{background: semantic.iconInfo, height: '6rem', padding: '1rem'}}>
-        <span style={{fontFamily: 'Fira Code'}}>not set</span>
-      </FlexItem>
-      <FlexItem col={'auto'} style={{background: semantic.iconSuccess, height: '6rem', padding: '1rem'}}>
-        <span style={{fontFamily: 'Fira Code'}}>col=auto</span>
-      </FlexItem>
-      <FlexItem col={6} style={{background: semantic.linkVisited, height: '6rem', padding: '1rem'}}>
-        <span style={{fontFamily: 'Fira Code'}}>col=6</span>
-      </FlexItem>
-    </Flex>
+    <div className='card'>
+      <Flex fluid>
+        <FlexItem
+          col={12}
+          style={{
+            background: semantic.brandPrimary,
+            height: '6rem',
+            padding: '1rem',
+          }}
+        >
+          <span style={{ fontFamily: 'Fira Code' }}>col=12</span>
+        </FlexItem>
+        <FlexItem
+          style={{
+            background: semantic.iconInfo,
+            height: '6rem',
+            padding: '1rem',
+          }}
+        >
+          <span style={{ fontFamily: 'Fira Code' }}>not set</span>
+        </FlexItem>
+        <FlexItem
+          col={'auto'}
+          style={{
+            background: semantic.iconSuccess,
+            height: '6rem',
+            padding: '1rem',
+          }}
+        >
+          <span style={{ fontFamily: 'Fira Code' }}>col=auto</span>
+        </FlexItem>
+        <FlexItem
+          col={6}
+          style={{
+            background: semantic.linkVisited,
+            height: '6rem',
+            padding: '1rem',
+          }}
+        >
+          <span style={{ fontFamily: 'Fira Code' }}>col=6</span>
+        </FlexItem>
+      </Flex>
+    </div>
   )
 }

--- a/apps/docs/src/components/examples/form/FormExamples.tsx
+++ b/apps/docs/src/components/examples/form/FormExamples.tsx
@@ -11,10 +11,16 @@ import {
 } from '@midas-ds/components'
 
 export const UncontrolledForm = () => {
-  const [result, setResult] = React.useState(null)
+  const [result, setResult] = React.useState<Record<
+    string,
+    FormDataEntryValue
+  > | null>(null)
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const data = Object.fromEntries(new FormData(e.currentTarget))
+    const data = Object.fromEntries(new FormData(e.currentTarget)) as Record<
+      string,
+      FormDataEntryValue
+    >
     setResult(data)
   }
 
@@ -23,37 +29,37 @@ export const UncontrolledForm = () => {
       <Form
         onSubmit={handleSubmit}
         className={styles.form}
-        validationBehavior={'native'} // use 'aria' to allow submit when invalid
+        validationBehavior='native' // use 'aria' to allow submit when invalid
       >
         <TextField
-          label={'Namn'}
-          name={'name'}
+          label='Namn'
+          name='name'
           isRequired
         />
         <TextField
-          label={'E-post'}
-          type={'email'}
-          name={'email'}
+          label='E-post'
+          type='email'
+          name='email'
           isRequired
         />
         <CheckboxGroup
-          label={'Spara mina uppgifter'}
-          name={'saveData'}
+          label='Spara mina uppgifter'
+          name='saveData'
           isRequired
         >
-          <Checkbox value={'agree'}>Jag godkänner</Checkbox>
+          <Checkbox value='agree'>Jag godkänner</Checkbox>
         </CheckboxGroup>
         <ButtonGroup>
-          <Button type={'submit'}>Skicka</Button>
+          <Button type='submit'>Skicka</Button>
           <Button
-            type={'reset'}
-            variant={'secondary'}
+            type='reset'
+            variant='secondary'
           >
             Rensa
           </Button>
         </ButtonGroup>
       </Form>
-      <span>{result && <pre>{JSON.stringify(result)}</pre>}</span>
+      <span>{result && <pre>{JSON.stringify(result, null, 2)}</pre>}</span>
     </>
   )
 }
@@ -66,20 +72,20 @@ export const ControlledForm = () => {
   return (
     <Form onSubmit={onSubmit}>
       <TextField
-        name={'name'}
-        label={'Namn'}
+        name='name'
+        label='Namn'
         onChange={setName}
         isRequired
       />
       <div>Ditt namn: {name}</div>
-      <Button type={'submit'}>Skicka</Button>
+      <Button type='submit'>Skicka</Button>
     </Form>
   )
 }
 
 export const RealtimeValidation = () => {
   const [password, setPassword] = React.useState('')
-  const errors = []
+  const errors: string[] = []
   if (password.length < 8) {
     errors.push('Lösenordet måste vara fler än 8 tecken.')
   }
@@ -92,13 +98,13 @@ export const RealtimeValidation = () => {
 
   return (
     <TextField
-      label={'Lösenord'}
+      label='Lösenord'
       style={{ whiteSpace: 'pre-line' }}
       isInvalid={errors.length > 0}
       value={password}
       onChange={setPassword}
       errorMessage={errors.join('\n')}
-      errorPosition={'bottom'}
+      errorPosition='bottom'
     />
   )
 }
@@ -106,8 +112,11 @@ export const RealtimeValidation = () => {
 export const ServerValidation = () => {
   const [isWaiting, setIsWaiting] = React.useState(false)
   // Fake server used in this example.
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
-  async function callServer(data) {
+  const delay = (ms: number): Promise<void> =>
+    new Promise(resolve => setTimeout(resolve, ms))
+  async function callServer(
+    data: Record<string, FormDataEntryValue>,
+  ): Promise<{ errors: Record<string, string> }> {
     setIsWaiting(true)
     await delay(1000)
     setIsWaiting(false)
@@ -117,11 +126,14 @@ export const ServerValidation = () => {
       },
     }
   }
-  const [errors, setErrors] = React.useState({})
+  const [errors, setErrors] = React.useState<Record<string, string>>({})
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    const data = Object.fromEntries(new FormData(e.currentTarget))
+    const data = Object.fromEntries(new FormData(e.currentTarget)) as Record<
+      string,
+      FormDataEntryValue
+    >
     const result = await callServer(data)
     setErrors(result.errors)
   }
@@ -133,12 +145,12 @@ export const ServerValidation = () => {
       className={styles.form}
     >
       <TextField
-        label={'Användarnamn'}
+        label='Användarnamn'
         name='username'
         isRequired
       />
       <TextField
-        label={'Lösenord'}
+        label='Lösenord'
         name='password'
         type='password'
         isRequired

--- a/apps/docs/src/components/examples/form/TextFieldExamples.tsx
+++ b/apps/docs/src/components/examples/form/TextFieldExamples.tsx
@@ -3,14 +3,15 @@ import * as React from 'react'
 
 export function ControlledValue() {
   const [text, setText] = React.useState('')
+
   return (
-    <>
+    <div className='card'>
       <TextField
         value={text}
         onChange={setText}
-        label={'Controlled value'}
+        label='Controlled value'
       />
       <Text>Text value: {text}</Text>
-    </>
+    </div>
   )
 }

--- a/apps/docs/src/components/examples/grid/GridExamples.tsx
+++ b/apps/docs/src/components/examples/grid/GridExamples.tsx
@@ -3,98 +3,114 @@ import { semantic } from '@midas-ds/components/theme'
 
 export const Example = props => {
   return (
-    <Grid style={{ paddingLeft: 0, paddingRight: 0 }}>
-      <GridItem
-        col={12}
-        style={{
-          background: semantic.brandPrimary,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=12
-        </span>
-      </GridItem>
-      <GridItem
-        col={3}
-        style={{
-          background: semantic.iconSuccess,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=3
-        </span>
-      </GridItem>
-      <GridItem
-        col={4}
-        style={{
-          background: semantic.iconInfo,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=4
-        </span>
-      </GridItem>
-      <GridItem
-        col={5}
-        style={{
-          background: semantic.iconWarning,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=5
-        </span>
-      </GridItem>
-      <GridItem
-        col={4}
-        style={{
-          background: semantic.linkVisited,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=4
-        </span>
-      </GridItem>
-      <GridItem
-        col={4}
-        style={{
-          background: semantic.buttonBackgroundPrimary,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=4
-        </span>
-      </GridItem>
-      <GridItem
-        col={4}
-        style={{
-          background: semantic.buttonBackgroundPrimaryActive,
-          height: '6rem',
-          width: '100%',
-          padding: '1rem',
-        }}
-      >
-        <span style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}>
-          col=4
-        </span>
-      </GridItem>
-    </Grid>
+    <div className='card'>
+      <Grid fluid>
+        <GridItem
+          col={12}
+          style={{
+            background: semantic.brandPrimary,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=12
+          </span>
+        </GridItem>
+        <GridItem
+          col={3}
+          style={{
+            background: semantic.iconSuccess,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=3
+          </span>
+        </GridItem>
+        <GridItem
+          col={4}
+          style={{
+            background: semantic.iconInfo,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=4
+          </span>
+        </GridItem>
+        <GridItem
+          col={5}
+          style={{
+            background: semantic.iconWarning,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=5
+          </span>
+        </GridItem>
+        <GridItem
+          col={4}
+          style={{
+            background: semantic.linkVisited,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=4
+          </span>
+        </GridItem>
+        <GridItem
+          col={4}
+          style={{
+            background: semantic.buttonBackgroundPrimary,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=4
+          </span>
+        </GridItem>
+        <GridItem
+          col={4}
+          style={{
+            background: semantic.buttonBackgroundPrimaryActive,
+            height: '6rem',
+            width: '100%',
+            padding: '1rem',
+          }}
+        >
+          <span
+            style={{ color: semantic.textOnColor, fontFamily: 'Fira Code' }}
+          >
+            col=4
+          </span>
+        </GridItem>
+      </Grid>
+    </div>
   )
 }

--- a/apps/docs/src/components/examples/layout/LayoutExamples.tsx
+++ b/apps/docs/src/components/examples/layout/LayoutExamples.tsx
@@ -4,75 +4,77 @@ import { semantic } from '@midas-ds/components/theme'
 import { Calendar, House, Plus, Gavel, ClipboardList } from 'lucide-react'
 
 export const BasicExample: React.FC<Partial<MidasLayout>> = props => (
-  <Layout
-    variant='internal'
-    items={[
-      {
-        items: [
-          {
-            title: 'Översikt',
-            href: '#',
-            icon: House,
-          },
-        ],
-      },
-      {
-        title: 'Ansökan',
-        items: [
-          {
-            title: 'Skapa ansökan',
-            href: '#',
-            icon: Plus,
-          },
-          {
-            title: 'Beslut',
-            href: '#',
-            icon: Gavel,
-          },
-        ],
-      },
-      {
-        title: 'Kort och konto',
-        items: [
-          {
-            title: 'LMA-kort',
-            href: '#',
-            icon: Calendar,
-          },
-          {
-            title: 'Avvikelser',
-            href: '#',
-            icon: ClipboardList,
-            hasBadge: true,
-          },
-        ],
-      },
-    ]}
-    title='Skapa ansökningar'
-    user={{ name: 'Namn Namnsson', title: 'Roll eller behörighet' }}
-    app={{ name: 'Namn på applikationen' }}
-    headerChildren={
-      <LinkButton
-        variant='tertiary'
-        target='_blank'
-      >
-        Öppna annan tjänst
-      </LinkButton>
-    }
-    {...props}
-  >
-    <div
-      style={{
-        background: semantic.layer02,
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: '100vh',
-        border: `dotted 2px ${semantic.borderSubtle}`,
-        color: semantic.textPrimary,
-      }}
+  <div className='card padding-0'>
+    <Layout
+      variant='internal'
+      items={[
+        {
+          items: [
+            {
+              title: 'Översikt',
+              href: '#',
+              icon: House,
+            },
+          ],
+        },
+        {
+          title: 'Ansökan',
+          items: [
+            {
+              title: 'Skapa ansökan',
+              href: '#',
+              icon: Plus,
+            },
+            {
+              title: 'Beslut',
+              href: '#',
+              icon: Gavel,
+            },
+          ],
+        },
+        {
+          title: 'Kort och konto',
+          items: [
+            {
+              title: 'LMA-kort',
+              href: '#',
+              icon: Calendar,
+            },
+            {
+              title: 'Avvikelser',
+              href: '#',
+              icon: ClipboardList,
+              hasBadge: true,
+            },
+          ],
+        },
+      ]}
+      title='Skapa ansökningar'
+      user={{ name: 'Namn Namnsson', title: 'Roll eller behörighet' }}
+      app={{ name: 'Namn på applikationen' }}
+      headerChildren={
+        <LinkButton
+          variant='tertiary'
+          target='_blank'
+        >
+          Öppna annan tjänst
+        </LinkButton>
+      }
+      {...props}
     >
-      Din applikation
-    </div>
-  </Layout>
+      <div
+        style={{
+          background: semantic.layer02,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          border: `dotted 2px ${semantic.borderSubtle}`,
+          color: semantic.textPrimary,
+        }}
+      >
+        Din applikation
+      </div>
+    </Layout>
+  </div>
 )

--- a/apps/docs/src/components/examples/layout/LayoutExamples.tsx
+++ b/apps/docs/src/components/examples/layout/LayoutExamples.tsx
@@ -1,80 +1,30 @@
 import React from 'react'
-import { Layout, LinkButton, MidasLayout } from '@midas-ds/components'
-import { semantic } from '@midas-ds/components/theme'
-import { Calendar, House, Plus, Gavel, ClipboardList } from 'lucide-react'
+import useBaseUrl from '@docusaurus/useBaseUrl'
 
-export const BasicExample: React.FC<Partial<MidasLayout>> = props => (
-  <div className='card padding-0'>
-    <Layout
-      variant='internal'
-      items={[
-        {
-          items: [
-            {
-              title: 'Översikt',
-              href: '#',
-              icon: House,
-            },
-          ],
-        },
-        {
-          title: 'Ansökan',
-          items: [
-            {
-              title: 'Skapa ansökan',
-              href: '#',
-              icon: Plus,
-            },
-            {
-              title: 'Beslut',
-              href: '#',
-              icon: Gavel,
-            },
-          ],
-        },
-        {
-          title: 'Kort och konto',
-          items: [
-            {
-              title: 'LMA-kort',
-              href: '#',
-              icon: Calendar,
-            },
-            {
-              title: 'Avvikelser',
-              href: '#',
-              icon: ClipboardList,
-              hasBadge: true,
-            },
-          ],
-        },
-      ]}
-      title='Skapa ansökningar'
-      user={{ name: 'Namn Namnsson', title: 'Roll eller behörighet' }}
-      app={{ name: 'Namn på applikationen' }}
-      headerChildren={
-        <LinkButton
-          variant='tertiary'
-          target='_blank'
-        >
-          Öppna annan tjänst
-        </LinkButton>
-      }
-      {...props}
-    >
-      <div
-        style={{
-          background: semantic.layer02,
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          height: '100vh',
-          border: `dotted 2px ${semantic.borderSubtle}`,
-          color: semantic.textPrimary,
-        }}
-      >
-        Din applikation
-      </div>
-    </Layout>
-  </div>
-)
+export const BasicExample: React.FC = props => {
+  const layoutExampleUrl = useBaseUrl('/layout-examples/layout')
+
+  return (
+    <div className='card'>
+      <iframe
+        title='Layout example'
+        style={{ width: '100%', height: 500, border: 'none' }}
+        src={layoutExampleUrl}
+      />
+    </div>
+  )
+}
+
+export const ExternalExample: React.FC = props => {
+  const layoutExampleUrl = useBaseUrl('/layout-examples/layout-external')
+
+  return (
+    <div className='card'>
+      <iframe
+        title='Layout external example'
+        style={{ width: '100%', height: 500, border: 'none' }}
+        src={layoutExampleUrl}
+      />
+    </div>
+  )
+}

--- a/apps/docs/src/components/examples/link-button/LinkButtonExamples.tsx
+++ b/apps/docs/src/components/examples/link-button/LinkButtonExamples.tsx
@@ -2,7 +2,10 @@ import { LinkButton } from '@midas-ds/components'
 
 export const Example = () => {
   return (
-    <>
+    <div
+      className='card'
+      style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}
+    >
       <LinkButton href='#'>Starta tjänst</LinkButton>
       <LinkButton
         variant='secondary'
@@ -16,6 +19,6 @@ export const Example = () => {
       >
         Starta tjänst
       </LinkButton>
-    </>
+    </div>
   )
 }

--- a/apps/docs/src/components/examples/table/TableExamples.tsx
+++ b/apps/docs/src/components/examples/table/TableExamples.tsx
@@ -34,46 +34,50 @@ const rows = [
 ]
 
 export const BasicExample = () => (
-  <Table aria-label='Fruit'>
-    <TableHeader>
-      <Column isRowHeader>Name</Column>
-      <Column>Description</Column>
-    </TableHeader>
-    <TableBody>
-      <Row>
-        <Cell>Banana</Cell>
-        <Cell>A yellow fruit</Cell>
-      </Row>
-      <Row>
-        <Cell>Pear</Cell>
-        <Cell>Usually green</Cell>
-      </Row>
-    </TableBody>
-  </Table>
+  <div className='card'>
+    <Table aria-label='Fruit'>
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+        <Column>Description</Column>
+      </TableHeader>
+      <TableBody>
+        <Row>
+          <Cell>Banana</Cell>
+          <Cell>A yellow fruit</Cell>
+        </Row>
+        <Row>
+          <Cell>Pear</Cell>
+          <Cell>Usually green</Cell>
+        </Row>
+      </TableBody>
+    </Table>
+  </div>
 )
 
 export const FullExample: React.FC<TableProps> = props => (
-  <Table
-    aria-label='Fruit'
-    {...props}
-  >
-    <TableHeader columns={columns}>
-      {column => {
-        return <Column>{column.name}</Column>
-      }}
-    </TableHeader>
-    <TableBody items={rows}>
-      {item => {
-        return (
-          <Row columns={columns}>
-            {column => {
-              return <Cell>{item[column.id]}</Cell>
-            }}
-          </Row>
-        )
-      }}
-    </TableBody>
-  </Table>
+  <div className='card'>
+    <Table
+      aria-label='Fruit'
+      {...props}
+    >
+      <TableHeader columns={columns}>
+        {column => {
+          return <Column>{column.name}</Column>
+        }}
+      </TableHeader>
+      <TableBody items={rows}>
+        {item => {
+          return (
+            <Row columns={columns}>
+              {column => {
+                return <Cell>{item[column.id]}</Cell>
+              }}
+            </Row>
+          )
+        }}
+      </TableBody>
+    </Table>
+  </div>
 )
 
 export const ControlledExample: React.FC<TableProps> = props => {

--- a/apps/docs/src/components/examples/tooltip/TooltipExamples.tsx
+++ b/apps/docs/src/components/examples/tooltip/TooltipExamples.tsx
@@ -6,7 +6,7 @@ import { Focusable } from 'react-aria-components'
 export const TooltipDelay = () => {
   return (
     <div
-      className={'card'}
+      className='card'
       style={{
         display: 'flex',
         flexDirection: 'row',
@@ -29,7 +29,7 @@ export const TooltipDelay = () => {
 export const TooltipPlacement = () => {
   return (
     <div
-      className={'card'}
+      className='card'
       style={{
         display: 'flex',
         alignItems: 'center',

--- a/apps/docs/src/components/getComponentMetaData.tsx
+++ b/apps/docs/src/components/getComponentMetaData.tsx
@@ -20,12 +20,18 @@ export const ComponentHeader = ({
       : baseUrl(`/storybook/?path=/docs/components-${name.toLowerCase()}--docs`)
 
   return (
-    <section style={{ marginBottom: 32, marginTop: -20 }}>
+    <section className='component-header'>
       <Flex fluid={true}>
-        <FlexItem className='friendlyName'>
+        <FlexItem
+          col='auto'
+          className='friendlyName'
+        >
           <b>{friendlyName}</b>
         </FlexItem>
-        <FlexItem col='auto'>
+        <FlexItem
+          col='auto'
+          className='headerLink'
+        >
           <LinkButton
             href={storybookLink}
             variant='tertiary'
@@ -35,7 +41,10 @@ export const ComponentHeader = ({
             Storybook
           </LinkButton>
         </FlexItem>
-        <FlexItem col='auto'>
+        <FlexItem
+          col='auto'
+          className='headerLink'
+        >
           {overrideHeadlessLink !== '' && (
             <LinkButton
               href={

--- a/apps/docs/src/components/propsTable.tsx
+++ b/apps/docs/src/components/propsTable.tsx
@@ -149,13 +149,14 @@ export const PropTable = ({ name, defaultOpen = true }) => {
   return (
     <Accordion
       className={styles.accordion}
-      type='multiple'
+      allowsMultipleExpanded
       defaultExpandedKeys={defaultOpen ? ['props'] : []}
     >
       {Object.getOwnPropertyNames(rest).length !== 0 && (
         <AccordionItem
           id='props'
           title='Props'
+          className={styles.accordionItem}
         >
           <Table propGroup={rest} />
         </AccordionItem>
@@ -164,6 +165,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
         <AccordionItem
           id='events'
           title='Events'
+          className={styles.accordionItem}
         >
           <Table
             propGroup={events}
@@ -175,6 +177,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
         <AccordionItem
           id='accessibility'
           title='Tillgänglighet'
+          className={styles.accordionItem}
         >
           <Table
             propGroup={accessibility}

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -88,6 +88,7 @@
   --ifm-link-color: #4289ad;
   --ifm-link-hover-color: #5897b8;
   --ifm-card-background-color: #000;
+  --ifm-code-background: #1e1e1e;
 }
 
 .theme-code-block {
@@ -102,7 +103,7 @@
   border-radius: 0;
 }
 
-.theme-code-block:has(~ .card) {
+.theme-code-block:has(+ .card) {
   margin-bottom: 0;
   border-bottom-width: 0;
 }

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -87,6 +87,14 @@
   --search-local-highlight-color: #25607f;
   --ifm-link-color: #4289ad;
   --ifm-link-hover-color: #5897b8;
+  --ifm-card-background-color: #000;
+}
+
+.theme-code-block {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: none !important;
+  max-height: 600px;
+  overflow-y: auto;
 }
 
 .prism-code {
@@ -96,16 +104,25 @@
 
 .theme-code-block:has(~ .card) {
   margin-bottom: 0;
+  border-bottom-width: 0;
+}
+
+.theme-code-block:has(+ .theme-code-block) {
+  margin-bottom: var(--ifm-leading);
 }
 
 .card {
   padding: 1.5rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
-}
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: none !important;
+  max-height: 600px;
+  overflow-y: auto;
 
-.theme-code-block:has(+ .theme-code-block) {
-  margin-bottom: var(--ifm-leading);
+  &.padding-0 {
+    padding: 0;
+  }
 }
 
 .card-image {

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -112,7 +112,8 @@
 }
 
 .card {
-  padding: 1.5rem;
+  position: relative;
+  padding: 1rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
   border: 1px solid var(--ifm-color-emphasis-200);
@@ -297,6 +298,11 @@ mark {
   border-radius: 0;
 }
 
+.component-header {
+  margin-bottom: 32px;
+  margin-top: -20px;
+}
+
 [class^='searchBar_'] [class^='dropdownMenu_'],
 [class^='searchBar_'] [class^='dropdownMenu_'] [class^='suggestion_'],
 [class^='searchQueryInput_'] {
@@ -340,12 +346,6 @@ mark {
 @media (max-width: 996px) {
   .navbar__items {
     gap: 1.5rem;
-  }
-}
-/* stylelint-disable-next-line media-feature-range-notation */
-@media (max-width: 996px) {
-  .navbar__items {
-    gap: 1.5rem;
 
     .navbar__toggle {
       margin: 0;
@@ -354,6 +354,10 @@ mark {
     [class^='navbarSearchContainer_'] {
       position: relative;
     }
+  }
+
+  .component-header .headerLink {
+    width: unset;
   }
 }
 

--- a/apps/docs/src/css/propstable.module.css
+++ b/apps/docs/src/css/propstable.module.css
@@ -10,6 +10,7 @@
   font-family: 'Inter', sans-serif;
   border-collapse: collapse;
   width: 100%;
+
   tr {
     word-break: break-all;
   }
@@ -18,6 +19,7 @@
     min-width: 6rem;
     vertical-align: top;
   }
+
   thead tr th:first-child,
   tbody tr td:first-child {
     width: 25%;
@@ -36,4 +38,6 @@
   padding: 0;
 }
 
-
+.accordionItem div[role='group'] {
+  overflow-x: auto;
+}

--- a/apps/docs/src/pages/layout-examples/layout-external.tsx
+++ b/apps/docs/src/pages/layout-examples/layout-external.tsx
@@ -1,0 +1,108 @@
+import { Layout, LinkButton } from '@midas-ds/components'
+import { semantic } from '@midas-ds/components/theme'
+import {
+  Calendar,
+  House,
+  Plus,
+  Gavel,
+  ClipboardList,
+  Search,
+  User,
+} from 'lucide-react'
+
+export default function LayoutExample() {
+  return (
+    <Layout
+      variant='external'
+      items={[
+        {
+          items: [
+            {
+              title: 'Hem',
+              href: '#',
+              icon: House,
+              active: true,
+            },
+            {
+              title: 'Ansökan',
+              href: '#',
+              icon: Search,
+            },
+            {
+              title: 'Boka',
+              href: '#',
+              icon: Calendar,
+              hasBadge: true,
+            },
+            {
+              title: 'Profil',
+              href: '#',
+              icon: User,
+            },
+            {
+              title: 'Kontakt',
+              href: '#',
+              icon: Plus,
+            },
+          ],
+        },
+        {
+          title: 'Ansökan',
+          items: [
+            {
+              title: 'Skapa ansökan',
+              href: '#',
+              icon: Plus,
+            },
+            {
+              title: 'Beslut',
+              href: '#',
+              icon: Gavel,
+            },
+          ],
+        },
+        {
+          title: 'Kort och konto',
+          items: [
+            {
+              title: 'LMA-kort',
+              href: '#',
+              icon: Calendar,
+            },
+            {
+              title: 'Avvikelser',
+              href: '#',
+              icon: ClipboardList,
+              hasBadge: true,
+            },
+          ],
+        },
+      ]}
+      title='Skapa ansökningar'
+      user={{ name: 'Namn Namnsson', title: 'Roll eller behörighet' }}
+      app={{ name: 'Namn på applikationen' }}
+      headerChildren={
+        <LinkButton
+          variant='tertiary'
+          target='_blank'
+        >
+          Öppna annan tjänst
+        </LinkButton>
+      }
+    >
+      <div
+        style={{
+          background: semantic.layer02,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          border: `dotted 2px ${semantic.borderSubtle}`,
+          color: semantic.textPrimary,
+        }}
+      >
+        Din applikation
+      </div>
+    </Layout>
+  )
+}

--- a/apps/docs/src/pages/layout-examples/layout.tsx
+++ b/apps/docs/src/pages/layout-examples/layout.tsx
@@ -1,0 +1,78 @@
+import { Layout, LinkButton } from '@midas-ds/components'
+import { semantic } from '@midas-ds/components/theme'
+import { Calendar, House, Plus, Gavel, ClipboardList } from 'lucide-react'
+
+export default function LayoutExample() {
+  return (
+    <Layout
+      variant='internal'
+      items={[
+        {
+          items: [
+            {
+              title: 'Översikt',
+              href: '#',
+              icon: House,
+            },
+          ],
+        },
+        {
+          title: 'Ansökan',
+          items: [
+            {
+              title: 'Skapa ansökan',
+              href: '#',
+              icon: Plus,
+            },
+            {
+              title: 'Beslut',
+              href: '#',
+              icon: Gavel,
+            },
+          ],
+        },
+        {
+          title: 'Kort och konto',
+          items: [
+            {
+              title: 'LMA-kort',
+              href: '#',
+              icon: Calendar,
+            },
+            {
+              title: 'Avvikelser',
+              href: '#',
+              icon: ClipboardList,
+              hasBadge: true,
+            },
+          ],
+        },
+      ]}
+      title='Skapa ansökningar'
+      user={{ name: 'Namn Namnsson', title: 'Roll eller behörighet' }}
+      app={{ name: 'Namn på applikationen' }}
+      headerChildren={
+        <LinkButton
+          variant='tertiary'
+          target='_blank'
+        >
+          Öppna annan tjänst
+        </LinkButton>
+      }
+    >
+      <div
+        style={{
+          background: semantic.layer02,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          border: `dotted 2px ${semantic.borderSubtle}`,
+          color: semantic.textPrimary,
+        }}
+      >
+        Din applikation
+      </div>
+    </Layout>
+  )
+}

--- a/packages/components/src/flex/FlexItem.tsx
+++ b/packages/components/src/flex/FlexItem.tsx
@@ -81,13 +81,13 @@ export const FlexItem: React.FC<FlexItemProps> = ({
 
   return (
     <div
+      {...props}
       className={clsx(
         styles.col,
         styles[colClass],
         styles[offsetClass],
-        props.className
+        props.className,
       )}
-      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
## Description

- Improve the overall style of previews

## Changes

- ALL examples now use card for better framing
- Adjusted styles to CodeBlock and Preview cards
- Clearer borders to frame in the examples and contain them to the code blocks
- Darker background on preview in dark mode since some examples use layer 01
- Added max-height + scroll to both code and preview
- Fixed Storybook and React Aria-links in mobile
- Changed padding on cards for a tighter look, especially on mobile
- Fix props table overflow in mobile
- Load Layout examples as iframe (like storybook does) to properly contain examples to card

## Additional information
DS-932, DS-1008, #329 

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
