### PR TITLE
fix(date-picker): remove custom portal element

### DIFF
--- a/apps/docs/changelog/source/10.4.1.md
+++ b/apps/docs/changelog/source/10.4.1.md
@@ -1,0 +1,27 @@
+---
+mdx:
+  format: md
+date: 2025-07-05T20:00
+---
+
+# 10.4.1
+
+<!-- truncate -->
+
+## 🩹 Fixes
+
+- **tabs:** remove list border ([9f1ac2a251](https://github.com/migrationsverket/midas/commit/9f1ac2a251))
+- **tag:** 📏 padding changes ([8116a667ed](https://github.com/migrationsverket/midas/commit/8116a667ed))
+
+## 📖 Documentation changes
+
+- fix strange start page render on load ([1ea8f710e6](https://github.com/migrationsverket/midas/commit/1ea8f710e6))
+- **contribute:** remove references to next and remix apps ([eeaff92597](https://github.com/migrationsverket/midas/commit/eeaff92597))
+- **release:** add release notes for 10.4.0 ([2c72a05b00](https://github.com/migrationsverket/midas/commit/2c72a05b00))
+- **release:** add release notes for 10.4.0 ([7361b26497](https://github.com/migrationsverket/midas/commit/7361b26497))
+
+## 🔧 Maintenance
+
+- remove unused test apps ([74c5f90604](https://github.com/migrationsverket/midas/commit/74c5f90604))
+- cleanup repo from unused apps and dependencies ([4cf2fc61f8](https://github.com/migrationsverket/midas/commit/4cf2fc61f8))
+- upgrade RAC to 1.10 + some other minor package upgrades ([71a7ab8093](https://github.com/migrationsverket/midas/commit/71a7ab8093))

--- a/apps/docs/changelog/source/11.0.0.md
+++ b/apps/docs/changelog/source/11.0.0.md
@@ -1,0 +1,34 @@
+---
+mdx:
+  format: md
+date: 2025-08-06T20:00
+---
+
+# 11.0.0
+
+<!-- truncate -->
+
+## 🚀 Features
+
+- **badge:** replace background token ([6f3cf9d4e8](https://github.com/migrationsverket/midas/commit/6f3cf9d4e8))
+- ⚠️ **file-upload:** replace FileUpload with React Aria FileTrigger ([c539f84bcc](https://github.com/migrationsverket/midas/commit/c539f84bcc))
+- **theme:** add badge-background token ([887eead46f](https://github.com/migrationsverket/midas/commit/887eead46f))
+- **theme:** add badgeBackground token ([c37972d7a6](https://github.com/migrationsverket/midas/commit/c37972d7a6))
+
+## 🩹 Fixes
+
+- **link:** fix issue with Link not opening in new window when target='\_blank' ([e172ec0e7c](https://github.com/migrationsverket/midas/commit/e172ec0e7c))
+- **popover:** add overflow-wrap to prevent long string from overflowing ([35895e2d99](https://github.com/migrationsverket/midas/commit/35895e2d99))
+- **theme:** change dark mode values for danger button ([46099f843e](https://github.com/migrationsverket/midas/commit/46099f843e))
+
+## 📖 Documentation changes
+
+- fix incorrect tsx in example ([7253aa2eb1](https://github.com/migrationsverket/midas/commit/7253aa2eb1))
+
+## 🔧 Maintenance
+
+- **deps:** bump the npm_and_yarn group across 1 directory with 4 updates ([e267f19a62](https://github.com/migrationsverket/midas/commit/e267f19a62))
+
+## ⚠️ Breaking Changes
+
+- **file-upload:** FileUpload is removed and replaced by FileTrigger. Aligns API exactly with React Aria

--- a/apps/docs/changelog/source/11.1.0.md
+++ b/apps/docs/changelog/source/11.1.0.md
@@ -1,0 +1,23 @@
+---
+mdx:
+  format: md
+date: 2025-08-10T20:00
+---
+
+# 11.1.0
+
+<!-- truncate -->
+
+## 🚀 Features
+
+- **components:** ✨ Export custom component types and interfaces ✨ ([4a07892b73](https://github.com/migrationsverket/midas/commit/4a07892b73))
+
+## 🩹 Fixes
+
+- **combobox:** make popover prop optional ([cbfb176fb1](https://github.com/migrationsverket/midas/commit/cbfb176fb1))
+- **popover:** prevent long words from breaking up ([9e4758f156](https://github.com/migrationsverket/midas/commit/9e4758f156))
+
+## 📖 Documentation changes
+
+- release notes v11.0.0 ([aa2fe35dbd](https://github.com/migrationsverket/midas/commit/aa2fe35dbd))
+- release notes v11.0.0 ([#721](https://github.com/migrationsverket/midas/pull/721))

--- a/nx.json
+++ b/nx.json
@@ -112,7 +112,6 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    
     "@nx/next:build": {
       "cache": true,
       "dependsOn": ["^build"],

--- a/packages/components/src/date-picker/DatePicker.tsx
+++ b/packages/components/src/date-picker/DatePicker.tsx
@@ -41,12 +41,9 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   popover,
   ...rest
 }) => {
-  const ref = React.useRef<HTMLDivElement>(null)
-
   return (
     <AriaDatePicker
       className={clsx(styles.datePicker, className)}
-      ref={ref}
       {...rest}
     >
       <LabelWrapper popover={popover}>
@@ -58,7 +55,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         <DateInput>{segment => <DateSegment segment={segment} />}</DateInput>
       </DatePickerInputField>
       {errorPosition === 'bottom' && <FieldError>{errorMessage}</FieldError>}
-      <DatePickerPopover ref={ref}>
+      <DatePickerPopover>
         <Calendar />
       </DatePickerPopover>
     </AriaDatePicker>

--- a/packages/components/src/date-picker/DatePickerPopover.tsx
+++ b/packages/components/src/date-picker/DatePickerPopover.tsx
@@ -6,15 +6,10 @@ interface DatePickerPopoverProps {
   children?: React.ReactNode
 }
 
-export const DatePickerPopover = React.forwardRef<
-  HTMLDivElement,
-  DatePickerPopoverProps
->(({ children }, ref) => (
-  <Popover
-    UNSTABLE_portalContainer={
-      (typeof ref !== 'function' && ref?.current) || undefined
-    }
-  >
+export const DatePickerPopover: React.FC<DatePickerPopoverProps> = ({
+  children,
+}) => (
+  <Popover>
     <Dialog className={styles.dialog}>{children}</Dialog>
   </Popover>
-))
+)

--- a/packages/components/src/date-picker/DateRangePicker.tsx
+++ b/packages/components/src/date-picker/DateRangePicker.tsx
@@ -42,12 +42,9 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   popover,
   ...rest
 }) => {
-  const ref = React.useRef<HTMLDivElement>(null)
-
   return (
     <AriaDateRangePicker
       className={clsx(styles.datePicker, className)}
-      ref={ref}
       {...rest}
     >
       <LabelWrapper popover={popover}>
@@ -65,7 +62,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
         </DateInput>
       </DatePickerInputField>
       {errorPosition === 'bottom' && <FieldError>{errorMessage}</FieldError>}
-      <DatePickerPopover ref={ref}>
+      <DatePickerPopover>
         <RangeCalendar />
       </DatePickerPopover>
     </AriaDateRangePicker>


### PR DESCRIPTION
## Description

Custom portal element (DatePicker container) would kick in after a re render in the component. Causing the popover to mount there instead of document.body

## Changes

* remove the custom portal element and fall back to the default value (document.body)
* add changelog entries generated when bulding the docs

## Additional Information

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
