### PR TITLE
docs: edit changelog autoformatting

### DIFF
--- a/apps/docs/changelog/source/1.0.1.md
+++ b/apps/docs/changelog/source/1.0.1.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-01-27T19:00
 ---
 
@@ -8,7 +8,7 @@ date: 2025-01-27T19:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **tag:** create a new component
 - **modal:** create a new component
@@ -58,7 +58,7 @@ date: 2025-01-27T19:00
 - **text-field:** support counter and maxCharacters
 - **ui:** export new components
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** hover on trigger
 - **accordion:** update icon size
@@ -213,7 +213,7 @@ date: 2025-01-27T19:00
 - **toast:** new focus state
 - **ui:** add modal
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - **modal:** new API
 - **card:** new card api

--- a/apps/docs/changelog/source/1.0.2.md
+++ b/apps/docs/changelog/source/1.0.2.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-01-27T20:00
 ---
 
@@ -8,7 +8,7 @@ date: 2025-01-27T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **modal:** create a new component
 - **button:** add react aria button component
@@ -59,7 +59,7 @@ date: 2025-01-27T20:00
 - **ui:** export new components
 -
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** hover on trigger
 - **accordion:** update icon size
@@ -212,7 +212,7 @@ date: 2025-01-27T20:00
 - **ui:** add modal
 - **ui:** update theme version
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - **modal:** new API
 - **card:** new card api

--- a/apps/docs/changelog/source/1.1.0.md
+++ b/apps/docs/changelog/source/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-01-31T20:00
 ---
 
@@ -8,6 +8,6 @@ date: 2025-01-31T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **components:** new api and style for accordion

--- a/apps/docs/changelog/source/1.2.0.md
+++ b/apps/docs/changelog/source/1.2.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-02-11T20:00
 ---
 
