### PR TITLE
Feat/link color tokens

### DIFF
--- a/apps/docs/blog/releases/10.0.0/index.mdx
+++ b/apps/docs/blog/releases/10.0.0/index.mdx
@@ -71,13 +71,16 @@ Tokens `borderInvalid` ersätts med `supportBorderWarning` och `textInvalid` ers
 
 ```
 
-Tokens `blue140` (`#25607F`) byter namn till `blue130` samt `blue170` (`#143C50`) byter namn till `blue150`
+Tokens `blue140` (`#25607F`) byter namn till `blue130` samt `blue170` (`#143C50`) byter namn till `blue150`, `purple140`
+byter namn till `purple110`.
 
 ```diff
 - blue140
 + blue130
 - blue170
-- blue150
++ blue150
+- purple140
++ purple110
 ```
 
 ### useMessageFormatter

--- a/apps/docs/blog/releases/10.0.0/index.mdx
+++ b/apps/docs/blog/releases/10.0.0/index.mdx
@@ -71,6 +71,15 @@ Tokens `borderInvalid` ersätts med `supportBorderWarning` och `textInvalid` ers
 
 ```
 
+Tokens `blue140` (`#25607F`) byter namn till `blue130` samt `blue170` (`#143C50`) byter namn till `blue150`
+
+```diff
+- blue140
++ blue130
+- blue170
+- blue150
+```
+
 ### useMessageFormatter
 
 `useMessageFormatter` försvinner till förmån för `useLocalizedStringFormatter` eftersom den är deprecated hos React Aria.

--- a/apps/docs/docs/basics/tokens.mdx
+++ b/apps/docs/docs/basics/tokens.mdx
@@ -157,7 +157,7 @@ I ljust läge växlar färgerna mellan vitt och grått för varje lager medan va
   />
   <Token
     token='borderDisabled'
-    desc='Kantlinke för disabled state'
+    desc='Kantlinje för disabled state'
   />
 </TokenGroup>
 

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -28,7 +28,9 @@
 @value --blue-10: #eaf2f6;
 @value --blue-20: #d5e5ed;
 @value --blue-40: #abcbdb;
+@value --blue-50: #94BCD1;
 @value --blue-60: #82b0c9;
+@value --blue-70:#6CA3C0;
 @value --blue-80: #5897b8;
 @value --blue-90: #4289ad;
 @value --blue-100: #2e7ca5;

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -32,10 +32,12 @@
 @value --blue-80: #5897b8;
 @value --blue-90: #4289ad;
 @value --blue-100: #2e7ca5;
-@value --blue-140: #25607f;
-@value --blue-170: #143c50;
+@value --blue-110: #2C7399;
+@value --blue-120:  #29698C;
+@value --blue-130: #25607f;
+@value --blue-150: #143c50;
 @value --purple-80: #b46ab4;
-@value --purple-140: #954b95;
+@value --purple-110: #954b95;
 @value --red-100: #b90835;
 @value --signal-blue-10: #eaf2f6;
 @value --signal-blue-100: #0066cc;
@@ -180,7 +182,7 @@
 @value --border-primary: light-dark(--gray-200, --gray-10);
 @value --border-secondary: light-dark(--gray-110, --gray-90);
 @value --border-subtle: light-dark(--gray-50, --gray-160);
-@value --border-tertiary: light-dark(--blue-170, --blue-100);
+@value --border-tertiary: light-dark(--blue-150, --blue-100);
 @value --border-disabled: light-dark(--gray-50, --gray-140);
 
 /* Field 01 */
@@ -200,7 +202,7 @@
 /* Icon */
 @value --icon-primary: light-dark(--gray-200, --gray-10);
 @value --icon-secondary: light-dark(--gray-140, --gray-70);
-@value --icon-tertiary: light-dark(--blue-170, --gray-10);
+@value --icon-tertiary: light-dark(--blue-150, --gray-10);
 @value --icon-inverse: light-dark(--white, --gray-200);
 @value --icon-on-color: light-dark(--white, --white);
 @value --icon-disabled: light-dark(--gray-50, --gray-140);
@@ -210,10 +212,10 @@
 @value --icon-important: light-dark(--signal-yellow-100, --signal-yellow-100);
 
 /* Link */
-@value --link-enabled: light-dark(--blue-100, --blue-90);
-@value --link-hover: light-dark(--blue-170, --blue-80);
-@value --link-pressed: light-dark(--gray-200, --blue-60);
-@value --link-visited: light-dark(--purple-140, --purple-80);
+@value --link-enabled: light-dark(--blue-120, --blue-70);
+@value --link-hover: light-dark(--blue-150, --blue-50);
+@value --link-pressed: light-dark(--gray-200, --blue-40);
+@value --link-visited: light-dark(--purple-110, --purple-80);
 
 /* Support */
 @value --support-border-success: light-dark(--signal-green-100, --signal-green-100);
