### PR TITLE
fix(radio): remove interactions with radiogroup items outside the lab…

### DIFF
--- a/packages/components/src/radio/Radio.module.css
+++ b/packages/components/src/radio/Radio.module.css
@@ -16,6 +16,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    align-items: start;
   }
 
   &[aria-orientation='horizontal'] .wrap {
@@ -100,6 +101,11 @@
     padding: 0.875rem 1rem;
     border: 1px solid --border-primary;
     width: auto;
+
+    &.radio {
+      width: 100%;
+      box-sizing: border-box;
+    }
 
     &[data-hovered] {
       background-color: --field-hover-02;


### PR DESCRIPTION
…el and button

## Description

With a radiogroup you could previously click outside the radio label. This should fix that problem

