### PR TITLE
fix(combobox): select the previous value on click

### DIFF
--- a/packages/components/src/combobox/ComboBox.stories.tsx
+++ b/packages/components/src/combobox/ComboBox.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ComboBox, ComboBoxItem, ComboBoxSection } from './ComboBox'
 import { generateMockOptions, optionsWithSections } from './utils'
 import { RunOptions } from 'axe-core'
-import { expect, userEvent } from '@storybook/test'
+import { expect, userEvent, within } from '@storybook/test'
 import styles from './ComboBox.module.css'
 import { sizeModes } from '../../.storybook/modes'
 import React from 'react'
@@ -84,6 +84,32 @@ export const Default: Story = {
 export const Invalid: Story = {
   args: {
     isInvalid: true,
+  },
+}
+
+export const DS1253: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  play: async ({
+    canvas,
+    canvasElement: {
+      ownerDocument: { body },
+    },
+    step,
+  }) => {
+    await step(
+      'it should select the text when clicking in a combobox with a selected value',
+      async () => {
+        const comboBox = canvas.getByRole('combobox')
+        await userEvent.click(comboBox)
+        await userEvent.keyboard('Apple')
+        await userEvent.click(within(body).getByText('Apple'))
+        await userEvent.click(comboBox)
+        await expect(window?.getSelection()?.toString()).toBe('Apple')
+      },
+    )
   },
 }
 

--- a/packages/components/src/combobox/ComboBox.tsx
+++ b/packages/components/src/combobox/ComboBox.tsx
@@ -54,6 +54,14 @@ export function ComboBox<T extends ListBoxOption>({
   size = 'large',
   ...props
 }: ComboBoxProps<T>) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  const handleMouseUp: React.MouseEventHandler<HTMLInputElement> = event => {
+    if (event.currentTarget.value) {
+      inputRef.current?.select()
+    }
+  }
+
   return (
     <AriaComboBox
       className={clsx(styles.combobox, className)}
@@ -69,6 +77,8 @@ export function ComboBox<T extends ListBoxOption>({
           className={clsx(styles.inputField, {
             [styles.medium]: size === 'medium',
           })}
+          onMouseUp={handleMouseUp}
+          ref={inputRef}
         />
         <Button
           className={clsx(styles.button, {


### PR DESCRIPTION
## Description

The mouse interaction is a bit off, should work like this: https://sapui5.hana.ondemand.com/#/entity/sap.m.ComboBox/sample/sap.m.sample.ComboBox

When you've already selected a value and you click in the input field the previously selected value should be selected (markerat)

fix: #657 

## Changes

- add a mouseUp handler
- add a test

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
