### PR TITLE
fix(calendar): 🐛 add cursor: not-allowed on disabled dates

### DIFF
--- a/packages/components/src/calendar/Calendar.module.css
+++ b/packages/components/src/calendar/Calendar.module.css
@@ -61,7 +61,6 @@
   }
 
   &[data-disabled='true'],
-  &[data-disabled='true'] .day,
   &[data-disabled='true'] button {
     cursor: not-allowed;
   }
@@ -133,6 +132,7 @@
 
   &[data-disabled] {
     color: --text-disabled;
+    cursor: not-allowed;
   }
 
   &.today {

--- a/packages/components/src/calendar/Calendar.stories.tsx
+++ b/packages/components/src/calendar/Calendar.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Calendar } from './Calendar'
 import { DateValue } from 'react-aria-components'
 import { useState } from 'react'
-import { expect, userEvent } from '@storybook/test'
+import { expect, userEvent, within } from '@storybook/test'
 import { today, getLocalTimeZone } from '@internationalized/date'
+import { mockedNow } from '../utils/storybook'
 
 type Story = StoryObj<typeof Calendar>
 
@@ -41,6 +42,28 @@ export const KeyboardTest: Story = {
             name: today(getLocalTimeZone()).add({ days: 1 }).day.toString(),
           }),
         ).toHaveAttribute('aria-selected', 'true')
+      },
+    )
+  },
+}
+
+export const DS1141: Story = {
+  tags: ['!dev', '!autodocs'],
+  args: {
+    minValue: mockedNow,
+  },
+  play: async ({ canvas, step }) => {
+    await step(
+      'it should show a "not-allowed" cursor when hovering disabled dates',
+      async () => {
+        const yesterdayButton = within(
+          canvas.getByRole('gridcell', {
+            name: `${mockedNow.day - 1}`,
+          }),
+        ).getByRole('button')
+
+        await userEvent.hover(yesterdayButton)
+        await expect(yesterdayButton).toHaveStyle({ cursor: 'not-allowed' })
       },
     )
   },


### PR DESCRIPTION
## Description

Reported by a fellow co-worker in the support channel

## Changes

- Apply `cursor: not-allowed;` to disabled dates.

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
