### PR TITLE
docs: render jsdoc links as markdown in component api description field

### DIFF
--- a/apps/docs/src/components/PropsTable.tsx
+++ b/apps/docs/src/components/PropsTable.tsx
@@ -13,6 +13,7 @@ import {
   Popover,
   Pressable,
 } from 'react-aria-components'
+import {jsdocLinkToMarkdown} from '@site/src/utils/jsdocLinkToMarkdown'
 
 export const DisplayCompositeTypes = ({ props }: Props) => {
   switch (props.type.name) {
@@ -157,7 +158,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
                   <td />
                 )}
                 <td data-title='Description'>
-                  <ReactMarkdown>{props[key].description}</ReactMarkdown>
+                  <ReactMarkdown>{jsdocLinkToMarkdown(props[key].description)}</ReactMarkdown>
                 </td>
               </tr>
             ))}

--- a/apps/docs/src/utils/jsdocLinkToMarkdown.ts
+++ b/apps/docs/src/utils/jsdocLinkToMarkdown.ts
@@ -1,0 +1,17 @@
+export const jsdocLinkToMarkdown = (jsdocLink: string) => {
+  if (!jsdocLink.includes('@link')) {
+    return jsdocLink
+  }
+  const textBefore = jsdocLink
+    .substring(0, jsdocLink.indexOf('{@link'))
+    .replace(/@\S*/g, '')
+  const url = jsdocLink.substring(
+    jsdocLink.indexOf('http'),
+    jsdocLink.lastIndexOf('/'),
+  )
+  const linkText = jsdocLink.substring(
+    jsdocLink.lastIndexOf('/') + 2,
+    jsdocLink.lastIndexOf('}'),
+  )
+  return `${textBefore}. See [${linkText}](${url}).`
+}


### PR DESCRIPTION
## Description

jsdoc links was not rendered as links in component api.

## How to check

Button has a field for Icon with a link to Lucide. This should now be a valid markdown link 

