### PR TITLE
docs: control size globally in storybook + new dark mode control

### DIFF
--- a/packages/components/.storybook/custom-theme.ts
+++ b/packages/components/.storybook/custom-theme.ts
@@ -20,6 +20,8 @@ export const customDarkTheme = create({
   colorPrimary: '#eaf2f6',
   colorSecondary: '#143c50',
   appBorderRadius: 0,
+  barTextColor: 'rgb(201, 205, 207)',
+  barSelectedColor: 'rgb(201, 205, 207)',
 })
 
 export const getPreferredColorScheme = () => {

--- a/packages/components/.storybook/modes.ts
+++ b/packages/components/.storybook/modes.ts
@@ -1,13 +1,14 @@
-export const modes = {
+// ** modes we should run on ALL stories
+export const globalModes = {
   'Light Mode': {
-    backgrounds: {
-      value: 'white',
+    scheme: {
+      value: 'light',
     },
     colorScheme: 'light',
   },
   'Dark Mode': {
-    backgrounds: {
-      value: '#121212',
+    scheme: {
+      value: 'dark',
     },
     colorScheme: 'dark',
   },
@@ -35,4 +36,17 @@ export const modes = {
   //     },
   //     viewport: 'xLarge',
   //   },
+}
+
+export const sizeModes = {
+  Large: {
+    size: {
+      value: 'large',
+    },
+  },
+  Medium: {
+    size: {
+      value: 'medium',
+    },
+  },
 }

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -7,10 +7,11 @@ import {
   getPreferredColorScheme,
 } from './custom-theme'
 import React from 'react'
-import { modes } from './modes'
+import { globalModes } from './modes'
 import MockDate from 'mockdate'
 import { getLocalTimeZone } from '@internationalized/date'
 import { mockedNow } from '../src/utils/storybook'
+import { semantic } from '../src/theme'
 
 const preview: Preview = {
   async beforeEach() {
@@ -21,10 +22,11 @@ const preview: Preview = {
   },
   parameters: {
     backgrounds: {
-      default: getPreferredColorScheme() === 'dark' ? 'Dark' : 'Light',
+      default: 'Background',
       values: [
-        { name: 'Light', value: 'white' },
-        { name: 'Dark', value: '#121212' },
+        { name: 'Background', value: semantic.background },
+        { name: 'Layer 01', value: semantic.layer01 },
+        { name: 'Layer 02', value: semantic.layer02 },
       ],
     },
     controls: {
@@ -49,9 +51,38 @@ const preview: Preview = {
       },
     },
     chromatic: {
-      modes: modes,
+      modes: globalModes,
     },
     a11y: { test: 'error', element: '#storybook-root' },
+  },
+  globalTypes: {
+    scheme: {
+      toolbar: {
+        title: 'Color Scheme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'light', title: 'Light', icon: 'sun' },
+          { value: 'dark', title: 'Dark', icon: 'moon' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    size: {
+      description: 'Global size for components',
+      toolbar: {
+        title: 'Size',
+        icon: 'expand',
+        items: [
+          { value: 'medium', title: 'Medium' },
+          { value: 'large', title: 'Large' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    size: 'large',
+    scheme: getPreferredColorScheme(),
   },
   decorators: [
     (Story, context) => {
@@ -63,34 +94,20 @@ const preview: Preview = {
       )
 
       React.useEffect(() => {
-        const userSelectedBackground:
-          | 'white'
-          | '#121212'
-          | 'transparent'
-          | undefined = context.globals.backgrounds?.value
-
-        if (
-          userSelectedBackground === 'white' ||
-          userSelectedBackground === '#121212'
-        ) {
-          return setColorMode(
-            userSelectedBackground === 'white' ? 'light' : 'dark',
-          )
-        }
-
-        return setColorMode(getPreferredColorScheme())
-      }, [context.globals.backgrounds])
+        const userSelectedScheme: 'light' | 'dark' = context.globals.scheme
+        setColorMode(userSelectedScheme)
+      }, [context.globals.scheme])
 
       React.useEffect(() => {
-        const popover = document.querySelector<HTMLElement>('body')
-        if (popover) popover.style.colorScheme = colorMode
+        const story = document.querySelector<HTMLElement>('body')
+        if (story) story.style.colorScheme = colorMode
       }, [colorMode])
 
       return (
         <RootTag
           style={{
             colorScheme: colorMode,
-            backgroundColor: colorMode === 'light' ? 'white' : '#121212',
+            backgroundColor: context.globals.backgrounds?.value,
           }}
         >
           <Story />

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from './Button'
 import { Plus, X } from 'lucide-react'
 import { expect, userEvent } from '@storybook/test'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof Button> = {
   component: Button,
@@ -16,6 +17,19 @@ const meta: Meta<typeof Button> = {
     isDisabled: {
       options: [true, false],
       control: { type: 'radio' },
+    },
+  },
+  render: (args, { globals: { size } }) => {
+    return (
+      <Button
+        {...args}
+        size={size}
+      />
+    )
+  },
+  parameters: {
+    chromatic: {
+      modes: sizeModes,
     },
   },
 }
@@ -69,13 +83,6 @@ export const SecondaryDisabled: Story = {
     const button = canvas.getByRole('button')
     await userEvent.click(button)
     await expect(button).toBeDisabled()
-  },
-}
-
-export const MediumSize = {
-  args: {
-    children: 'Button',
-    size: 'medium',
   },
 }
 

--- a/packages/components/src/combobox/ComboBox.stories.tsx
+++ b/packages/components/src/combobox/ComboBox.stories.tsx
@@ -5,6 +5,7 @@ import { Item, Section } from './types'
 import { RunOptions } from 'axe-core'
 import { expect, userEvent } from '@storybook/test'
 import styles from './ComboBox.module.css'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof ComboBox> = {
   component: ComboBox,
@@ -20,9 +21,16 @@ const meta: Meta<typeof ComboBox> = {
   argTypes: {
     placeholder: { control: 'text' },
   },
-  parameters: {},
-  render: args => (
-    <ComboBox {...args}>
+  parameters: {
+    chromatic: {
+      modes: sizeModes,
+    },
+  },
+  render: (args, { globals: { size } }) => (
+    <ComboBox
+      {...args}
+      size={size}
+    >
       <ComboBoxItem>Apple</ComboBoxItem>
       <ComboBoxItem>Lemon</ComboBoxItem>
     </ComboBox>
@@ -42,22 +50,23 @@ export const Default: Story = {
     description: 'Description',
     className: 'test',
   },
-  render: args => (
+  render: (args, { globals: { size } }) => (
     <ComboBox
       data-testid='test'
       items={options}
       {...args}
+      size={size}
     >
       {(item: Item) => <ComboBoxItem>{item.name}</ComboBoxItem>}
     </ComboBox>
   ),
-  play: async ({ canvas, step }) => {
-    await step('it should be large per default', async () => {
+  play: async ({ canvas, step, globals: { size } }) => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByRole('combobox')).toHaveStyle({
-        height: '48px',
+        height: size === 'large' ? '48px' : '40px',
       })
       await expect(canvas.getByRole('button')).toHaveStyle({
-        height: '48px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
 
@@ -68,22 +77,6 @@ export const Default: Story = {
         expect(comboBox).toHaveClass(styles.combobox, 'test')
       },
     )
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    size: 'medium',
-  },
-  play: async ({ canvas, step }) => {
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByRole('combobox')).toHaveStyle({
-        height: '40px',
-      })
-      await expect(canvas.getByRole('button')).toHaveStyle({
-        height: '40px',
-      })
-    })
   },
 }
 
@@ -134,9 +127,12 @@ export const Required: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
-  render: args => (
+  render: (args, { globals: { size } }) => (
     <form>
-      <ComboBox {...args}>
+      <ComboBox
+        {...args}
+        size={size}
+      >
         <ComboBoxItem>Hej</ComboBoxItem>
       </ComboBox>
       <button type='submit'>Submit</button>
@@ -169,9 +165,12 @@ export const CustomErrorMessage: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
-  render: args => (
+  render: (args, { globals: { size } }) => (
     <form>
-      <ComboBox {...args}>
+      <ComboBox
+        {...args}
+        size={size}
+      >
         <ComboBoxItem>Hej</ComboBoxItem>
       </ComboBox>
       <button type='submit'>Submit</button>
@@ -199,8 +198,11 @@ export const Sectioned: Story = {
     ...Default.args,
     items: optionsWithSections,
   },
-  render: args => (
-    <ComboBox {...args}>
+  render: (args, { globals: { size } }) => (
+    <ComboBox
+      {...args}
+      size={size}
+    >
       {(section: Section<Item>) => <ComboBoxSelection {...section} />}
     </ComboBox>
   ),

--- a/packages/components/src/date-field/DateField.stories.tsx
+++ b/packages/components/src/date-field/DateField.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { DateField } from './DateField'
 import { CalendarDate } from '@internationalized/date'
 import { expect } from '@storybook/test'
+import { sizeModes } from '../../.storybook/modes'
 
 type Story = StoryObj<typeof DateField>
 
@@ -25,33 +26,31 @@ export default {
         rules: { 'color-contrast': { enabled: false } },
       },
     },
+    chromatic: {
+      modes: sizeModes,
+    },
   },
   args: {
     errorPosition: 'top',
     label: 'Välj ett datum',
     description: 'Vilket som helst',
   },
+  render: (args, { globals: { size } }) => {
+    return (
+      <DateField
+        {...args}
+        size={size}
+      />
+    )
+  },
 } as Meta<typeof DateField>
 
 /** Don't put format in description, it changes with browser language settings! */
 export const Default: Story = {
-  play: async ({ step, canvas }) => {
-    await step('it should be large per default', async () => {
+  play: async ({ step, canvas, globals: { size } }) => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByTestId('date-field_input-field')).toHaveStyle({
-        height: '48px',
-      })
-    })
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    size: 'medium',
-  },
-  play: async ({ step, canvas }) => {
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByTestId('date-field_input-field')).toHaveStyle({
-        height: '40px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
   },

--- a/packages/components/src/date-picker/DatePicker.stories.tsx
+++ b/packages/components/src/date-picker/DatePicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { DatePicker } from './DatePicker'
 import { expect, userEvent } from '@storybook/test'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof DatePicker> = {
   component: DatePicker,
@@ -27,45 +28,29 @@ const meta: Meta<typeof DatePicker> = {
         rules: { 'color-contrast': { enabled: false } },
       },
     },
+    chromatic: {
+      modes: sizeModes,
+    },
+  },
+  render: (args, { globals: { size } }) => {
+    return (
+      <DatePicker
+        {...args}
+        size={size}
+      />
+    )
   },
 }
 export default meta
 type Story = StoryObj<typeof DatePicker>
 
 export const Primary: Story = {
-  play: async ({ step, canvas }) => {
-    await step('it should be large per default', async () => {
+  play: async ({ step, canvas, globals: { size } }) => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByRole('group')).toHaveStyle({
-        height: '48px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    size: 'medium',
-  },
-  play: async ({ step, canvas }) => {
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByRole('group')).toHaveStyle({
-        height: '40px',
-      })
-    })
-  },
-}
-
-export const MediumSizeInvalid: Story = {
-  args: {
-    size: 'medium',
-    isInvalid: true,
-  },
-}
-
-export const MediumSizeDisabled: Story = {
-  args: {
-    size: 'medium',
-    isDisabled: true,
   },
 }
 

--- a/packages/components/src/date-picker/DateRangePicker.stories.tsx
+++ b/packages/components/src/date-picker/DateRangePicker.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { DateRangePicker } from './DateRangePicker'
 import { expect } from '@storybook/test'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof DateRangePicker> = {
   component: DateRangePicker,
@@ -22,6 +23,9 @@ const meta: Meta<typeof DateRangePicker> = {
         rules: { 'color-contrast': { enabled: false } },
       },
     },
+    chromatic: {
+      modes: sizeModes,
+    },
   },
   args: {
     label: 'Välj datum',
@@ -29,44 +33,25 @@ const meta: Meta<typeof DateRangePicker> = {
     errorMessage: 'Felmeddelande',
     errorPosition: 'top',
   },
+  render: (args, { globals: { size } }) => {
+    return (
+      <DateRangePicker
+        {...args}
+        size={size}
+      />
+    )
+  },
 }
 export default meta
 type Story = StoryObj<typeof DateRangePicker>
 
 export const Primary: Story = {
-  play: async ({ step, canvas }) => {
-    await step('it should be large per default', async () => {
+  play: async ({ step, canvas, globals: { size } }) => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByRole('group')).toHaveStyle({
-        height: '48px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    size: 'medium',
-  },
-  play: async ({ step, canvas }) => {
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByRole('group')).toHaveStyle({
-        height: '40px',
-      })
-    })
-  },
-}
-
-export const MediumSizeInvalid: Story = {
-  args: {
-    size: 'medium',
-    isInvalid: true,
-  },
-}
-
-export const MediumSizeDisabled: Story = {
-  args: {
-    size: 'medium',
-    isDisabled: true,
   },
 }
 

--- a/packages/components/src/search-field/SearchField.stories.tsx
+++ b/packages/components/src/search-field/SearchField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { SearchField } from './SearchField'
 import { expect, fn, userEvent } from '@storybook/test'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof SearchField> = {
   component: SearchField,
@@ -8,10 +9,21 @@ const meta: Meta<typeof SearchField> = {
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    chromatic: {
+      modes: sizeModes,
+    },
   },
   args: {
     buttonText: 'Sök',
     errorPosition: 'top',
+  },
+  render: (args, { globals: { size } }) => {
+    return (
+      <SearchField
+        {...args}
+        size={size}
+      />
+    )
   },
 }
 export default meta
@@ -23,7 +35,12 @@ export const Primary: Story = {
     onChange: fn(),
     onSubmit: fn(),
   },
-  play: async ({ canvas, step, args: { onChange, onSubmit, buttonText } }) => {
+  play: async ({
+    canvas,
+    step,
+    globals: { size },
+    args: { onChange, onSubmit, buttonText },
+  }) => {
     await step(
       'it should be possible to submit a search string using only the keyboard',
       async () => {
@@ -46,31 +63,14 @@ export const Primary: Story = {
       },
     )
 
-    await step('it should be large per default', async () => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByRole('searchbox')).toHaveStyle({
-        height: '48px',
+        height: size === 'large' ? '48px' : '40px',
       })
       await expect(
         canvas.getByRole('button', { name: buttonText }),
       ).toHaveStyle({
-        height: '48px',
-      })
-    })
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    placeholder: 'Sök efter en person',
-    size: 'medium',
-  },
-  play: async ({ canvas, step }) => {
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByRole('searchbox')).toHaveStyle({
-        height: '40px',
-      })
-      await expect(canvas.getByRole('button')).toHaveStyle({
-        height: '40px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
   },

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -5,6 +5,7 @@ import { options, optionsWithSections } from './utils'
 import { expect, userEvent } from '@storybook/test'
 import { useState } from 'react'
 import { Selection } from 'react-aria-components'
+import { sizeModes } from '../../.storybook/modes'
 
 const meta: Meta<typeof Select> = {
   component: Select,
@@ -22,12 +23,25 @@ const meta: Meta<typeof Select> = {
     showTags: false,
     errorPosition: 'top',
   },
+  parameters: {
+    chromatic: {
+      modes: sizeModes,
+    },
+  },
+  render: (args, { globals: { size } }) => {
+    return (
+      <Select
+        {...args}
+        size={size}
+      />
+    )
+  },
 }
 export default meta
 type Story = StoryObj<typeof Select>
 
 export const Normal: Story = {
-  play: async ({ args, canvas, step }) => {
+  play: async ({ args, canvas, step, globals: { size } }) => {
     await step(
       'It should be possible to select an item using the keyboard',
       async () => {
@@ -42,37 +56,9 @@ export const Normal: Story = {
         expect(visibleValue).toBeVisible()
       },
     )
-    await step('it should be large sized', async () => {
+    await step('it should change size according to size prop', async () => {
       await expect(canvas.getByRole('button')).toHaveStyle({
-        height: '48px',
-      })
-    })
-  },
-}
-
-export const MediumSize: Story = {
-  args: {
-    size: 'medium',
-  },
-  play: async ({ args, canvas, step }) => {
-    await step(
-      'It should be possible to select an item using the keyboard',
-      async () => {
-        await userEvent.tab()
-        await userEvent.keyboard('[Space]')
-        await userEvent.keyboard('[Space]')
-
-        const hiddenSelect = canvas.getByLabelText(`${args.label}-hidden`)
-        const visibleValue = canvas.getByText(options[0].name, {
-          selector: 'span',
-        })
-        expect(hiddenSelect).toHaveDisplayValue([options[0].name])
-        expect(visibleValue).toBeVisible()
-      },
-    )
-    await step('it should be medium sized', async () => {
-      await expect(canvas.getByRole('button')).toHaveStyle({
-        height: '40px',
+        height: size === 'large' ? '48px' : '40px',
       })
     })
   },

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { RunOptions } from 'axe-core'
 import { expect, userEvent } from '@storybook/test'
 import { TextField } from '../textfield'
+import { sizeModes } from '../../.storybook/modes'
 
 export default {
   title: 'Components/TextField',
@@ -17,6 +18,19 @@ export default {
     description: 'Description',
     errorPosition: 'top',
   },
+  parameters: {
+    chromatic: {
+      modes: sizeModes,
+    },
+  },
+  render: (args, { globals: { size } }) => {
+    return (
+      <TextField
+        {...args}
+        size={size}
+      />
+    )
+  },
 } as Meta<typeof TextField>
 
 type Story = StoryObj<typeof TextField>
@@ -25,13 +39,18 @@ export const Primary: Story = {
   args: {
     className: 'test-class',
   },
-  play: async ({ canvas, step }) => {
+  play: async ({ canvas, step, args: { label }, globals: { size } }) => {
     await step(
       'it should preserve its classNames when being passed new ones',
       async () => {
         expect(canvas.getByRole('textbox').classList.length).toBe(2)
       },
     )
+    await step('it should change size according to size prop', async () => {
+      await expect(canvas.getByLabelText(label as string)).toHaveStyle({
+        height: size === 'large' ? '48px' : '40px',
+      })
+    })
   },
 }
 
@@ -201,25 +220,6 @@ export const ShowCounterWithDefaultValue: Story = {
         expect(
           canvas.getByText((defaultValue as string).length),
         ).toBeInTheDocument()
-      },
-    )
-  },
-}
-
-export const MediumSizeInput: Story = {
-  tags: ['!autodocs'],
-  args: {
-    defaultValue: 'Medium size input',
-    size: 'medium',
-    label: 'Medium size textfield',
-  },
-  play: async ({ canvas, step, args: { label } }) => {
-    await step(
-      'it should have an input field with the height of 40px',
-      async () => {
-        await expect(canvas.getByLabelText(label as string)).toHaveStyle({
-          height: '40px',
-        })
       },
     )
   },


### PR DESCRIPTION
## Description

Add size as a global setting in storybook

## Changes

- Added size as a global setting
- Added new setting for color scheme
- Added new setting for background (was dark mode, now background layers)
- Added size modes to chromatic to snapshot sizes on selected components

## Additional Information

Open a story and set size/dark mode settings in SB Toolbar

## Checklist

- [X] Tests added if applicable
- [X] Documentation updated
- [X] Conventional commit messages
