### PR TITLE
chore(components): add command to watch for typescript errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ build
 
 # Nx
 .nx
+tmp
 
 # Editors
 .idea

--- a/packages/components/.storybook/examples/SearchField.stories.tsx
+++ b/packages/components/.storybook/examples/SearchField.stories.tsx
@@ -20,10 +20,14 @@ export default meta
 type Story = StoryObj<typeof SearchField>
 
 type DataRow = { id: number; fruit: string; description: string }
+
+type ColumnId = {
+  [key in keyof DataRow]: key
+}[keyof DataRow]
+
 type ColumnType = {
   name: string
-  id: string
-
+  id: ColumnId
   isRowHeader?: boolean
 }
 

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -121,6 +121,16 @@
         "lintFilePatterns": ["packages/components/**/*.css"],
         "formatter": "unix"
       }
+    },
+    "compile": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "main": "packages/components/src/index.ts",
+        "outputPath": "dist/tsc",
+        "tsConfig": "packages/components/tsconfig.lib.json",
+        "watch": true,
+        "generatePackageJson": false
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

A little typescript error in a search field example story

## Changes

- chore(search-field): add column id type to story
- chore(components): add command to watch for typescript errors

## Additional Information

run `nx compile components` to watch for typescript errors

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