@@ -230,7 +232,7 @@
 /* Text */
 @value --text-primary: light-dark(--gray-200, --gray-10);
 @value --text-secondary: light-dark(--gray-140, --gray-70);
-@value --text-tertiary: light-dark(--blue-170, --gray-10);
+@value --text-tertiary: light-dark(--blue-150, --gray-10);
 @value --text-on-color: light-dark(--white, --white);
 @value --text-inverse: light-dark(--gray-10, --gray-200);
 @value --text-disabled: light-dark(--gray-50, --gray-140);
@@ -238,9 +240,9 @@
 @value --text-placeholder: light-dark(--gray-70, --gray-140);
 
 /* Button */
-@value --button-background-primary: light-dark(--blue-170, --blue-100);
-@value --button-background-primary-hover: light-dark(--blue-140, --blue-140);
-@value --button-background-primary-active: light-dark(--blue-100, --blue-170);
+@value --button-background-primary: light-dark(--blue-150, --blue-100);
+@value --button-background-primary-hover: light-dark(--blue-130, --blue-140);
+@value --button-background-primary-active: light-dark(--blue-100, --blue-150);
 @value --button-background-secondary: light-dark(--white, --gray-200);
 @value --button-background-secondary-hover: light-dark(--white-hover, --gray-190);
 @value --button-background-secondary-active: light-dark(--gray-30, --gray-180);

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -29,7 +29,9 @@ export const baseColors = {
   blue10: '#eaf2f6',
   blue20: '#d5e5ed',
   blue40: '#abcbdb',
+  blue50: '#94BCD1',
   blue60: '#82b0c9',
+  blue70: '#6CA3C0',
   blue80: '#5897b8',
   blue90: '#4289ad',
   blue100: '#2e7ca5',
@@ -203,9 +205,9 @@ export const semantic = {
   iconWarning: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed100})`,
   iconImportant: `light-dark(${baseColors.signalYellow100}, ${baseColors.signalYellow100})`,
 
-  linkEnabled: `light-dark(${baseColors.blue100}, ${baseColors.blue90})`,
-  linkHover: `light-dark(${baseColors.blue150}, ${baseColors.blue80})`,
-  linkPressed: `light-dark(${baseColors.gray200}, ${baseColors.blue60})`,
+  linkEnabled: `light-dark(${baseColors.blue120}, ${baseColors.blue70})`,
+  linkHover: `light-dark(${baseColors.blue150}, ${baseColors.blue50})`,
+  linkPressed: `light-dark(${baseColors.gray200}, ${baseColors.blue40})`,
   linkVisited: `light-dark(${baseColors.purple110}, ${baseColors.purple80})`,
 
   supportBorderSuccess: `light-dark(${baseColors.signalGreen100}, ${baseColors.signalGreen100})`,

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -33,11 +33,13 @@ export const baseColors = {
   blue80: '#5897b8',
   blue90: '#4289ad',
   blue100: '#2e7ca5',
-  blue140: '#25607f',
-  blue170: '#143c50',
+  blue110: '#2C7399',
+  blue120: '#29698C',
+  blue130: '#25607f',
+  blue150: '#143c50',
 
   purple80: '#b46ab4',
-  purple140: '#954b95',
+  purple110: '#954b95',
   red100: '#b90835',
 
   signalBlue10: '#eaf2f6',
@@ -175,7 +177,7 @@ export const semantic = {
   borderPrimary: `light-dark(${baseColors.gray200}, ${baseColors.gray10})`,
   borderSecondary: `light-dark(${baseColors.gray110}, ${baseColors.gray90})`,
   borderSubtle: `light-dark(${baseColors.gray50}, ${baseColors.gray160})`,
-  borderTertiary: `light-dark(${baseColors.blue170}, ${baseColors.blue100})`,
+  borderTertiary: `light-dark(${baseColors.blue150}, ${baseColors.blue100})`,
 
   borderDisabled: `light-dark(${baseColors.gray50}, ${baseColors.gray140})`,
 
@@ -192,7 +194,7 @@ export const semantic = {
 
   iconPrimary: `light-dark(${baseColors.gray200}, ${baseColors.gray10})`,
   iconSecondary: `light-dark(${baseColors.gray140}, ${baseColors.gray70})`,
-  iconTertiary: `light-dark(${baseColors.blue170}, ${baseColors.gray10})`,
+  iconTertiary: `light-dark(${baseColors.blue150}, ${baseColors.gray10})`,
   iconInverse: `light-dark(${baseColors.white}, ${baseColors.gray200})`,
   iconOnColor: `light-dark(${baseColors.white}, ${baseColors.white})`,
   iconDisabled: `light-dark(${baseColors.gray50}, ${baseColors.gray140})`,
@@ -202,9 +204,9 @@ export const semantic = {
   iconImportant: `light-dark(${baseColors.signalYellow100}, ${baseColors.signalYellow100})`,
 
   linkEnabled: `light-dark(${baseColors.blue100}, ${baseColors.blue90})`,
-  linkHover: `light-dark(${baseColors.blue170}, ${baseColors.blue80})`,
+  linkHover: `light-dark(${baseColors.blue150}, ${baseColors.blue80})`,
   linkPressed: `light-dark(${baseColors.gray200}, ${baseColors.blue60})`,
-  linkVisited: `light-dark(${baseColors.purple140}, ${baseColors.purple80})`,
+  linkVisited: `light-dark(${baseColors.purple110}, ${baseColors.purple80})`,
 
   supportBorderSuccess: `light-dark(${baseColors.signalGreen100}, ${baseColors.signalGreen100})`,
   supportBorderInfo: `light-dark(${baseColors.signalBlue100}, ${baseColors.signalBlue100})`,
@@ -219,16 +221,16 @@ export const semantic = {
 
   textPrimary: `light-dark(${baseColors.gray200}, ${baseColors.gray10})`,
   textSecondary: `light-dark(${baseColors.gray140}, ${baseColors.gray70})`,
-  textTertiary: `light-dark(${baseColors.blue170}, ${baseColors.gray10})`,
+  textTertiary: `light-dark(${baseColors.blue150}, ${baseColors.gray10})`,
   textOnColor: `light-dark(${baseColors.white}, ${baseColors.white})`,
   textInverse: `light-dark(${baseColors.gray10}, ${baseColors.gray200})`,
   textDisabled: `light-dark(${baseColors.gray50}, ${baseColors.gray140})`,
   textWarning: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed80})`,
   textPlaceholder: `light-dark(${baseColors.gray70}, ${baseColors.gray140})`,
 
