### PR TITLE
test: remove storybook background transiton

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -91,7 +91,10 @@ const preview: Preview = {
 
       const story = document.querySelector<HTMLElement>('body')
 
-      if (story) story.style.colorScheme = context.globals.scheme
+      if (story) {
+        story.style.colorScheme = context.globals.scheme
+        story.style.transition = 'none'
+      }
 
       return (
         <RootTag


### PR DESCRIPTION
## Description

Storybook does this:

```css
.sb-show-main { 
  transition: background-color 0.3s; 
}
```

This makes the a11y addon to perceive the wrong background color in dark mode

![Skärmbild 2025-06-23 102933](https://github.com/user-attachments/assets/c7c6cc5a-44b2-45b1-bfcf-b6bb830bdf3f)


## Changes

- remove background transition

## Additional Information

https://github.com/storybookjs/storybook/issues/25257

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
