### PR TITLE
fix(select): prevent Select dropdown from closing prematurely in Modal

### DIFF
--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -111,11 +111,6 @@ const SelectComponent = React.forwardRef<HTMLButtonElement, MidasSelectProps>(
         )}
         <ListBoxPopover
           isOpen={state.isOpen}
-          onOpenChange={(isOpen: boolean) => {
-            if (!isOpen) {
-              state.close()
-            }
-          }}
           triggerRef={triggerRef}
           style={{ width: triggerWidth }}
         >


### PR DESCRIPTION
This addresses an issue where the Select component's dropdown would immediately close when used inside a Modal, particularly when the parent component (e.g., a Table) caused re-renders that disrupted the overlay context.
