### PR TITLE
fix(theme): change dark mode values for danger button

### DIFF
--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -250,9 +250,9 @@
 @value --button-background-secondary-active: light-dark(--gray-30, --gray-180);
 @value --button-background-tertiary-hover: light-dark(--white-hover, --gray-190);
 @value --button-background-tertiary-active: light-dark(--gray-30, --gray-180);
-@value --button-background-danger: light-dark(--signal-red-100, --signal-red-100);
-@value --button-background-danger-hover: light-dark(--signal-red-120, --signal-red-120);
-@value --button-background-danger-active: light-dark(--signal-red-150, --signal-red-150);
+@value --button-background-danger: light-dark(--signal-red-100, --signal-red-80);
+@value --button-background-danger-hover: light-dark(--signal-red-120, --signal-red-100);
+@value --button-background-danger-active: light-dark(--signal-red-150, --signal-red-130);
 @value --button-background-disabled: light-dark(--gray-10, --gray-180);
 @value --button-border-secondary: light-dark(--border-tertiary, --gray-10);
 @value --button-background-icon-hover: light-dark(rgba(0 0 0 / 10%), rgba(255 255 255 / 10%));

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -244,9 +244,9 @@ export const semantic = {
   buttonBackgroundSecondaryActive: `light-dark(${baseColors.gray30}, ${baseColors.gray180})`,
   buttonBackgroundTertiaryHover: `light-dark(${baseColors.whiteHover}, ${baseColors.gray190})`,
   buttonBackgroundTertiaryActive: `light-dark(${baseColors.gray30}, ${baseColors.gray180})`,
-  buttonBackgroundDanger: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed100})`,
-  buttonBackgroundDangerHover: `light-dark(${baseColors.signalRed120}, ${baseColors.signalRed120})`,
-  buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed150})`,
+  buttonBackgroundDanger: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed80})`,
+  buttonBackgroundDangerHover: `light-dark(${baseColors.signalRed120}, ${baseColors.signalRed100})`,
+  buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed130})`,
   buttonBackgroundDisabled: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
   /**
    *  @deprecated since v10.2.0, please use the `skeleton01` instead.


### PR DESCRIPTION
## Description

Changed the values of signal-red used for danger button in dark mode to create consistency across the UI.

## Changes

change `--button-background-danger ` dark mode value to `--signal-red-80`
change `--button-background-danger-hover ` dark mode value to `--signal-red-100` 
change `--button-background-danger-active ` dark mode value to `--signal-red-130`

same changes in tokens.ts


## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
