### PR TITLE
fix(tabs): remove list border

### DIFF
--- a/packages/components/src/tabs/Tabs.module.css
+++ b/packages/components/src/tabs/Tabs.module.css
@@ -6,7 +6,6 @@
 }
 
 .list {
-  border-bottom: 1px solid --border-subtle;
   display: flex;
   flex-flow: row wrap;
 }


### PR DESCRIPTION
## Description

Removes the thin bottom border. Not present in any current design files

## Changes

remove .list border-bottom

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
