### PR TITLE
Bugfix/infobanner toast role

### DIFF
--- a/apps/docs/docs/components/info-banner.mdx
+++ b/apps/docs/docs/components/info-banner.mdx
@@ -135,7 +135,7 @@ import { InfoBanner } from '@midas-ds/components'
   />
 </div>
 
-## Dismissable
+## Stängbar
 
 Det går att göra det möjligt för användaren att stänga informationsmeddelandet via `dismissable`. Det bör inte användas för varningar.
 
@@ -158,6 +158,20 @@ Det går att göra det möjligt för användaren att stänga informationsmeddela
     message='Detta är ett meddelande om att allt gick bra.'
   />
 </div>
+
+## Dynamiskt
+
+InfoBanner är utformad för att vara ett statiskt meddelande som visuellt drar till sig uppmärksamhet. Om du planerar att använda InfoBanner som ett meddelande som kommer fram när användaren gör något rekommenderas komponenten [Toast](../toast) istället.
+Om du ändå vill använda InfoBanner som ett dynamiskt meddelande behöver `role="alert"` adderas för att skärmläsare ska uppfatta meddelandet som en notis till användaren.
+
+```tsx {2}
+<InfoBanner
+  role='alert'
+  type='success'
+  title='Det gick bra!'
+  message='Detta är ett meddelande om att allt gick bra.'
+/>
+```
 
 ## API
 

--- a/apps/docs/docs/components/info-banner.mdx
+++ b/apps/docs/docs/components/info-banner.mdx
@@ -137,12 +137,12 @@ import { InfoBanner } from '@midas-ds/components'
 
 ## Stängbar
 
-Det går att göra det möjligt för användaren att stänga informationsmeddelandet via `dismissable`. Det bör inte användas för varningar.
+Det går att göra det möjligt för användaren att stänga informationsmeddelandet via `isDismissable`. Det bör inte användas för varningar.
 
 ```tsx
 <InfoBanner
   // highlight-start
-  dismissable
+  isDismissable
   // highlight-end
   type='success'
   title='Det gick bra!'
@@ -152,7 +152,7 @@ Det går att göra det möjligt för användaren att stänga informationsmeddela
 
 <div className='card'>
   <InfoBanner
-    dismissable
+    isDismissable
     type='success'
     title='Det gick bra!'
     message='Detta är ett meddelande om att allt gick bra.'

--- a/packages/components/src/info-banner/InfoBanner.tsx
+++ b/packages/components/src/info-banner/InfoBanner.tsx
@@ -23,6 +23,7 @@ export interface InfoBannerProps
    *  Specify if the InfoBanner should have a dismiss button in the top right corner
    */
   dismissable?: boolean
+  role?: React.AriaRole
 }
 
 const iconMap = {
@@ -31,6 +32,7 @@ const iconMap = {
   important: AlertCircle,
   warning: AlertTriangle,
 }
+
 /**
  * Displays a static message as an inline banner
  */
@@ -40,6 +42,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
   type,
   children,
   dismissable = false,
+  role = 'alert',
   ...rest
 }) => {
   const Icon = iconMap[type]
@@ -49,6 +52,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
     return (
       <div
         {...rest}
+        role={role}
         className={clsx(styles.infoBanner, styles[type], rest.className)}
       >
         <Icon

--- a/packages/components/src/info-banner/InfoBanner.tsx
+++ b/packages/components/src/info-banner/InfoBanner.tsx
@@ -23,7 +23,6 @@ export interface InfoBannerProps
    *  Specify if the InfoBanner should have a dismiss button in the top right corner
    */
   dismissable?: boolean
-  role?: React.AriaRole
 }
 
 const iconMap = {
@@ -42,7 +41,6 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
   type,
   children,
   dismissable = false,
-  role = 'alert',
   ...rest
 }) => {
   const Icon = iconMap[type]
@@ -52,7 +50,6 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
     return (
       <div
         {...rest}
-        role={role}
         className={clsx(styles.infoBanner, styles[type], rest.className)}
       >
         <Icon

--- a/packages/components/src/info-banner/InfoBanner.tsx
+++ b/packages/components/src/info-banner/InfoBanner.tsx
@@ -21,8 +21,13 @@ export interface InfoBannerProps
   children?: React.ReactNode
   /**
    *  Specify if the InfoBanner should have a dismiss button in the top right corner
+   *  @deprecated since 10.0.1. Please use `isDismissable` instead
    */
   dismissable?: boolean
+  /**
+   *  Specify if the InfoBanner should have a dismiss button in the top right corner
+   */
+  isDismissable?: boolean
 }
 
 const iconMap = {
@@ -41,6 +46,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
   type,
   children,
   dismissable = false,
+  isDismissable = false,
   ...rest
 }) => {
   const Icon = iconMap[type]
@@ -64,7 +70,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
             {children}
           </div>
         </div>
-        {dismissable && (
+        {(dismissable || isDismissable) && (
           <div className={styles.dismissable}>
             <Button
               variant='icon'

--- a/packages/components/src/toast/Toast.tsx
+++ b/packages/components/src/toast/Toast.tsx
@@ -157,8 +157,8 @@ export function Toast<T extends MidasToast>({
       style={{ viewTransitionName: props.toast.key }}
     >
       <div
-        className={styles.toastContent}
         {...contentProps}
+        className={clsx(styles.toastContent, contentProps.className)}
       >
         <Icon
           className={styles.icon}


### PR DESCRIPTION
## Description

Explain use of role alert on info banners on docweb. 

## Changes

Explaining when to use role alert on an InfoBanner 

## Additional Information

Att använda någon annan roll än alert på t.ex toast förhindrar skärmläsaren att läsa upp det när toasten kommer fram, vilket nog är det vi vill. Därför är den oförändrad. 

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
