### PR TITLE
docs(radio): use null as empty value in controlled example

### DIFF
--- a/apps/docs/docs/components/radio.mdx
+++ b/apps/docs/docs/components/radio.mdx
@@ -52,12 +52,17 @@ import { Radio, RadioGroup } from '@midas-ds/components'
 Använd attributet `value` och eventet `onChange` för att använda controlled value på RadioGroup.
 Den valda radioknappens värde skickas till callbacken, så kan du använda det för att uppdatera ditt state.
 
+:::warning
+Notera att ett tomt val representeras av `null` eller `undefined` och inte en tom sträng.
+:::
+
 ```tsx
 import React from 'react'
 ```
 
 ```tsx
-const [selectedFruit, setSelectedFruit] = useState('')
+// highlight-next-line
+const [selectedFruit, setSelectedFruit] = useState<string | null>(null)
 
 return (
   <RadioGroup

--- a/apps/docs/src/components/examples/radio/RadioExamples.tsx
+++ b/apps/docs/src/components/examples/radio/RadioExamples.tsx
@@ -14,7 +14,7 @@ export const BasicExample: React.FC = () => (
 )
 
 export const ControlledExample = () => {
-  const [selectedFruit, setSelectedFruit] = useState('')
+  const [selectedFruit, setSelectedFruit] = useState<string | null>(null)
 
   return (
     <>


### PR DESCRIPTION
## Description

An example of the `RadioGroup` in the docs app causes some a11y issues.

## Changes

- use `null` as empty value in controlled example

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