-  buttonBackgroundPrimary: `light-dark(${baseColors.blue170}, ${baseColors.blue100})`,
-  buttonBackgroundPrimaryHover: `light-dark(${baseColors.blue140}, ${baseColors.blue140})`,
-  buttonBackgroundPrimaryActive: `light-dark(${baseColors.blue100}, ${baseColors.blue170})`,
+  buttonBackgroundPrimary: `light-dark(${baseColors.blue150}, ${baseColors.blue100})`,
+  buttonBackgroundPrimaryHover: `light-dark(${baseColors.blue130}, ${baseColors.blue130})`,
+  buttonBackgroundPrimaryActive: `light-dark(${baseColors.blue100}, ${baseColors.blue150})`,
   buttonBackgroundSecondary: `light-dark(${baseColors.white}, ${baseColors.gray200})`,
   buttonBackgroundSecondaryHover: `light-dark(${baseColors.whiteHover}, ${baseColors.gray190})`,
   buttonBackgroundSecondaryActive: `light-dark(${baseColors.gray30}, ${baseColors.gray180})`,
@@ -239,7 +241,7 @@ export const semantic = {
   buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed150})`,
   buttonBackgroundDisabled: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
   buttonBackgroundSkeleton: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
-  buttonBorderSecondary: `light-dark(${baseColors.blue170}, ${baseColors.gray10})`,
+  buttonBorderSecondary: `light-dark(${baseColors.blue150}, ${baseColors.gray10})`,
 
   logoPrimary: `light-dark(${baseColors.red100}, ${baseColors.white})`,
 


### PR DESCRIPTION
## Description

Update tokens according to:

> Färgen för länkar behöver ändras för att uppnå tillräcklig kontrast mot olika bakgrunder. I samband med detta justeras även visa färger i den blå färgskalan så att de följer samma upplägg som färgschemat framtaget av Elin.
> Lägg till följande:
> blue-110 = #2C7399
> blue-120 = #29698C
> Find replace:
> blue-140 > blue-130 (#25607F)
> blue-170 > blue-150 (#143C50)
> Förändringen av färg för länkar speglas av följande branch i Figma: ⌥ DS-1098 Justera länkfärg för att säkerställa kontrast mot olika bakgrunder
>  
> Tänk på att byta ut blue-140 och blue-170 enligt ovan, där de refereras till av semantiska variabler.
> 