### PR TITLE
docs: typo on numbers in grid sizing table

### DIFF
--- a/apps/docs/docs/components/grid.mdx
+++ b/apps/docs/docs/components/grid.mdx
@@ -168,7 +168,7 @@ Flex har inbyggda marginaler som anpassar sig efter skärmstorlek. Marginalerna 
 
 <NoMarginExample />
 
-## Nästad användning
+## Nästlad användning
 
 Rutnät kan även användas inuti andra rutnät. Detta kan vara användbart för att skapa komplexa layouter där du vill ha flera nivåer av kolumner.
 
@@ -176,11 +176,11 @@ Rutnät kan även användas inuti andra rutnät. Detta kan vara användbart för
 <Grid>
   <GridItem size={6}>
     <Grid removeMargins={true}>
-      <GridItem size={6}>Nästad 1</GridItem>
-      <GridItem size={6}>Nästad 2</GridItem>
+      <GridItem size={6}>Nästlad 1</GridItem>
+      <GridItem size={6}>Nästlad 2</GridItem>
     </Grid>
   </GridItem>
-  <GridItem size={6}>Huvud 2</GridItem>
+  <GridItem size={6}>size=6</GridItem>
 </Grid>
 ```
 

--- a/apps/docs/docs/components/grid.mdx
+++ b/apps/docs/docs/components/grid.mdx
@@ -194,8 +194,8 @@ Grids skalas enligt följande specifikation.
 | :--- | :---------------- | :--------------- | :-------------------- | :------- | :-------------- | :-------- |
 | `xs` | 0 - 479 px        | 16 px            | Skalas                | 12       | 16 px           |           |
 | `sm` | 480 px - 767 px   | 16 px            | Skalas                | 12       | 16 px           |           |
-| `md` | 768 px - 1023 px  | 16 px            | Skalas                | 12       | 16 px           |           |
-| `lg` | 1024 px - 1279 px | 32 px            | Skalas                | 12       | 16 px           |           |
+| `md` | 768 px - 1023 px  | 32 px            | Skalas                | 12       | 16 px           |           |
+| `lg` | 1024 px - 1279 px | 32 px            | Skalas                | 12       | 24 px           |           |
 | `xl` | över 1280 px      | 32 px            | Skalas                | 12       | 24 px           | Nej       |
 | `xl` | över 1280 px      | Skalas           | 1368 px               | 12       | 24 px           | Ja        |
 

--- a/apps/docs/src/components/examples/grid/GridExamples.tsx
+++ b/apps/docs/src/components/examples/grid/GridExamples.tsx
@@ -215,13 +215,13 @@ export const NestedExample = () => {
               style={{ background: semantic.layer01, padding: '1rem' }}
               size={6}
             >
-              Nästad 1
+              Nästlad 1 - size=6
             </GridItem>
             <GridItem
               style={{ background: semantic.layer01, padding: '1rem' }}
               size={6}
             >
-              Nästad 2
+              Nästlad 2 - size=6
             </GridItem>
           </Grid>
         </GridItem>
@@ -229,7 +229,7 @@ export const NestedExample = () => {
           style={{ background: semantic.layer01, padding: '1rem' }}
           size={6}
         >
-          Huvud 2
+          size=6
         </GridItem>
       </Grid>
     </div>


### PR DESCRIPTION
## Description

Typo 💟 

## Changes

Changed two sizings on docweb

## Checklist

- [ ] Tests added if applicable
- [X] Documentation updated
- [X] Conventional commit messages
