### PR TITLE
fix(combobox): remove label element in ListBoxSection

### DIFF
--- a/packages/components/src/combobox/ComboBox.stories.tsx
+++ b/packages/components/src/combobox/ComboBox.stories.tsx
@@ -194,6 +194,55 @@ export const CustomErrorMessage: Story = {
   },
 }
 
+export const DS1207: StoryObj<typeof ComboBox<ListBoxSectionElement>> = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    placeholder: 'Välj eller sök frukt',
+    label: 'Välj en frukt',
+    description: 'Description',
+    className: 'test',
+    items: optionsWithSections,
+  },
+  render: (args, { globals: { size } }) => (
+    <ComboBox
+      {...args}
+      size={size}
+    >
+      {section => (
+        <ComboBoxSection
+          {...section}
+          id={section.name}
+        />
+      )}
+    </ComboBox>
+  ),
+  play: async ({ canvas, step, args }) => {
+    await step(
+      'The label should preserve its id when opening and closing the list box',
+      async () => {
+        await expect(
+          canvas.getByRole('combobox', {
+            name: args.label as string,
+          }),
+        ).toBeInTheDocument()
+
+        await userEvent.tab()
+        await userEvent.keyboard('[ArrowDown]')
+        await userEvent.keyboard('[Escape]')
+
+        await expect(
+          canvas.getByRole('combobox', {
+            name: args.label as string,
+          }),
+        ).toBeInTheDocument()
+      },
+    )
+  },
+}
+
 // The generic type is infered from the items prop in real life
 export const Sectioned: StoryObj<typeof ComboBox<ListBoxSectionElement>> = {
   args: {

--- a/packages/components/src/list-box/ListBoxSection.tsx
+++ b/packages/components/src/list-box/ListBoxSection.tsx
@@ -4,7 +4,6 @@ import {
   Header,
   type ListBoxSectionProps as AriaListBoxSectionProps,
 } from 'react-aria-components'
-import { Label } from '../label'
 import type { ListBoxSectionElement } from './types'
 import styles from './ListBox.module.css'
 
@@ -20,14 +19,7 @@ export const ListBoxSection = <T extends ListBoxSectionElement>({
   ...rest
 }: ListBoxSectionProps<T>) => (
   <AriaListBoxSection {...rest}>
-    <Header>
-      <Label
-        elementType='span'
-        className={styles.listBoxSectionHeading}
-      >
-        {name}
-      </Label>
-    </Header>
+    <Header className={styles.listBoxSectionHeading}>{name}</Header>
     {children}
   </AriaListBoxSection>
 )

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -47,7 +47,6 @@ const SelectComponent = React.forwardRef<HTMLButtonElement, SelectProps>(
     return (
       <TextField
         {...props}
-        aria-label={props.label || 'placeholder'}
         className={clsx(styles.wrapper, props.className)}
       >
         <HiddenMultiSelect


### PR DESCRIPTION
## Description

We used an unnecessary `Label` for our `ListBoxSection`s which caused an ID-collision making our `ComboBox` (and `Select`) to lose the aria-labeledby connection when opening and closing the `ListBox`

## Changes

- Create a test
- Remove the label in `ListBoxSection`
- Remove the workaround `aria-label` passed to `Select`

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
