### PR TITLE
fix(calendar): fix the text color in enable hover state

### DIFF
--- a/packages/components/src/calendar/Calendar.module.css
+++ b/packages/components/src/calendar/Calendar.module.css
@@ -144,11 +144,7 @@
   border: solid 2px --layer-01;
   cursor: pointer;
 
-  &[data-hovered]:not(
-      [data-unavailable],
-      [data-disabled],
-      [data-selected]
-    ) {
+  &[data-hovered]:not([data-unavailable], [data-disabled], [data-selected]) {
     background-color: --field-hover-01;
     border-color: --field-hover-01;
   }


### PR DESCRIPTION
## Description

enable hover has wrong text color

## Changes

add color to text in hover 

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
