### PR TITLE
feature(table): medium size

### DIFF
--- a/apps/docs/docs/components/table.mdx
+++ b/apps/docs/docs/components/table.mdx
@@ -176,7 +176,7 @@ const [selectedKeys, setSelectedKeys] = React.useState<Selection>(new Set(['appl
 
 ### Randiga rader
 
-Använd `striped` om du vill att raderna ska alternera mellan vit och grå.
+Använd `striped` om du vill att raderna ska vara olika.
 
 ```tsx
 <Table

--- a/apps/docs/docs/components/table.mdx
+++ b/apps/docs/docs/components/table.mdx
@@ -53,7 +53,7 @@ Börja med att sätta upp dina kolumner. Nycklarna på raderna ska sedan referer
 
 ```tsx
 const columns = [
-  { name: 'Namn', id: 'name' },
+  { name: 'Namn', id: 'name', isRowHeader: true },
   { name: 'Beskrivning', id: 'description', width: 'max-content' },
 ]
 
@@ -82,7 +82,7 @@ const rows = [
 <Table aria-label='Fruit'>
   <TableHeader columns={columns}>
     {column => {
-      return <Column>{column.name}</Column>
+      return <Column isRowHeader={column.isRowHeader}>{column.name}</Column>
     }}
   </TableHeader>
   <TableBody items={rows}>
@@ -103,20 +103,20 @@ const rows = [
 
 ### Kompakt tabell
 
-Använd `narrow` om du vill ha en kompaktare tabell.
+Använd `size='medium'` om du vill ha en kompaktare tabell.
 
 ```tsx
 <Table
   aria-label='Fruit'
   // highlight-start
-  narrow
+  size='medium'
   // highlight-end
 >
   ...
 </Table>
 ```
 
-<FullExample narrow />
+<FullExample size='medium' />
 
 ### Valbara rader
 

--- a/apps/docs/src/components/examples/table/TableExamples.tsx
+++ b/apps/docs/src/components/examples/table/TableExamples.tsx
@@ -11,7 +11,7 @@ import {
 } from '@midas-ds/components'
 
 const columns = [
-  { name: 'Namn', id: 'name' },
+  { name: 'Namn', id: 'name', isRowHeader: true },
   { name: 'Beskrivning', id: 'description', width: 'max-content' },
 ]
 
@@ -62,7 +62,7 @@ export const FullExample: React.FC<TableProps> = props => (
     >
       <TableHeader columns={columns}>
         {column => {
-          return <Column>{column.name}</Column>
+          return <Column isRowHeader={column.isRowHeader}>{column.name}</Column>
         }}
       </TableHeader>
       <TableBody items={rows}>

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -126,6 +126,16 @@
   &.padding-0 {
     padding: 0;
   }
+
+  table {
+    border-collapse: unset;
+
+    thead {
+      tr {
+        border: unset;
+      }
+    }
+  }
 }
 
 .card-image {

--- a/packages/components/src/table/Table.module.css
+++ b/packages/components/src/table/Table.module.css
@@ -1,21 +1,32 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --layer-accent-01, --layer-01, --border-subtle, --layer-accent-hover-01, --layer-hover-01, --border-primary, --text-primary from tokens;
+@value --border-primary, --border-subtle, --font-family, --layer-01, --layer-accent-01, --layer-accent-hover-01, --layer-hover-01, --size-60, --size-80, --size-130, --size-150, --text-primary from tokens;
 
 .cell {
   background-color: --layer-01;
   border-top: 1px --border-subtle solid;
-  padding: 1rem;
+  padding: calc(--size-80 - 1px) --size-80 --size-80;
   color: --text-primary;
 }
 
 .table {
   font-family: --font-family;
   border-spacing: 0;
+  line-height: 1;
 
   &.narrow {
     th,
     td {
       padding: 0.2rem 1rem;
+    }
+  }
+
+  &.medium {
+    .cell {
+      padding: calc(--size-60 - 1px) --size-80 --size-60;
+    }
+
+    .column {
+      padding: --size-60 --size-80;
     }
   }
 

--- a/packages/components/src/table/Table.module.css
+++ b/packages/components/src/table/Table.module.css
@@ -1,73 +1,85 @@
 @value tokens: "../theme/tokens.css";
-@value --border-primary, --border-subtle, --font-family, --layer-01, --layer-accent-01, --layer-accent-hover-01, --layer-hover-01, --size-60, --size-80, --size-130, --size-150, --text-primary from tokens;
-
-.cell {
-  background-color: --layer-01;
-  border-top: 1px --border-subtle solid;
-  padding: calc(--size-80 - 1px) --size-80 --size-80;
-  color: --text-primary;
-}
+@value --border-primary, --border-subtle, --font-family, --font-size-10, --font-size-20, --layer-01, --layer-accent-01, --layer-accent-hover-01, --layer-hover-01, --line-height-10, --line-height-20, --size-10, --size-20, --size-60, --size-75, --size-80, --size-130, --size-150, --text-primary from tokens;
 
 .table {
-  font-family: --font-family;
   border-spacing: 0;
-  line-height: 1;
+  font-family: --font-family;
+  font-size: --font-size-20;
+  line-height: --line-height-20;
+
+  .tableHeader {
+    background-color: --layer-accent-01;
+    color: --text-primary;
+
+    .column {
+      font-weight: 500;
+      padding: --size-75 --size-80;
+      text-align: left;
+
+      &[data-focused],
+      &[data-hovered] {
+        outline: --size-10 solid --border-primary;
+      }
+    }
+  }
+
+  .row {
+    &[data-focused] {
+      outline: --size-10 solid --border-primary;
+    }
+
+    &[data-href] {
+      cursor: pointer;
+    }
+
+    &[data-hovered] .cell {
+      background-color: --layer-hover-01;
+    }
+
+    .cell {
+      background-color: --layer-01;
+      border-top: 1px --border-subtle solid;
+      color: --text-primary;
+      padding: calc(--size-75 - 1px) --size-80 --size-75;
+    }
+  }
 
   &.narrow {
-    th,
-    td {
-      padding: 0.2rem 1rem;
+    font-size: --font-size-10;
+    line-height: --line-height-10;
+
+    .column {
+      padding: --size-20 --size-80;
+    }
+
+    .cell {
+      padding: calc(--size-20 - 1px) --size-80 --size-20;
     }
   }
 
   &.medium {
-    .cell {
-      padding: calc(--size-60 - 1px) --size-80 --size-60;
-    }
-
     .column {
-      padding: --size-60 --size-80;
+      padding: calc(--size-60 - 1px) --size-80;
+    }
+
+    .cell {
+      padding: calc(--size-60 - 2px) --size-80 calc(--size-60 - 1px);
     }
   }
 
-  th[data-focused='true'] {
-    outline: 2px solid --border-primary;
+  &.striped {
+    .row {
+      &:nth-child(even) {
+        .cell {
+          background-color: --layer-accent-01;
+        }
+
+        &[data-hovered] {
+          .cell {
+            background-color: --layer-accent-hover-01;
+          }
+        }
+      }
+    }
   }
-
-  th[data-hovered='true'] {
-    outline: 2px solid --border-primary;
-  }
-
-  &.striped .row:nth-child(2n) .cell {
-    background-color: --layer-accent-01;
-  }
-
-  &.striped .row:nth-child(2n):hover .cell {
-    background-color: --layer-accent-hover-01;
-  }
-}
-
-.row {
-  &[data-focused='true'] {
-    outline: 2px solid --border-primary;
-  }
-
-  &[data-href] {
-    cursor: pointer;
-  }
-
-  &[data-hovered='true'] td {
-    background-color: --layer-hover-01;
-  }
-}
-
-.tableHeader {
-  background-color: --layer-accent-01;
-  color: --text-primary;
-}
-
-.column {
-  padding: 1rem;
-  text-align: left;
-  font-weight: 500;
 }

--- a/packages/components/src/table/Table.module.css
+++ b/packages/components/src/table/Table.module.css
@@ -57,7 +57,7 @@
     }
   }
 
-  &.medium {
+  &.medium:not(.narrow) {
     .column {
       padding: calc(--size-60 - 1px) --size-80;
     }

--- a/packages/components/src/table/Table.stories.tsx
+++ b/packages/components/src/table/Table.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent } from '@storybook/test'
 import { hexToRgb, lightDark } from '../utils/test'
 import { Table, TableHeader, Column, TableBody, Row, Cell } from './Table'
 import styles from './Table.module.css'
+import { sizeModes } from '../../.storybook/modes'
 
 type Story = StoryObj<typeof Table>
 
@@ -50,6 +51,11 @@ export default {
   argTypes: {
     size: {
       control: false,
+    },
+  },
+  parameters: {
+    chromatic: {
+      modes: sizeModes,
     },
   },
   render: (args, { globals: { size } }) => {

--- a/packages/components/src/table/Table.stories.tsx
+++ b/packages/components/src/table/Table.stories.tsx
@@ -1,25 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Table, TableHeader, Column, TableBody, Row, Cell } from './Table'
 import { expect, userEvent } from '@storybook/test'
-import styles from './Table.module.css'
 import { hexToRgb, lightDark } from '../utils/test'
+import { Table, TableHeader, Column, TableBody, Row, Cell } from './Table'
+import styles from './Table.module.css'
 
-const meta: Meta<typeof Table> = {
-  component: Table,
-  subcomponents: {
-    TableHeader: TableHeader as React.ComponentType<unknown>,
-    Column: Column as React.ComponentType<unknown>,
-    TableBody: TableBody as React.ComponentType<unknown>,
-    Row: Row as React.ComponentType<unknown>,
-    Cell: Cell as React.ComponentType<unknown>,
-  },
-  title: 'Components/Table',
-  tags: ['autodocs'],
-  args: {
-    'aria-label': 'Files',
-  },
-}
-export default meta
 type Story = StoryObj<typeof Table>
 
 interface Column {
@@ -48,12 +32,31 @@ const rows = [
   { id: 4, name: 'log.txt', date: '1/18/2016', type: 'Text Document' },
 ] satisfies Row[]
 
-export const Primary: Story = {
-  render: ({ ...args }) => {
+export default {
+  component: Table,
+  subcomponents: {
+    TableHeader: TableHeader as React.ComponentType<unknown>,
+    Column: Column as React.ComponentType<unknown>,
+    TableBody: TableBody as React.ComponentType<unknown>,
+    Row: Row as React.ComponentType<unknown>,
+    Cell: Cell as React.ComponentType<unknown>,
+  },
+  title: 'Components/Table',
+  tags: ['autodocs'],
+  args: {
+    'aria-label': 'Files',
+    selectionMode: 'multiple',
+  },
+  argTypes: {
+    size: {
+      control: false,
+    },
+  },
+  render: (args, { globals: { size } }) => {
     return (
       <Table
-        selectionMode='multiple'
         {...args}
+        size={size}
       >
         <TableHeader columns={columns}>
           {column => (
@@ -70,10 +73,29 @@ export const Primary: Story = {
       </Table>
     )
   },
+} satisfies Meta<typeof Table>
+
+export const Primary: Story = {
+  play: async ({ canvas, step, globals: { size } }) => {
+    await step(
+      'columns should change size according to size prop',
+      async () => {
+        canvas.getAllByRole('columnheader').forEach(async column => {
+          const { height } = column.getBoundingClientRect()
+          await expect(height).toBe(size === 'large' ? 48 : 40)
+        })
+      },
+    )
+    await step('cells should change size according to size prop', async () => {
+      canvas.getAllByRole('gridcell').forEach(async cell => {
+        const { height } = cell.getBoundingClientRect()
+        await expect(height).toBe(size === 'large' ? 48 : 40)
+      })
+    })
+  },
 }
 
 export const Striped: Story = {
-  ...Primary,
   args: {
     striped: true,
     className: 'my-class',
@@ -82,7 +104,7 @@ export const Striped: Story = {
     const table = canvas.getByLabelText(args['aria-label'] as string)
 
     await step('Class names should be appended', async () => {
-      expect(table).toHaveClass(styles.table, 'my-class')
+      await expect(table).toHaveClass(styles.table, args.className as string)
     })
 
     await step('The rows should change background color on hover', async () => {

--- a/packages/components/src/table/Table.stories.tsx
+++ b/packages/components/src/table/Table.stories.tsx
@@ -78,16 +78,20 @@ export default {
 export const Primary: Story = {
   play: async ({ canvas, step, globals: { size } }) => {
     await step(
-      'columns should change size according to size prop',
+      'table headers should change size according to size prop',
       async () => {
-        canvas.getAllByRole('columnheader').forEach(async column => {
+        const tableHeaders = await canvas.findAllByRole('columnheader')
+
+        tableHeaders.forEach(async column => {
           const { height } = column.getBoundingClientRect()
           await expect(height).toBe(size === 'large' ? 48 : 40)
         })
       },
     )
     await step('cells should change size according to size prop', async () => {
-      canvas.getAllByRole('gridcell').forEach(async cell => {
+      const cells = await canvas.findAllByRole('gridcell')
+
+      cells.forEach(async cell => {
         const { height } = cell.getBoundingClientRect()
         await expect(height).toBe(size === 'large' ? 48 : 40)
       })

--- a/packages/components/src/table/Table.tsx
+++ b/packages/components/src/table/Table.tsx
@@ -36,7 +36,7 @@ export interface TableProps extends AriaTableProps {
    *  @deprecated since v10.1.1, please use the `size` prop instead.
    */
   narrow?: boolean
-  /** Row and column height (large: 48px, medium: 40px)
+  /** Row height (large: 48px, medium: 40px)
    *  @default 'large'
    * */
   size?: Size
@@ -48,26 +48,20 @@ export interface TableProps extends AriaTableProps {
 
 export const Table = ({
   narrow,
-  size,
+  size = 'large',
   striped,
   className,
   ...rest
-}: TableProps) => {
-  const classNames = clsx(
-    styles.table,
-    narrow && styles.narrow,
-    size === 'medium' && styles.medium,
-    striped && styles.striped,
-    className,
-  )
-
-  return (
-    <AriaTable
-      className={classNames}
-      {...rest}
-    />
-  )
-}
+}: TableProps) => (
+  <AriaTable
+    className={clsx(styles.table, className, {
+      [styles.narrow]: narrow,
+      [styles.medium]: size === 'medium',
+      [styles.striped]: striped,
+    })}
+    {...rest}
+  />
+)
 
 export const TableHeader = <T extends object>({
   columns,

--- a/packages/components/src/table/Table.tsx
+++ b/packages/components/src/table/Table.tsx
@@ -28,22 +28,35 @@ import {
   GripVertical,
 } from 'lucide-react'
 import clsx from 'clsx'
+import { Size } from '../common/types'
 
 export interface TableProps extends AriaTableProps {
   /**
    *  A more compact version of the table
+   *  @deprecated since v10.1.1, please use the `size` prop instead.
    */
   narrow?: boolean
+  /** Row and column height (large: 48px, medium: 40px)
+   *  @default 'large'
+   * */
+  size?: Size
   /**
    * Alternating colors for rows
    */
   striped?: boolean
 }
 
-export const Table = ({ narrow, striped, className, ...rest }: TableProps) => {
+export const Table = ({
+  narrow,
+  size,
+  striped,
+  className,
+  ...rest
+}: TableProps) => {
   const classNames = clsx(
     styles.table,
     narrow && styles.narrow,
+    size === 'medium' && styles.medium,
     striped && styles.striped,
     className,
   )

--- a/packages/components/src/table/Table.tsx
+++ b/packages/components/src/table/Table.tsx
@@ -47,9 +47,9 @@ export interface TableProps extends AriaTableProps {
 }
 
 export const Table = ({
-  narrow,
+  narrow = false,
   size = 'large',
-  striped,
+  striped = false,
   className,
   ...rest
 }: TableProps) => (


### PR DESCRIPTION
## Description

Medium size for `Table`

## Changes

- feat(table): add size prop
- style(table): adjust paddings and heights
- test(table): test medium size prop
- docs(table): update docs on medium size

## Additional Information

Found some deviations from the Figma figma spec!
Updates the font size and paddings

- sort the CSS
- use token values
- get rid of DOM element selectors like `th` and `td` in favor of `.cell` and `.column` etc.
- nest some selectors
- update the styling for `narrow` even if its deprecated.

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
