### PR TITLE
fix(skeleton): dont overwrite properties

### DIFF
--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -9,7 +9,7 @@
         "midas/handle-deprecated-comments": [
           1,
           {
-            "version": "9.0.0"
+            "version": "10.0.0"
           }
         ],
         "jsx-a11y/no-autofocus": "off"

--- a/packages/components/src/skeleton/Skeleton.stories.tsx
+++ b/packages/components/src/skeleton/Skeleton.stories.tsx
@@ -2,7 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Skeleton } from './Skeleton'
 import { expect } from '@storybook/test'
 import styles from './Skeleton.module.css'
-const meta: Meta<typeof Skeleton> = {
+
+type Story = StoryObj<typeof Skeleton>
+
+export default {
   component: Skeleton,
   title: 'Components/Skeleton',
   tags: ['autodocs'],
@@ -15,22 +18,19 @@ const meta: Meta<typeof Skeleton> = {
       control: { type: 'radio' },
     },
   },
-}
-export default meta
-type Story = StoryObj<typeof Skeleton>
-
-export const Rectangle: Story = {
-  args: {
-    variant: 'rectangle',
-    width: '100px',
-    height: '40px',
-  },
   render: args => (
     <Skeleton
       {...args}
       data-testid='skeleton'
     />
   ),
+} as Meta<typeof Skeleton>
+
+export const Rectangle: Story = {
+  args: {
+    width: '100px',
+    height: '40px',
+  },
   play: async ({ canvas }) => {
     const skeleton = canvas.getByTestId('skeleton')
     await expect(skeleton).toHaveClass(styles.wave, styles.skeleton)
@@ -42,12 +42,6 @@ export const Circle: Story = {
     variant: 'circle',
     width: '50px',
   },
-  render: args => (
-    <Skeleton
-      {...args}
-      data-testid='skeleton'
-    />
-  ),
   play: async ({ canvas }) => {
     const skeleton = canvas.getByTestId('skeleton')
     await expect(skeleton).toHaveClass(styles.wave, styles.circle)
@@ -71,12 +65,6 @@ export const NoAnimation: Story = {
       },
     },
   },
-  render: args => (
-    <Skeleton
-      {...args}
-      data-testid='skeleton'
-    />
-  ),
   play: async ({ canvas }) => {
     const skeleton = canvas.getByTestId('skeleton')
     await expect(skeleton).not.toHaveClass(styles.wave)
@@ -88,14 +76,37 @@ export const Animation: Story = {
     ...Rectangle.args,
     isAnimated: true,
   },
-  render: args => (
-    <Skeleton
-      {...args}
-      data-testid='skeleton'
-    />
-  ),
   play: async ({ canvas }) => {
     const skeleton = canvas.getByTestId('skeleton')
     await expect(skeleton).toHaveClass(styles.wave)
+  },
+}
+
+export const DS1191: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    width: '100px',
+    height: '40px',
+    className: 'derp',
+    style: {
+      verticalAlign: 'bottom',
+    },
+  },
+  play: async ({ canvas, step }) => {
+    await step(
+      'It should merge provided className and style props',
+      async () => {
+        const skeleton = canvas.getByTestId('skeleton')
+        await expect(skeleton).toHaveClass(styles.wave, styles.skeleton, 'derp')
+        await expect(skeleton).toHaveStyle({
+          width: '100px',
+          height: '40px',
+          verticalAlign: 'bottom',
+        })
+      },
+    )
   },
 }

--- a/packages/components/src/skeleton/Skeleton.tsx
+++ b/packages/components/src/skeleton/Skeleton.tsx
@@ -31,6 +31,8 @@ export const Skeleton: React.FC<SkeletonProps> = ({
   width,
   height,
   isAnimated = true,
+  className,
+  style,
   ...rest
 }) => {
   if (variant === 'circle' && height !== undefined) {
@@ -41,13 +43,14 @@ export const Skeleton: React.FC<SkeletonProps> = ({
 
   return (
     <div
-      {...rest}
       className={clsx(
         styles.skeleton,
         styles[variant],
         isAnimated && styles.wave,
+        className,
       )}
-      style={{ width, height }}
+      style={{ width, height, ...style }}
+      {...rest}
     />
   )
 }

--- a/tools/eslint/handle-deprecated-comments.js
+++ b/tools/eslint/handle-deprecated-comments.js
@@ -4,13 +4,27 @@ module.exports = {
     docs: {
       description: 'A hint that the source code exports deprecated features',
     },
+    schema: {
+      type: 'array',
+      minItems: 0,
+      maxItems: 1,
+      items: [
+        {
+          type: 'object',
+          properties: {
+            version: { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      ],
+    },
   },
   create(context) {
     const version = context?.options?.[0]?.version
 
-    const getSemver = str => str.match(new RegExp(/\d\.\d\.\d/))
+    const getSemver = str => str.match(new RegExp(/\d{1,3}\.\d{1,3}\.\d{1,3}/))
 
-    const getMajor = matchArray => parseInt(matchArray[0][0], 10)
+    const getMajor = matchArray => parseInt(matchArray[0], 10)
 
     const processComment = comment => {
       if (

--- a/tools/eslint/handle-deprecated-comments.test.js
+++ b/tools/eslint/handle-deprecated-comments.test.js
@@ -15,6 +15,10 @@ ruleTester.run('handle-deprecated-comments', rule, {
     {
       code: '// any comment',
     },
+    {
+      options: [{ version: '9.0.0' }],
+      code: '// @deprecated since v10.0.0',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## Description

Reported by a fellow co worker in the support channel

`Skeleton` accepts `className` and `style` (among others) but it gets overwritten.

## Changes

- chore: update eslint rule to handle major versions > 9
- fix(skeleton): dont overwrite className and style props

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
