### PR TITLE
Calculate Button sizes more accurate

### DIFF
--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -1,15 +1,17 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --button-background-primary-hover, --button-background-primary, --icon-primary, --button-background-primary-active, --button-background-secondary, --font-size-30, --text-on-color, --button-border-secondary, --button-background-secondary-hover, --button-background-disabled, --white, --border-disabled, --button-background-secondary-active, --button-background-tertiary-hover, --button-background-tertiary-active, --text-tertiary, --button-background-danger, --button-background-danger-hover, --text-disabled, --button-background-disabled, --button-background-danger-active, --focus, --button-background-icon-hover, --button-background-icon-active, --size-50, --size-70, --size-120, --size-130, --size-150 from tokens;
+@value --font-family, --button-background-primary-hover, --button-background-primary, --icon-primary, --button-background-primary-active, --button-background-secondary, --font-size-30, --text-on-color, --button-border-secondary, --button-background-secondary-hover, --button-background-disabled, --white, --border-disabled, --button-background-secondary-active, --button-background-tertiary-hover, --button-background-tertiary-active, --text-tertiary, --button-background-danger, --button-background-danger-hover, --text-disabled, --button-background-disabled, --button-background-danger-active, --focus, --button-background-icon-hover, --button-background-icon-active, --size-50, --size-70, --size-80, --size-120, --size-130, --size-150, --line-height-30 from tokens;
 
 .button {
+  --border-width: 1px;
+
   font-family: --font-family;
   font-size: --font-size-30;
   font-weight: 500;
-  padding: --size-70 --size-120;
-  min-height: --size-150;
-  line-height: 1;
+  padding: calc(--size-70 - var(--border-width))
+    calc(--size-120 - var(--border-width));
+  line-height: --line-height-30;
   background-color: --button-background-primary;
-  border: solid 1px transparent;
+  border: solid var(--border-width) transparent;
   color: --text-on-color;
   cursor: pointer;
   opacity: 1;
@@ -72,7 +74,6 @@
 .tertiary {
   color: --text-tertiary;
   background-color: transparent;
-  padding: 0.8125rem 0.9375rem;
   opacity: 1;
 
   &[data-hovered] {
@@ -92,7 +93,7 @@
 
 .iconBtn {
   background-color: transparent;
-  padding: --size-70;
+  padding: calc(--size-70 - var(--border-width));
   color: --icon-primary;
   display: flex;
   align-items: center;
@@ -108,6 +109,10 @@
 
   &[data-pressed] {
     background-color: --button-background-icon-active;
+  }
+
+  &.medium {
+    padding: calc(--size-50 - var(--border-width));
   }
 }
 
@@ -142,8 +147,8 @@
 }
 
 .medium {
-  min-height: --size-130;
-  padding: --size-50 --size-70;
+  padding: calc(--size-50 - var(--border-width))
+    calc(--size-80 - var(--border-width));
 }
 
 @media (forced-colors: active) {

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -32,16 +32,6 @@ const meta: Meta<typeof Button> = {
       modes: sizeModes,
     },
   },
-}
-
-export default meta
-type Story = StoryObj<typeof Button>
-
-export const Primary: Story = {
-  args: {
-    children: 'Button',
-    className: 'test-class',
-  },
   play: async ({ canvas, step, globals: { size } }) => {
     await step('it should have focus when clicked', async () => {
       const button = canvas.getByRole('button')
@@ -56,6 +46,16 @@ export const Primary: Story = {
         height: size === 'large' ? '48px' : '40px',
       })
     })
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Button>
+
+export const Primary: Story = {
+  args: {
+    children: 'Button',
+    className: 'test-class',
   },
 }
 

--- a/packages/components/src/link-button/LinkButton.module.css
+++ b/packages/components/src/link-button/LinkButton.module.css
@@ -2,12 +2,15 @@
 @value --font-family, --font-size-30, --breakpoint-xs, --button-background-primary, --button-border-secondary, --text-on-color, --button-background-primary-hover, --button-background-primary-active, --focus, --button-background-disabled, --text-disabled, --text-tertiary, --border-tertiary, --button-background-secondary, --button-background-secondary-hover, --button-background-secondary-active, --border-disabled, --button-background-tertiary-hover, --button-background-tertiary-active, --button-background-danger, --button-background-danger-hover, --button-background-danger-active, --white, --icon-secondary, --button-background-icon-hover, --icon-tertiary, --size-50, --size-70, --size-80 from tokens;
 
 .linkButton {
+  --border-width: 1px;
+
   font-family: --font-family;
   font-size: --font-size-30;
   font-weight: 500;
-  padding: calc(--size-70 - 1px) calc(--size-80 - 1px);
+  padding: calc(--size-70 - var(--border-width))
+    calc(--size-80 - var(--border-width));
   background-color: --button-background-primary;
-  border: solid 1px transparent;
+  border: solid var(--border-width) transparent;
   color: --text-on-color;
   cursor: pointer;
   outline: none;
@@ -115,7 +118,7 @@
 
 .iconBtn {
   background-color: transparent;
-  padding: 0.875rem;
+  padding: calc(--size-70 - var(--border-width));
   color: --text-tertiary;
   display: flex;
   align-items: center;
@@ -134,6 +137,10 @@
   &:active {
     background-color: --button-background-tertiary-active;
   }
+
+  &.medium {
+    padding: calc(--size-50 - var(--border-width));
+  }
 }
 
 .iconLeft {
@@ -145,7 +152,8 @@
 }
 
 .medium {
-  padding: calc(--size-50 - 1px) --size-70;
+  padding: calc(--size-50 - var(--border-width))
+    calc(--size-80 - var(--border-width));
 }
 
 @media --breakpoint-xs {

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -32,6 +32,13 @@ const meta: Meta<typeof LinkButton> = {
       />
     )
   },
+  play: async ({ canvas, step, globals: { size } }) => {
+    await step('it should change size according to size prop', async () => {
+      await expect(
+        canvas.getByTestId('link-button').getBoundingClientRect().height,
+      ).toBe(size === 'large' ? 48 : 40)
+    })
+  },
 }
 export default meta
 type Story = StoryObj<typeof LinkButton>
@@ -42,13 +49,6 @@ export const Primary: Story = {
     href: '#',
     'data-testid': 'link-button',
     className: 'test-class',
-  },
-  play: async ({ canvas, step, globals: { size } }) => {
-    await step('it should change size according to size prop', async () => {
-      await expect(
-        canvas.getByTestId('link-button').getBoundingClientRect().height,
-      ).toBe(size === 'large' ? 48 : 40)
-    })
   },
 }
 


### PR DESCRIPTION
## Description

Figma och CSS räknar inte riktigt border-box på samma sätt. Figma inkluderar bredden av en border i totala storleken av boxen men det gör CSS. Bästa approachen här för att ha det helt synkat med tokens mellan kod och Figma blir att räkna bort bredden på kantlinjen.

## Changes

- Räkna ut storleken på padding genom att ta bort bredden på border
- Ta bort min-height
- Kör storlekstester på alla varianter
- Korrekt kvadratisk storlek på ikonknappar

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
