### PR TITLE
fix(link-button): add disabled styling

### DIFF
--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -17,8 +17,8 @@
   gap: 0.5rem;
   text-decoration: none;
 
-  &[data-hovered],
-  &:hover {
+  &[data-hovered]:not(:disabled, [data-disabled]),
+  &:hover:not(:disabled, [data-disabled]) {
     text-decoration: none;
     background-color: --button-background-primary-hover;
     color: --text-on-color;
@@ -43,7 +43,7 @@
   &[data-disabled],
   &:disabled {
     color: --text-disabled;
-    pointer-events: none;
+    cursor: not-allowed;
     background-color: --button-background-disabled;
   }
 }
@@ -57,8 +57,8 @@
     color: --icon-tertiary;
   }
 
-  &[data-hovered],
-  &:hover {
+  &[data-hovered]:not(:disabled, [data-disabled]),
+  &:hover:not(:disabled, [data-disabled]) {
     color: --text-tertiary;
     background-color: --button-background-secondary-hover;
   }
@@ -66,6 +66,10 @@
   &[data-disabled],
   &:disabled {
     border-color: --border-disabled;
+
+    .icon {
+      color: --text-disabled;
+    }
   }
 
   &[data-pressed],
@@ -79,8 +83,8 @@
   background-color: transparent;
   opacity: 1;
 
-  &[data-hovered],
-  &:hover {
+  &[data-hovered]:not(:disabled, [data-disabled]),
+  &:hover:not(:disabled, [data-disabled]) {
     color: --text-tertiary;
     background-color: --button-background-tertiary-hover;
   }
@@ -96,8 +100,8 @@
   background-color: --button-background-danger;
   opacity: 1;
 
-  &[data-hovered],
-  &:hover {
+  &[data-hovered]:not(:disabled, [data-disabled]),
+  &:hover:not(:disabled, [data-disabled]) {
     background-color: --button-background-danger-hover;
   }
 
@@ -115,15 +119,14 @@
   display: flex;
   align-items: center;
 
-  &[data-hovered],
-  &:hover {
+  &[data-hovered]:not(:disabled, [data-disabled]),
+  &:hover:not(:disabled, [data-disabled]) {
     background-color: --button-background-icon-hover;
   }
 
   &[data-disabled],
   &:disabled {
     color: --text-disabled;
-    pointer-events: none;
   }
 
   &[data-pressed],

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { LinkButton } from './LinkButton'
 import { X } from 'lucide-react'
+import { expect, userEvent } from '@storybook/test'
 
 const meta: Meta<typeof LinkButton> = {
   component: LinkButton,
@@ -61,6 +62,13 @@ export const Disabled: Story = {
   args: {
     ...Primary.args,
     isDisabled: true,
+  },
+  play: async ({ canvas, step }) => {
+    await step('It should have cursor not allowed when disabled', async () => {
+      const linkButton = canvas.getByRole('link')
+      await userEvent.hover(linkButton)
+      await expect(linkButton).toHaveStyle({ cursor: 'not-allowed' })
+    })
   },
 }
 


### PR DESCRIPTION
## Description

Support ticket

## Changes

- add `cursor: not-allowed` to disabled `LinkButton`s
- add consistent disabled styling to `LinkButton` variations


## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
