### PR TITLE
docs: no bg on proptable accordions

### DIFF
--- a/apps/docs/src/components/PropsTable.tsx
+++ b/apps/docs/src/components/PropsTable.tsx
@@ -13,7 +13,7 @@ import {
   Popover,
   Pressable,
 } from 'react-aria-components'
-import {jsdocLinkToMarkdown} from '@site/src/utils/jsdocLinkToMarkdown'
+import { jsdocLinkToMarkdown } from '../utils/jsdocLinkToMarkdown'
 
 export const DisplayCompositeTypes = ({ props }: Props) => {
   switch (props.type.name) {
@@ -158,7 +158,9 @@ export const PropTable = ({ name, defaultOpen = true }) => {
                   <td />
                 )}
                 <td data-title='Description'>
-                  <ReactMarkdown>{jsdocLinkToMarkdown(props[key].description)}</ReactMarkdown>
+                  <ReactMarkdown>
+                    {jsdocLinkToMarkdown(props[key].description)}
+                  </ReactMarkdown>
                 </td>
               </tr>
             ))}
@@ -179,6 +181,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
           id='props'
           title='Props'
           className={styles.accordionItem}
+          hasBackground={false}
         >
           <Grid propGroup={rest} />
         </AccordionItem>
@@ -188,6 +191,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
           id='events'
           title='Events'
           className={styles.accordionItem}
+          hasBackground={false}
         >
           <Grid
             propGroup={events}
@@ -200,6 +204,7 @@ export const PropTable = ({ name, defaultOpen = true }) => {
           id='accessibility'
           title='Tillgänglighet'
           className={styles.accordionItem}
+          hasBackground={false}
         >
           <Grid
             propGroup={accessibility}


### PR DESCRIPTION
## Description

Har att göra med att vi nu sätter bakgrund på Accordions och glitch mellan Docusaurus lösning med [data-theme=""] i HTML och vår lösning med color-scheme i CSS. 

## Changes

- Stäng av bakgrund på Accordion på PropsTable, onödigt där

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
