### PR TITLE
fix(combobox): make popover prop optional

### DIFF
--- a/packages/components/src/combobox/ComboBox.tsx
+++ b/packages/components/src/combobox/ComboBox.tsx
@@ -44,7 +44,7 @@ export interface ComboBoxProps<T extends ListBoxOption>
    *  @default 'large'
    * */
   size?: Size
-  popover: InfoPopoverProps
+  popover?: InfoPopoverProps
 }
 
 export function ComboBox<T extends ListBoxOption>({


### PR DESCRIPTION
The 'popover' prop in the ComboBox component was incorrectly marked as required. This commit makes it optional, aligning with its intended usage.

