### PR TITLE
docs: re-add example borders

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -93,6 +93,7 @@
 
 .theme-code-block {
   box-shadow: none !important;
+  border: 1px solid var(--ifm-color-emphasis-200);
   max-height: 600px;
   overflow-y: auto;
 }
@@ -117,6 +118,7 @@
   border-radius: 0;
   margin-bottom: var(--ifm-leading);
   box-shadow: none !important;
+  border: 1px solid var(--ifm-color-emphasis-200);
   max-height: 600px;
   overflow-y: auto;
 
@@ -407,6 +409,7 @@ html[data-theme='dark'] .navbar--github-link::before {
 
 .no-margin-children {
   margin-bottom: 1rem;
+
   p {
     margin-bottom: 0;
     white-space: wrap;


### PR DESCRIPTION
## Description

Återställer kantlinjer på kodexemplen. Det är mycket tydligare på detta sättet vad som är ett exempel och vad som är bara text.

Utan:
![Screenshot 2025-05-27 at 09 03 42](https://github.com/user-attachments/assets/d2dd8d3e-b430-4c9b-81f0-2ca31ad2824b)
![Screenshot 2025-05-27 at 09 06 29](https://github.com/user-attachments/assets/5e3e8f96-5e1a-4ada-9974-81bef82353bd)

Med:
![Screenshot 2025-05-27 at 09 03 36](https://github.com/user-attachments/assets/1556ea8b-2269-405c-972c-b08c8cdb01e8)
![Screenshot 2025-05-27 at 09 06 17](https://github.com/user-attachments/assets/0a34b571-9efc-440c-b86e-e40761a10a29)

## Changes

- Re-add border to code examples and cards


## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
