### PR TITLE
chore: ⬇️ remove max-height from card-guidelines

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -92,7 +92,7 @@
 }
 
 .theme-code-block {
-/*  border: 1px solid var(--ifm-color-emphasis-200);*/
+  /*  border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
   max-height: 600px;
   overflow-y: auto;
@@ -117,7 +117,8 @@
   padding: 1rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
-/*  border: 1px solid var(--ifm-color-emphasis-200);*/
+
+  /*  border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
   max-height: 600px;
   overflow-y: auto;
@@ -142,10 +143,9 @@ table td {
   padding: 1rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
-  border: 1px solid var(--ifm-color-emphasis-200);
+
+  /* border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
-  max-height: 600px;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -92,7 +92,6 @@
 }
 
 .theme-code-block {
-  /*  border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
   max-height: 600px;
   overflow-y: auto;
@@ -117,8 +116,6 @@
   padding: 1rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
-
-  /*  border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
   max-height: 600px;
   overflow-y: auto;
@@ -143,8 +140,6 @@ table td {
   padding: 1rem;
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
-
-  /* border: 1px solid var(--ifm-color-emphasis-200); */
   box-shadow: none !important;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description

Removes max-height constraint from card-guidelines which is used on the language page

## Changes

Removed `max-height`

## Additional Information

The constraint works fine for our component pages but isn't neccessary on the language page, it just looks wierd that you have to scroll an example

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
