### PR TITLE
fix(tag): 📏 padding changes 

### DIFF
--- a/packages/components/src/tag/Tag.module.css
+++ b/packages/components/src/tag/Tag.module.css
@@ -83,6 +83,10 @@
 
 .tagText {
   line-height: 1.15;
+  padding: 7px --size-40;
+}
+
+.dismissable .tagText {
   padding: 7px --size-10 7px --size-40;
 }
 

--- a/packages/components/src/tag/Tag.module.css
+++ b/packages/components/src/tag/Tag.module.css
@@ -1,10 +1,10 @@
 @value tokens: "../theme/tokens.css";
-@value --font-family, --field-01, --text-disabled, --field-active-01, --field-hover-01, --icon-primary, --support-background-success, --support-background-info, --support-background-important, --support-background-warning, --button-background-icon-hover, --button-background-icon-active, --border-primary, --support-border-success, --support-border-info, --support-border-important, --support-border-warning, --text-primary, --border-disabled from tokens;
+@value --font-family, --field-01, --text-disabled, --field-active-01, --field-hover-01, --icon-primary, --support-background-success, --support-background-info, --support-background-important, --support-background-warning, --button-background-icon-hover, --button-background-icon-active, --border-primary, --support-border-success, --support-border-info, --support-border-important, --support-border-warning, --text-primary, --border-disabled, --size-10, --size-20, --size-40 from tokens;
 
 .button {
   color: --icon-primary;
   min-height: unset !important;
-  padding: 0.375rem !important;
+  padding: --size-20 !important;
   border-radius: 1.5rem;
   border: unset;
 
@@ -32,7 +32,6 @@
 }
 
 .tag {
-  max-height: 2rem;
   display: inline-flex;
   align-items: center;
   border-radius: 1.25rem;
@@ -84,7 +83,7 @@
 
 .tagText {
   line-height: 1.15;
-  padding: 0.5rem;
+  padding: 7px --size-10 7px --size-40;
 }
 
 .tagList {


### PR DESCRIPTION
## Description

Our tags have a bit too much white space between the label and the X button. This PR makes them shorter. Also discovered and fixed height issues.

## Changes

add size tokens
change tagText right padding to` --size-10` when `dismissable`
change tagText top/bottom padding to `7px`
change button padding to `--size-20`

## Additional Information

`max-height` does not account for border, which made our tags 34px high instead of 32. 
We need to use `7px` for top/bottom padding on tagText to get the right height, but it is the same in Figma so there is no escaping the ugliness

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
