### PR TITLE
fix: 🐛 replace special characters in chromatic branch names

### DIFF
--- a/.github/workflows/documentation-pr.yml
+++ b/.github/workflows/documentation-pr.yml
@@ -36,9 +36,9 @@ jobs:
         if: github.event.action != 'closed'
         run: npm ci
 
-      - name: Lint and build website
+      - name: Lint, test and build website
         if: github.event.action != 'closed'
-        run: npx nx run-many -t lint,build --projects=docs
+        run: npx nx run-many -t lint,test,build --projects=docs
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type * as Preset from '@docusaurus/preset-classic'
 import { themes as prismThemes } from 'prism-react-renderer'
 import path from 'path'
 import fs from 'fs'
+import { getBranchUrl } from './src/utils/chromatic'
 
 const packagesDir = path.resolve(__dirname, '../../packages')
 
@@ -44,12 +45,7 @@ const config: Config = {
     locales: ['sv'],
   },
   customFields: {
-    currentChromaticBranchUrl: process.env.GITHUB_HEAD_REF?.replace(
-      /-{2,}/g,
-      '-',
-    )
-      .replace(/[/_]/g, '-')
-      .slice(0, 37),
+    currentChromaticBranchUrl: getBranchUrl(process.env.GITHUB_HEAD_REF),
   },
   plugins: [
     [

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -44,7 +44,12 @@ const config: Config = {
     locales: ['sv'],
   },
   customFields: {
-    currentChromaticBranchUrl: process.env.GITHUB_HEAD_REF?.replace(/\//g, '-'),
+    currentChromaticBranchUrl: process.env.GITHUB_HEAD_REF?.replace(
+      /-{2,}/g,
+      '-',
+    )
+      .replace(/[/_]/g, '-')
+      .slice(0, 37),
   },
   plugins: [
     [

--- a/apps/docs/jest.config.js
+++ b/apps/docs/jest.config.js
@@ -1,0 +1,9 @@
+export default {
+  displayName: 'docs',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+}

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -30,6 +30,12 @@
       "options": {
         "lintFilePatterns": ["apps/docs/**/*.{ts,tsx,js,jsx,mdx}"]
       }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "apps/docs/jest.config.js"
+      }
     }
   },
   "tags": ["docs", "apps"]

--- a/apps/docs/src/utils/chromatic.test.ts
+++ b/apps/docs/src/utils/chromatic.test.ts
@@ -1,0 +1,18 @@
+import { getBranchUrl } from './chromatic'
+
+test('getBranchUrl', () => {
+  const testCases = [
+    ['feature/fix-bug', 'feature-fix-bug'],
+    ['feature----fix-bug', 'feature-fix-bug'],
+    ['feature/DS-1234_component-x-y-z', 'feature-ds-1234-component-x-y-z'],
+    ['feature---dashboard/fix-bug', 'feature-dashboard-fix-bug'],
+    [
+      'thisisareallysuperduperextralongbranchname',
+      'thisisareallysuperduperextralongbranc',
+    ],
+  ]
+
+  testCases.forEach(([input, expected]) => {
+    expect(getBranchUrl(input)).toBe(expected)
+  })
+})

--- a/apps/docs/src/utils/chromatic.ts
+++ b/apps/docs/src/utils/chromatic.ts
@@ -1,0 +1,7 @@
+// https://www.chromatic.com/docs/permalinks/#branches-that-contain-special-characters-or-are-too-long
+export const getBranchUrl = (branchName?: string) =>
+  branchName
+    ?.replace(/-{2,}/g, '-')
+    .replace(/[/_]/g, '-')
+    .slice(0, 37)
+    .toLocaleLowerCase()


### PR DESCRIPTION
## Description

chromatic doesnt allow all characters in branch names

## Changes

- add test foundation for docs
- replace underscores, multiple dashes and slashes with a single dash in chromatic branch url

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