@@ -8,12 +8,12 @@ date: 2025-02-11T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **components:** new api and style for accordion ([efab0a198](https://github.com/migrationsverket/midas/commit/efab0a198))
 - **components:** add nvm config ([7cbbce66e](https://github.com/migrationsverket/midas/commit/7cbbce66e))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - import/export text-field css directly from css module ([#212](https://github.com/migrationsverket/midas/pull/212))
 - **components:** fix text when titles are longer than one row ([28b06cd31](https://github.com/migrationsverket/midas/commit/28b06cd31))

--- a/apps/docs/changelog/source/1.3.0.md
+++ b/apps/docs/changelog/source/1.3.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-02-19T20:00
 ---
 
@@ -8,12 +8,12 @@ date: 2025-02-19T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **accordion:** support react nodes in title ([#259](https://github.com/migrationsverket/midas/pull/259))
 - **text-field:** add dossier number validation ([#261](https://github.com/migrationsverket/midas/pull/261))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** support any elements in title ([1129fd742](https://github.com/migrationsverket/midas/commit/1129fd742))
 - **card:** add React.useId to generate unique id ([160319d03](https://github.com/migrationsverket/midas/commit/160319d03))

--- a/apps/docs/changelog/source/10.0.0.md
+++ b/apps/docs/changelog/source/10.0.0.md
@@ -8,7 +8,7 @@ date: 2025-05-20T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - ⚠️ **accordion:** remove deprecated prop `type='multiple'`, use `allowsMultipleExpanded` instead ([8c82cbd681](https://github.com/migrationsverket/midas/commit/8c82cbd681))
 - **button:** add size property, a story and style ([946bd9aa7d](https://github.com/migrationsverket/midas/commit/946bd9aa7d))
@@ -37,14 +37,14 @@ date: 2025-05-20T20:00
 - ⚠️ **tokens:** rename tokens `blue140` & `blue170` and add new tokens `blue110`, `blue120`, rename `purple140` to `purple110` ([b79d586d53](https://github.com/migrationsverket/midas/commit/b79d586d53))
 - **tokens:** add new tokens `blue50` and `blue70`, update link colors ([d814a4c961](https://github.com/migrationsverket/midas/commit/d814a4c961))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - replace unsupported characters in chromatic permalink ([d653d10e69](https://github.com/migrationsverket/midas/commit/d653d10e69))
 - **accordion:** set correct height on uncontained variant ([#557](https://github.com/migrationsverket/midas/pull/557))
 - **calendar:** add cursor: not-allowed on disabled dates ([6592b4fb15](https://github.com/migrationsverket/midas/commit/6592b4fb15))
 - **select:** increase the margin top to give more space between tag group and select ([5514f642b0](https://github.com/migrationsverket/midas/commit/5514f642b0))
 
-### 📖 Documentation changes
+## 📖 Documentation changes
 
 - truly responsive propstable ([#554](https://github.com/migrationsverket/midas/pull/554))
 - swizzle admonitions ([#538](https://github.com/migrationsverket/midas/pull/538))
@@ -75,7 +75,7 @@ date: 2025-05-20T20:00
 - **release:** update release notes with breaking changes `purple140` -> `purple110` ([22f685ae97](https://github.com/migrationsverket/midas/commit/22f685ae97))
 - **tokens:** fix typo ([d55e6f224b](https://github.com/migrationsverket/midas/commit/d55e6f224b))
 
-### 🔧 Maintenance
+## 🔧 Maintenance
 
 - update version in eslint config ([93edc05f7c](https://github.com/migrationsverket/midas/commit/93edc05f7c))
 - add new eslint rules ([#545](https://github.com/migrationsverket/midas/pull/545))
@@ -88,7 +88,7 @@ date: 2025-05-20T20:00
 - **deps:** bump undici in the npm_and_yarn group across 1 directory ([63e9f61a23](https://github.com/migrationsverket/midas/commit/63e9f61a23))
 - ⚠️ **useMessageFormatter:** remove `useMessageFormatter` since deprecation ([01d94a8d75](https://github.com/migrationsverket/midas/commit/01d94a8d75))
 
-### 🧪 Tests updated
+## 🧪 Tests updated
 
 - **button:** add a test in primary story ([53f4fe042e](https://github.com/migrationsverket/midas/commit/53f4fe042e))
 - **button:** add a test to stories ([0348794fc7](https://github.com/migrationsverket/midas/commit/0348794fc7))
@@ -97,7 +97,7 @@ date: 2025-05-20T20:00
 - **select:** add test to check the size ([2c692d9ea0](https://github.com/migrationsverket/midas/commit/2c692d9ea0))
 - **select:** fix the test ([f41535787b](https://github.com/migrationsverket/midas/commit/f41535787b))
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - ⚠️ **tokens:** rename tokens `blue140` & `blue170` and add new tokens `blue110`, `blue120`, rename `purple140` to `purple110` ([b79d586d53](https://github.com/migrationsverket/midas/commit/b79d586d53))
 - **skeleton:** variant `rectangular` is no longer available, use `rectangle` instead. Animation is now a boolean and the prop to use is `isAnimated`

--- a/apps/docs/changelog/source/10.1.0.md
+++ b/apps/docs/changelog/source/10.1.0.md
@@ -8,9 +8,7 @@ date: 2025-05-23T20:00
 
 <!-- truncate -->
 
-#
-
-### 🚀 Features
+## 🚀 Features
 
 - **accordion:** add new variant `hasBackground` ([1022bcc58a](https://github.com/migrationsverket/midas/commit/1022bcc58a))
 - **accordion:** add variant `hasBackground` ([2b429a73b3](https://github.com/migrationsverket/midas/commit/2b429a73b3))
@@ -19,7 +17,7 @@ date: 2025-05-23T20:00
 - **tag:** add new prop ([82a0998769](https://github.com/migrationsverket/midas/commit/82a0998769))
 - **tag:** add dark mode style ([408be2acb7](https://github.com/migrationsverket/midas/commit/408be2acb7))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **link-button:** add disabled styling ([143f708127](https://github.com/migrationsverket/midas/commit/143f708127))
 - **radio:** remove interactions with radiogroup items outside the label and button ([0b9f197971](https://github.com/migrationsverket/midas/commit/0b9f197971))
@@ -30,18 +28,18 @@ date: 2025-05-23T20:00
 - **tag:** unset border to make button the right width/height ([769cfa8ec5](https://github.com/migrationsverket/midas/commit/769cfa8ec5))
 - **tag:** fix the hover and fix the disabled style ([3a21642715](https://github.com/migrationsverket/midas/commit/3a21642715))
 
-### 💅 Refactors
+## 💅 Refactors
 
 - **tag:** move render function to meta data ([48d9f9b126](https://github.com/migrationsverket/midas/commit/48d9f9b126))
 
-### 📖 Documentation changes
+## 📖 Documentation changes
 
 - add usage example ([c25a9cafc5](https://github.com/migrationsverket/midas/commit/c25a9cafc5))
 - control size globally in storybook + new dark mode control ([#596](https://github.com/migrationsverket/midas/pull/596))
 - **tag:** add new tag page ([f3f7506d18](https://github.com/migrationsverket/midas/commit/f3f7506d18))
 - **tag:** fix description text ([979a879bb3](https://github.com/migrationsverket/midas/commit/979a879bb3))
 
-### 🔧 Maintenance
+## 🔧 Maintenance
 
 - change react import statement ([efe3c867f0](https://github.com/migrationsverket/midas/commit/efe3c867f0))
 - update eslint rule to handle major versions > 9 ([ba85178773](https://github.com/migrationsverket/midas/commit/ba85178773))

--- a/apps/docs/changelog/source/10.1.1.md
+++ b/apps/docs/changelog/source/10.1.1.md
@@ -8,9 +8,7 @@ date: 2025-06-09T20:00
 
 <!-- truncate -->
 
-#
-
-### 🩹 Fixes
+## 🩹 Fixes
 
 - replace invalid token --blue-140 ([#620](https://github.com/migrationsverket/midas/pull/620))
 - **combobox:** virtualize the listbox ([14745432fc](https://github.com/migrationsverket/midas/commit/14745432fc))
@@ -19,7 +17,7 @@ date: 2025-06-09T20:00
 - **link:** better icon logic on links, support for external and download ([#617](https://github.com/migrationsverket/midas/pull/617))
 - **link-button:** add support for medium size ([#618](https://github.com/migrationsverket/midas/pull/618))
 
-### 💅 Refactors
+## 💅 Refactors
 
 - **combobox:** extract shared listbox components ([bfe30e237e](https://github.com/migrationsverket/midas/commit/bfe30e237e))
 - **combobox:** add explicit id prop to sections ([57b0df3264](https://github.com/migrationsverket/midas/commit/57b0df3264))
@@ -27,7 +25,7 @@ date: 2025-06-09T20:00
 - **select:** separate code ([01926124ee](https://github.com/migrationsverket/midas/commit/01926124ee))
 - **select:** merge select and combobox list item types ([ed6bbf4d50](https://github.com/migrationsverket/midas/commit/ed6bbf4d50))
 
-### 📖 Documentation changes
+## 📖 Documentation changes
 
 - link to latest major release notes ([f5ed23dc93](https://github.com/migrationsverket/midas/commit/f5ed23dc93))
 - improvements to link pages ([#612](https://github.com/migrationsverket/midas/pull/612))
@@ -39,7 +37,7 @@ date: 2025-06-09T20:00
 - **combobox:** update sectioned example ([c32d5db3e6](https://github.com/migrationsverket/midas/commit/c32d5db3e6))
 - **release-notes:** add release notes for 10.1.0 ([a912e097bc](https://github.com/migrationsverket/midas/commit/a912e097bc))
 
-### 🔧 Maintenance
+## 🔧 Maintenance
 
 - test chromatic build ([8613c3cded](https://github.com/migrationsverket/midas/commit/8613c3cded))
 - update test files with changed props ([fd165fa775](https://github.com/migrationsverket/midas/commit/fd165fa775))

--- a/apps/docs/changelog/source/10.2.0.md
+++ b/apps/docs/changelog/source/10.2.0.md
@@ -8,9 +8,7 @@ date: 2025-06-18T20:00
 
 <!-- truncate -->
 
-#
-
-### 🚀 Features
+## 🚀 Features
 
 - **calendar:** extend calendar with state for disabled ([#635](https://github.com/migrationsverket/midas/pull/635))
 - **grid:** new grid v2 📏 ([#656](https://github.com/migrationsverket/midas/pull/656))
@@ -18,17 +16,17 @@ date: 2025-06-18T20:00
 - **table:** add size prop ([6f3cc36071](https://github.com/migrationsverket/midas/commit/6f3cc36071))
 - **theme:** new color tokens for skeleton ([#663](https://github.com/migrationsverket/midas/pull/663))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - css syntax errors for media queries ([d4935c1e57](https://github.com/migrationsverket/midas/commit/d4935c1e57))
 - **calendar:** change text color for day button on hover ([#651](https://github.com/migrationsverket/midas/pull/651))
 - **textfield:** remove `height:100%` on wrapper ([dccd5bdd09](https://github.com/migrationsverket/midas/commit/dccd5bdd09))
 
-### 💅 Refactors
+## 💅 Refactors
 
 - **field-error:** make component usable without context ([9ce07e9444](https://github.com/migrationsverket/midas/commit/9ce07e9444))
 
-### 📖 Documentation changes
+## 📖 Documentation changes
 
 - add release notes for 10.1.1 ([154ab05ae6](https://github.com/migrationsverket/midas/commit/154ab05ae6))
 - add new UI kit ([0badda2287](https://github.com/migrationsverket/midas/commit/0badda2287))
@@ -54,7 +52,7 @@ date: 2025-06-18T20:00
 - **table:** update docs on medium size ([c70a1ff4df](https://github.com/migrationsverket/midas/commit/c70a1ff4df))
 - **table:** change 'striped' description ([49005eea58](https://github.com/migrationsverket/midas/commit/49005eea58))
 
-### 🔧 Maintenance
+## 🔧 Maintenance
 
 - run storybook tests in pipeline temporary ([730680d696](https://github.com/migrationsverket/midas/commit/730680d696))
 - format css ([9c9e48254f](https://github.com/migrationsverket/midas/commit/9c9e48254f))
@@ -65,14 +63,14 @@ date: 2025-06-18T20:00
 - **deps-dev:** bump brace-expansion ([4cdfd0e167](https://github.com/migrationsverket/midas/commit/4cdfd0e167))
 - **search-field:** add column id type to story ([12a8b9af66](https://github.com/migrationsverket/midas/commit/12a8b9af66))
 
-### 🧪 Tests updated
+## 🧪 Tests updated
 
 - **calendar:** bypass a11y tests on disabled stories ([d1ce956cb5](https://github.com/migrationsverket/midas/commit/d1ce956cb5))
 - **table:** test medium size prop ([073b317cc8](https://github.com/migrationsverket/midas/commit/073b317cc8))
 - **table:** await queries ([7e18645ead](https://github.com/migrationsverket/midas/commit/7e18645ead))
 - **table:** add chromatic modes ([7081f8adac](https://github.com/migrationsverket/midas/commit/7081f8adac))
 
-### 🎨 Styles
+## 🎨 Styles
 
 - **link-button:** change chevron icon to arrow icon ([#647](https://github.com/migrationsverket/midas/pull/647))
 - **table:** adjust paddings and heights ([b84828bfd7](https://github.com/migrationsverket/midas/commit/b84828bfd7))

--- a/apps/docs/changelog/source/2.0.0.md
+++ b/apps/docs/changelog/source/2.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-02-25T20:00
 ---
 
@@ -8,14 +8,14 @@ date: 2025-02-25T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - **layout:** design improvements + tooltip ([#231](https://github.com/migrationsverket/midas/pull/231))
 - ⚠️ **textarea:** rename maxCharacters property ([06116cee9](https://github.com/migrationsverket/midas/commit/06116cee9))
 - ⚠️ **text-field:** rename maxCharacters property ([44eec760e](https://github.com/migrationsverket/midas/commit/44eec760e))
 - **tooltip:** new component tooltip ([3bc3fcd4f](https://github.com/migrationsverket/midas/commit/3bc3fcd4f))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accessibility:** fix focus for high contrast mode ([#267](https://github.com/migrationsverket/midas/pull/267))
 - **accordion:** append classname ([aaaa0ddb1](https://github.com/migrationsverket/midas/commit/aaaa0ddb1))
@@ -41,7 +41,7 @@ date: 2025-02-25T20:00
 - **theme:** add global css export ([#282](https://github.com/migrationsverket/midas/pull/282))
 - **tooltip:** append classname ([0e6e6e483](https://github.com/migrationsverket/midas/commit/0e6e6e483))
 
-### Documentation Changes
+## Documentation Changes
 
 - dropdown + layout + tooltip ([28d3bc661](https://github.com/migrationsverket/midas/commit/28d3bc661))
 - **components:** sync docusaurus and storybook autodocs config ([4e061ad4d](https://github.com/migrationsverket/midas/commit/4e061ad4d))
@@ -50,6 +50,6 @@ date: 2025-02-25T20:00
 - **docs:** add link to design pattern ([38db9d2de](https://github.com/migrationsverket/midas/commit/38db9d2de))
 - **file-upload:** manually extend react aria props for autodocs ([07ecde229](https://github.com/migrationsverket/midas/commit/07ecde229))
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - **textarea:** TextArea propert maxCharacters is renamed to maxLength

--- a/apps/docs/changelog/source/2.0.1.md
+++ b/apps/docs/changelog/source/2.0.1.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-02-27T20:00
 ---
 
@@ -8,13 +8,13 @@ date: 2025-02-27T20:00
 
 <!-- truncate -->
 
-##
+## 🩹 Fixes
 
 - **radio:** fix hover on mobile, remove 100% height on RadioGroup ([#286](https://github.com/migrationsverket/midas/pull/286))
 - **text-field:** update dossnr regex to support new delimiter ([c5e1b4428](https://github.com/migrationsverket/midas/commit/c5e1b4428))
 - **text-field:** add rule for matching delimiters for doss nr ([026073775](https://github.com/migrationsverket/midas/commit/026073775))
 - **text-field:** cover more cases on dossnr ([0f27d8b33](https://github.com/migrationsverket/midas/commit/0f27d8b33))
 
-### Documentation Changes
+## Documentation Changes
 
 - update get started with node 22 ([098e4e1e0](https://github.com/migrationsverket/midas/commit/098e4e1e0))

--- a/apps/docs/changelog/source/3.0.0.md
+++ b/apps/docs/changelog/source/3.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-02-28T20:00
 ---
 
@@ -8,11 +8,11 @@ date: 2025-02-28T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - ⚠️ **search-field:** remove broken property ([1c04349ce](https://github.com/migrationsverket/midas/commit/1c04349ce))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **card:** append props.className ([#295](https://github.com/migrationsverket/midas/pull/295))
 - **search-field:** move validation error message ([85c1b7990](https://github.com/migrationsverket/midas/commit/85c1b7990))
@@ -23,10 +23,10 @@ date: 2025-02-28T20:00
 - **search-field:** add border bottom and pixel push some paddings ([e53d56bb7](https://github.com/migrationsverket/midas/commit/e53d56bb7))
 - **search-field:** validation text ([#290](https://github.com/migrationsverket/midas/pull/290))
 
-### Documentation Changes
+## Documentation Changes
 
 - **search-field:** add stories ([8766d4d8e](https://github.com/migrationsverket/midas/commit/8766d4d8e))
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - **search-field:** `isRequired` property of `SearchField` is no longer supported

--- a/apps/docs/changelog/source/3.1.0.md
+++ b/apps/docs/changelog/source/3.1.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-06T20:00
 ---
 
@@ -8,11 +8,11 @@ date: 2025-03-06T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **button:** set primary border to 2px when in high-contrast mode ([fdcf32e1d](https://github.com/migrationsverket/midas/commit/fdcf32e1d))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **calendar** set default weekday style to `short` ([#303](https://github.com/migrationsverket/midas/pull/303))
 - **checkbox:** change cursor to pointer ([d5ce18403](https://github.com/migrationsverket/midas/commit/d5ce18403))
@@ -21,7 +21,7 @@ date: 2025-03-06T20:00
 - **datepicker:** change cursor to pointer ([5425f7282](https://github.com/migrationsverket/midas/commit/5425f7282))
 - **radio:** change cursor to pointer ([c18ec8f4e](https://github.com/migrationsverket/midas/commit/c18ec8f4e))
 
-### Documentation Changes
+## Documentation Changes
 
 - add new UIkit ([a47947b63](https://github.com/migrationsverket/midas/commit/a47947b63))
 - add instructions for bug reporting ([93205ee30](https://github.com/migrationsverket/midas/commit/93205ee30))

--- a/apps/docs/changelog/source/4.0.0.md
+++ b/apps/docs/changelog/source/4.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-10T20:00
 ---
 
@@ -8,20 +8,20 @@ date: 2025-03-10T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - ⚠️ updated select, multi-select and modal components
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **layout:** design adjustments
 - **radio:** change cursor to pointer
 
-### Documentation Changes
+## Documentation Changes
 
 - **date-picker:** add style unavailable and code example for Unavailable Date in docs
 - **docs:** add new UIkit
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - `Select`, `MultiSelect` and `Modal` now have updated API:s, expect things not to work as before. Make sure to check the API:s before upgrading.

--- a/apps/docs/changelog/source/5.0.0.md
+++ b/apps/docs/changelog/source/5.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-17T20:00
 ---
 
@@ -8,11 +8,11 @@ date: 2025-03-17T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - ⚠️ support for dark mode across all components
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **button:** deprecate small version
 - **card:** deprecate card background
@@ -25,7 +25,7 @@ date: 2025-03-17T20:00
 - **select:** change direct element selector
 - **table:** deprecate narrow version
 
-### Documentation Changes
+## Documentation Changes
 
 - dark mode support for storybook and docusaurus
 - add instructions for bug reporting
@@ -39,6 +39,6 @@ date: 2025-03-17T20:00
 - **docs:** add new UIkit
 - **localization:** add dev instructions for localization
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - dark mode :city_sunrise:

--- a/apps/docs/changelog/source/5.0.1.md
+++ b/apps/docs/changelog/source/5.0.1.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-20T20:00
 ---
 
@@ -8,7 +8,7 @@ date: 2025-03-20T20:00
 
 <!-- truncate -->
 
-##
+## 🩹 Fixes
 
 - **checkbox:** swap old tokens
 - **checkbox:** swap old focus token
@@ -20,7 +20,7 @@ date: 2025-03-20T20:00
 - **toast:** remove explicit dep
 - **toast:** re-organize animations and breakpoints
 
-### Documentation Changes
+## Documentation Changes
 
 - add strict mode to docs
 - add strict mode to docs

--- a/apps/docs/changelog/source/6.0.0.md
+++ b/apps/docs/changelog/source/6.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-24T19:00
 ---
 
@@ -8,7 +8,7 @@ date: 2025-03-24T19:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - use `cursor: not-allowed` for disabled elements
 - **modal:** add boilerplate code for new modal implementation
@@ -19,7 +19,7 @@ date: 2025-03-24T19:00
 - ⚠️ **modal:** deprecate `ModalTrigger` and `Dialog`
 - **modal:** replace h2 with heading component
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - remove test setup from build
 - add react types to dependencies
@@ -32,10 +32,10 @@ date: 2025-03-24T19:00
 - **button:** change iconbtn color token
 - **layout:** change minimize menu button to icon variant
 
-### Documentation Changes
+## Documentation Changes
 
 - **modal:** update instructions with new modal API
 
-### ⚠️ Breaking Changes
+## ⚠️ Breaking Changes
 
 - **modal:** Use the new DialogTrigger and Modal instead of ModalTrigger and Dialog. New API will apply.

--- a/apps/docs/changelog/source/6.0.1.md
+++ b/apps/docs/changelog/source/6.0.1.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-24T20:00
 ---
 
@@ -8,6 +8,6 @@ date: 2025-03-24T20:00
 
 <!-- truncate -->
 
-##
+## 🩹 Fixes
 
 - **select:** 🐛 Selected values doesn't match selected IDs

--- a/apps/docs/changelog/source/6.1.0.md
+++ b/apps/docs/changelog/source/6.1.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-03-28T20:00
 ---
 
@@ -8,11 +8,11 @@ date: 2025-03-28T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **text:** add description slot ([73d308a13](https://github.com/migrationsverket/midas/commit/73d308a13))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **link-button:** add pseudo-classes in CSS link-button ([#385](https://github.com/migrationsverket/midas/pull/385))
 - **textfield:** fix token on input value ([e79f935e3](https://github.com/migrationsverket/midas/commit/e79f935e3))

--- a/apps/docs/changelog/source/6.2.0.md
+++ b/apps/docs/changelog/source/6.2.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-01T20:00
 ---
 
@@ -8,12 +8,12 @@ date: 2025-04-01T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **badge:** 🆕 new component - badge to indicate user of unread items
 - **badge:** 🆕 new component - badge to indicate user of unread items
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **date-picker:** add disabled style to divider
 - **link-button:** fix secondary border and icon color in dark mode
@@ -26,7 +26,7 @@ date: 2025-04-01T20:00
 - **theme:** update icon-secondary with new value for dark mode
 - **theme:** update some tokens to new naming convention
 
-### Documentation Changes
+## Documentation Changes
 
 - april fools
 - a bit longer april fools joke

--- a/apps/docs/changelog/source/7.0.0.md
+++ b/apps/docs/changelog/source/7.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-02T20:00
 ---
 
@@ -8,7 +8,7 @@ date: 2025-04-02T20:00
 
 <!-- truncate -->
 
-### Documentation Changes
+## Documentation Changes
 
 - remove april fools ([4bcdaa31c](https://github.com/migrationsverket/midas/commit/4bcdaa31c))
 - remove april fools ([#381](https://github.com/migrationsverket/midas/pull/381))

--- a/apps/docs/changelog/source/7.1.0.md
+++ b/apps/docs/changelog/source/7.1.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-04T20:00
 ---
 
@@ -8,17 +8,17 @@ date: 2025-04-04T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - ✨💄 add semantic z-index tokens ([#401](https://github.com/migrationsverket/midas/pull/401))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **combobox:** fix background color to input ([997eac80b](https://github.com/migrationsverket/midas/commit/997eac80b))
 - **date-picker:** add missing disabled styles ([10b394897](https://github.com/migrationsverket/midas/commit/10b394897))
 - **theme:** replace invalid text and border colors in dark mode ([3291a9cbd](https://github.com/migrationsverket/midas/commit/3291a9cbd))
 
-### Documentation Changes
+## Documentation Changes
 
 - **link:** fix broken url address ([#403](https://github.com/migrationsverket/midas/pull/403))
 - **modal:** 📝 add examples with form elements ([#399](https://github.com/migrationsverket/midas/pull/399))

--- a/apps/docs/changelog/source/8.0.0.md
+++ b/apps/docs/changelog/source/8.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-15T20:00
 ---
 
@@ -8,14 +8,14 @@ date: 2025-04-15T20:00
 
 <!-- truncate -->
 
-### 🚀 Features
+## 🚀 Features
 
 - ✨💄 add semantic z-index tokens ([#401](https://github.com/migrationsverket/midas/pull/401))
 - ✨ add errorPosition to form fields ([#416](https://github.com/migrationsverket/midas/pull/416))
 - **layout:** new navbar component and external variant of layout ([ad54f5955](https://github.com/migrationsverket/midas/commit/ad54f5955))
 - **spinner:** change prop `dark` to `isOnColor` ([#443](https://github.com/migrationsverket/midas/pull/443))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** fix responsive content hiding when changing screen size ([#446](https://github.com/migrationsverket/midas/pull/446))
 - **button:** add cursor styling for disabled state ([1ab3f6c55](https://github.com/migrationsverket/midas/commit/1ab3f6c55))
@@ -29,7 +29,7 @@ date: 2025-04-15T20:00
 - **radio:** add support for horizontal orientation ([e5c9ad3eb](https://github.com/migrationsverket/midas/commit/e5c9ad3eb))
 - **theme:** replace invalid text and border colors in dark mode ([a6259f46c](https://github.com/migrationsverket/midas/commit/a6259f46c))
 
-### Documentation Changes
+## Documentation Changes
 
 - use markdown links ([f1fb5714b](https://github.com/migrationsverket/midas/commit/f1fb5714b))
 - update link docs with new code and examples ([a25a2def3](https://github.com/migrationsverket/midas/commit/a25a2def3))

--- a/apps/docs/changelog/source/8.1.0.md
+++ b/apps/docs/changelog/source/8.1.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-23T20:00
 ---
 
@@ -8,11 +8,11 @@ date: 2025-04-23T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **accordion:** accordion status ✅ / 🚨 ([#485](https://github.com/migrationsverket/midas/pull/485))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** rename invalid token ([e4b13c928](https://github.com/migrationsverket/midas/commit/e4b13c928))
 - **modal:** make text in modal selectable ([#490](https://github.com/migrationsverket/midas/pull/490))
@@ -20,7 +20,7 @@ date: 2025-04-23T20:00
 - **select:** remove explicit size for indeterminate symbol ([5f805c134](https://github.com/migrationsverket/midas/commit/5f805c134))
 - **theme:** add dark mode focus ([#483](https://github.com/migrationsverket/midas/pull/483))
 
-### Documentation Changes
+## Documentation Changes
 
 - clarify use of global.css and disable switch functionality ([#489](https://github.com/migrationsverket/midas/pull/489))
 - **link:** remove invalid dom nesting ([38a742db5](https://github.com/migrationsverket/midas/commit/38a742db5))

--- a/apps/docs/changelog/source/8.2.0.md
+++ b/apps/docs/changelog/source/8.2.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-04-28T20:00
 ---
 
@@ -8,18 +8,18 @@ date: 2025-04-28T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **label:** deprecate prop variant and add new css class ([42e33be662](https://github.com/migrationsverket/midas/commit/42e33be662))
 - **theme:** add --icon-tertiary, new color for --icon-secondary ([f0ef381472](https://github.com/migrationsverket/midas/commit/f0ef381472))
 - **tooltip:** allow locale agnostic tooltip placement ([#492](https://github.com/migrationsverket/midas/pull/492))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** remove disabled styling if component has disabled children ([1c704b714d](https://github.com/migrationsverket/midas/commit/1c704b714d))
 - **checkbox:** set correct line-height and adjust high contrast visibility ([6ca7ea9ba9](https://github.com/migrationsverket/midas/commit/6ca7ea9ba9))
 
-### Documentation Changes
+## Documentation Changes
 
 - add test docs ([af6540ff7c](https://github.com/migrationsverket/midas/commit/af6540ff7c))
 - move test instructions to a separate file ([33fe370e2d](https://github.com/migrationsverket/midas/commit/33fe370e2d))

--- a/apps/docs/changelog/source/8.3.0.md
+++ b/apps/docs/changelog/source/8.3.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-05-07T20:00
 ---
 
@@ -8,14 +8,14 @@ date: 2025-05-07T20:00
 
 <!-- truncate -->
 
-##
+## 🚀 Features
 
 - **layout:** change background color for menu item ([d9ffc16bb6](https://github.com/migrationsverket/midas/commit/d9ffc16bb6))
 - **layout:** change font weight for active menu item ([57e2485234](https://github.com/migrationsverket/midas/commit/57e2485234))
 - **textfield:** add medium size variant ([#520](https://github.com/migrationsverket/midas/pull/520))
 - **theme:** use `--support-border-warning` instead of `--border-invalid` ([#518](https://github.com/migrationsverket/midas/pull/518))
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **accordion:** remove padding bottom for last uncontained accordionitem ([463a7fa29e](https://github.com/migrationsverket/midas/commit/463a7fa29e))
 - **accordion:** add a minimal padding to allow items with margin-bottom ([e0b2d8058b](https://github.com/migrationsverket/midas/commit/e0b2d8058b))
@@ -26,7 +26,7 @@ date: 2025-05-07T20:00
 - **textfield:** add border bottom in disabled and change ivalid border to 2px ([2bcd1d5beb](https://github.com/migrationsverket/midas/commit/2bcd1d5beb))
 - **textfield:** remove opacity from disabled ([0332d83cb6](https://github.com/migrationsverket/midas/commit/0332d83cb6))
 
-### Documentation Changes
+## Documentation Changes
 
 - improvements to preview 💅 🔍 ✨ ([#530](https://github.com/migrationsverket/midas/pull/530))
 - **radio:** update Radio button guidelines ([6c5038fff1](https://github.com/migrationsverket/midas/commit/6c5038fff1))

--- a/apps/docs/changelog/source/9.0.0.md
+++ b/apps/docs/changelog/source/9.0.0.md
@@ -1,6 +1,6 @@
 ---
 mdx:
- format: md
+  format: md
 date: 2025-05-08T20:00
 ---
 
@@ -8,12 +8,12 @@ date: 2025-05-08T20:00
 
 <!-- truncate -->
 
-### 🩹 Fixes
+## 🩹 Fixes
 
 - **grid:** prevent midas classnames to get overwritten ([#541](https://github.com/migrationsverket/midas/pull/541))
 - **info-banner:** add correct line-height ([#540](https://github.com/migrationsverket/midas/pull/540))
 - **textfield:** merge textfield and input/textarea native dom props ([#499](https://github.com/migrationsverket/midas/pull/499))
 
-### Documentation Changes
+## Documentation Changes
 
 - **toast:** fix local example in storybook ([#542](https://github.com/migrationsverket/midas/pull/542))

--- a/apps/docs/src/plugins/changelog/index.ts
+++ b/apps/docs/src/plugins/changelog/index.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-non-null-assertion: 0 */
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -5,98 +7,102 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import fs from 'fs-extra';
-import pluginContentBlog from '@docusaurus/plugin-content-blog';
-import {aliasedSitePath, docuHash, normalizeUrl} from '@docusaurus/utils';
+import path from 'path'
+import fs from 'fs-extra'
+import pluginContentBlog from '@docusaurus/plugin-content-blog'
+import { aliasedSitePath, docuHash, normalizeUrl } from '@docusaurus/utils'
 
-export {validateOptions} from '@docusaurus/plugin-content-blog';
+export { validateOptions } from '@docusaurus/plugin-content-blog'
 
 /**
  * Multiple versions may be published on the same day, causing the order to be
  * the reverse. Therefore, our publish time has a "fake hour" to order them.
  */
 // TODO may leak small amount of memory in multi-locale builds
-const publishTimes = new Set<string>();
+const publishTimes = new Set<string>()
 
-type Author = {name: string; url: string; alias: string; imageURL: string};
+type Author = { name: string; url: string; alias: string; imageURL: string }
 
-type AuthorsMap = Record<string, Author>;
+type AuthorsMap = Record<string, Author>
 
 type ChangelogEntry = {
-  title: string;
-  content: string;
-  authors: Author[];
-};
+  title: string
+  content: string
+  authors: Author[]
+}
 
 function parseAuthor(committerLine: string): Author {
   const groups = committerLine.match(
     /- (?:(?<name>.*?) \()?\[@(?<alias>.*)\]\((?<url>.*?)\)\)?/,
-  )!.groups as {name: string; alias: string; url: string};
+  )!.groups as { name: string; alias: string; url: string }
 
   return {
     ...groups,
     name: groups.name ?? groups.alias,
     imageURL: `https://github.com/${groups.alias}.png`,
-  };
+  }
 }
 
 function parseAuthors(content: string): Author[] {
-  const committersContent = content.match(/## Committers: \d.*/s)?.[0];
+  const committersContent = content.match(/## Committers: \d.*/s)?.[0]
   if (!committersContent) {
-    return [];
+    return []
   }
-  const committersLines = committersContent.match(/- .*/g)!;
+  const committersLines = committersContent.match(/- .*/g)!
 
   const authors = committersLines
     .map(parseAuthor)
-    .sort((a, b) => a.url.localeCompare(b.url));
+    .sort((a, b) => a.url.localeCompare(b.url))
 
-  return authors;
+  return authors
 }
 
 function createAuthorsMap(changelogEntries: ChangelogEntry[]): AuthorsMap {
-  const allAuthors = changelogEntries.flatMap((entry) => entry.authors);
-  const authorsMap: AuthorsMap = {};
-  allAuthors?.forEach((author) => {
-    authorsMap[author.alias] = author;
-  });
-  return authorsMap;
+  const allAuthors = changelogEntries.flatMap(entry => entry.authors)
+  const authorsMap: AuthorsMap = {}
+  allAuthors?.forEach(author => {
+    authorsMap[author.alias] = author
+  })
+  return authorsMap
 }
 
 function toChangelogEntry(sectionContent: string): ChangelogEntry | null {
   const title = sectionContent
     .match(/(##|#) .*/)?.[0]
     .trim()
-    .replace('## ', '').replace('# ', '');
+    .replace('## ', '')
+    .replace('# ', '')
+
   if (!title) {
-    return null;
+    return null
   }
+
   const content = sectionContent
-    .replace(/\n## .*/, '').replace(/# .*/, '')
+    .split('\n')
+    .filter((_, i) => i > 1)
+    .join('\n')
     .trim()
-    .replace('running_woman', 'running');
 
-  const authors = parseAuthors(content);
+  const authors = parseAuthors(content)
 
-  let hour = 20;
-  const date = title.match(/ \((?<date>.*)\)/)?.groups!.date;
+  let hour = 20
+  const date = title.match(/ \((?<date>.*)\)/)?.groups!.date
   while (publishTimes.has(`${date}T${hour}:00`)) {
-    hour -= 1;
+    hour -= 1
   }
-  publishTimes.add(`${date}T${hour}:00`);
+  publishTimes.add(`${date}T${hour}:00`)
 
   return {
     authors,
     title: title.replace(/ \(.*\)/, ''),
     content: `---
 mdx:
- format: md
+  format: md
 date: ${`${date}T${hour}:00`}${
       authors.length > 0
         ? `
 authors:
-${authors.map((author) => `  - '${author.alias}'`).join('\n')}`
+${authors.map(author => `  - '${author.alias}'`).join('\n')}`
         : ''
     }
 ---
@@ -105,15 +111,15 @@ ${authors.map((author) => `  - '${author.alias}'`).join('\n')}`
 
 <!-- truncate -->
 
-${content.replace(/####/g, '##')}`,
-  };
+${content.replace(/###/g, '##')}\n`,
+  }
 }
 
 function toChangelogEntries(fileContent: string): ChangelogEntry[] {
   return fileContent
     .split(/(?=\n(##|#) )/)
     .map(toChangelogEntry)
-    .filter((s): s is ChangelogEntry => s !== null);
+    .filter((s): s is ChangelogEntry => s !== null)
 }
 
 async function createBlogFiles(
@@ -121,88 +127,86 @@ async function createBlogFiles(
   changelogEntries: ChangelogEntry[],
 ) {
   await Promise.all(
-    changelogEntries.map((changelogEntry) =>
+    changelogEntries.map(changelogEntry =>
       fs.outputFile(
         path.join(generateDir, `${changelogEntry.title}.md`),
         changelogEntry.content,
       ),
     ),
-  );
+  )
 
   await fs.outputFile(
     path.join(generateDir, 'authors.json'),
     JSON.stringify(createAuthorsMap(changelogEntries), null, 2),
-  );
+  )
 }
 
 const ChangelogPlugin: typeof pluginContentBlog =
   async function ChangelogPlugin(context, options) {
-    const generateDir = path.join(context.siteDir, 'changelog/source');
+    const generateDir = path.join(context.siteDir, 'changelog/source')
     const blogPlugin = await pluginContentBlog(context, {
       ...options,
       path: generateDir,
       id: 'changelog',
       blogListComponent: '@theme/ChangelogList',
       blogPostComponent: '@theme/ChangelogPage',
-    });
-    const changelogPath = path.join(__dirname, '../../../../../CHANGELOG.md');
+    })
+    const changelogPath = path.join(__dirname, '../../../../../CHANGELOG.md')
     return {
       ...blogPlugin,
       name: 'changelog-plugin',
 
       async loadContent() {
-        const fileContent = await fs.readFile(changelogPath, 'utf-8');
-        const changelogEntries = toChangelogEntries(fileContent);
+        const fileContent = await fs.readFile(changelogPath, 'utf-8')
+        const changelogEntries = toChangelogEntries(fileContent)
 
         // We have to create intermediate files here
         // Unfortunately Docusaurus doesn't have yet any concept of virtual file
-        await createBlogFiles(generateDir, changelogEntries);
+        await createBlogFiles(generateDir, changelogEntries)
 
         // Read the files we actually just wrote
-        const content = (await blogPlugin.loadContent?.())!;
+        const content = (await blogPlugin.loadContent?.())!
 
         content.blogPosts.forEach((post, index) => {
-          const pageIndex = Math.floor(
-            index / (options.postsPerPage as number),
-          );
+          const pageIndex = Math.floor(index / (options.postsPerPage as number))
           // @ts-expect-error: TODO Docusaurus use interface declaration merging
           post.metadata.listPageLink = normalizeUrl([
             context.baseUrl,
             options.routeBasePath,
             pageIndex === 0 ? '/' : `/page/${pageIndex + 1}`,
-          ]);
-        });
-        return content;
+          ])
+        })
+        return content
       },
 
       configureWebpack(...args) {
-        const config = blogPlugin.configureWebpack?.(...args);
+        const config = blogPlugin.configureWebpack?.(...args)
         const pluginDataDirRoot = path.join(
           context.generatedFilesDir,
           'changelog-plugin',
           'default',
-        );
+        )
         // Redirect the metadata path to our folder
         // @ts-expect-error: unsafe but works
-        const mdxLoader = config.module.rules[0].use[0];
+        const mdxLoader = config.module.rules[0].use[0]
         mdxLoader.options.metadataPath = (mdxPath: string) => {
           // Note that metadataPath must be the same/in-sync as
           // the path from createData for each MDX.
-          const aliasedPath = aliasedSitePath(mdxPath, context.siteDir);
-          return path.join(pluginDataDirRoot, `${docuHash(aliasedPath)}.json`);
-        };
-        return config;
+          const aliasedPath = aliasedSitePath(mdxPath, context.siteDir)
+          return path.join(pluginDataDirRoot, `${docuHash(aliasedPath)}.json`)
+        }
+        return config
       },
 
       getThemePath() {
-        return './theme';
+        return './theme'
       },
 
       getPathsToWatch() {
         // Don't watch the generated dir
-        return [changelogPath];
+        return [changelogPath]
       },
-    };
-  };
+    }
+  }
 
-export default ChangelogPlugin;
+export default ChangelogPlugin


### PR DESCRIPTION
## Description

Update the changelog autoformatting that happens when we build or serve the docs app.
This will align with our prettier config, so editing/formatting a file shouldnt cause any diffs.

## Changes

- Add a newline at the end of each entry
- Add a space before the frontmatter "format: md"
- Convert all h3:s to h2:s

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
