### PR TITLE
docs: add authors map file and update all release notes

### DIFF
--- a/apps/docs/blog/release-notes/10.0.0.mdx
+++ b/apps/docs/blog/release-notes/10.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.0.0
+authors: midas
 date: 2025-05-15
 ---
 

--- a/apps/docs/blog/release-notes/10.1.0.mdx
+++ b/apps/docs/blog/release-notes/10.1.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.1.0
+authors: midas
 date: 2025-05-23
 ---
 

--- a/apps/docs/blog/release-notes/10.1.1.mdx
+++ b/apps/docs/blog/release-notes/10.1.1.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.1.1
+authors: midas
 date: 2025-06-09
 ---
 

--- a/apps/docs/blog/release-notes/10.2.0.mdx
+++ b/apps/docs/blog/release-notes/10.2.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.2.0
+authors: midas
 date: 2025-06-18
 ---
 

--- a/apps/docs/blog/release-notes/10.3.0.mdx
+++ b/apps/docs/blog/release-notes/10.3.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.3.0
+authors: midas
 date: 2025-06-25
 ---
 

--- a/apps/docs/blog/release-notes/10.4.0.mdx
+++ b/apps/docs/blog/release-notes/10.4.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 10.4.0
+authors: midas
 date: 2025-07-02
 ---
 
@@ -30,7 +31,6 @@ accepterar nu `className` för att applicera egen css.
 - **theme:** new tokens for calendar date states ([0f819928d0](https://github.com/migrationsverket/midas/commit/0f819928d0))
 - **theme:** change dark mode color on calendarBackgroundInRange ([d745cb2adf](https://github.com/migrationsverket/midas/commit/d745cb2adf))
 - **toast:** 💄 accept custom className ([#692](https://github.com/migrationsverket/midas/pull/692))
-
 
 {/* truncate */}
 

--- a/apps/docs/blog/release-notes/11.0.0.mdx
+++ b/apps/docs/blog/release-notes/11.0.0.mdx
@@ -1,35 +1,32 @@
 ---
 slug: 11.0.0
 title: Release 11.0.0
-author: Midas
-author_title: Midas Core Team
-author_url: https://github.com/migrationsverket/midas
-author_image_url: https://avatars.githubusercontent.com/u/110020437?s=200&v=4
+authors: midas
 tags: [release-notes, v11, breaking-change]
 ---
 
 ## 🚀 Features
 
--   **file-upload:** Komponenten `FileUpload` är borttagen och ersatt av `FileTrigger` från React Aria. Detta innebär att API:et för komponenten nu är i linje med React Aria. Se dokumentationen för mer information om hur du använder den nya komponenten.
--   **theme:** Nya tokens för `badge-background` har lagts till.
+- **file-upload:** Komponenten `FileUpload` är borttagen och ersatt av `FileTrigger` från React Aria. Detta innebär att API:et för komponenten nu är i linje med React Aria. Se dokumentationen för mer information om hur du använder den nya komponenten.
+- **theme:** Nya tokens för `badge-background` har lagts till.
 
 ## 🩹 Fixes
 
--   **link:** En bugg har fixats som gjorde att länkar med `target='_blank'` inte öppnades i ett nytt fönster.
--   **popover:** En bugg har fixats som gjorde att långa strängar kunde flöda över i en popover.
--   **theme:** Färger för "danger button" i dark mode har justerats.
+- **link:** En bugg har fixats som gjorde att länkar med `target='_blank'` inte öppnades i ett nytt fönster.
+- **popover:** En bugg har fixats som gjorde att långa strängar kunde flöda över i en popover.
+- **theme:** Färger för "danger button" i dark mode har justerats.
 
 ## 📖 Documentation changes
 
--   Ett felaktigt `tsx`-exempel har korrigerats.
+- Ett felaktigt `tsx`-exempel har korrigerats.
 
 ## 🔧 Maintenance
 
--   Beroenden har uppdaterats.
+- Beroenden har uppdaterats.
 
 ## ⚠️ Breaking Changes
 
--   **file-upload:** Komponenten `FileUpload` är borttagen och ersatt av `FileTrigger`. Detta är en "breaking change" och kräver att du uppdaterar din kod. Se dokumentationen för `file-upload` för mer information.
+- **file-upload:** Komponenten `FileUpload` är borttagen och ersatt av `FileTrigger`. Detta är en "breaking change" och kräver att du uppdaterar din kod. Se dokumentationen för `file-upload` för mer information.
 
 {/* truncate */}
 

--- a/apps/docs/blog/release-notes/2.0.0.mdx
+++ b/apps/docs/blog/release-notes/2.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 2.0.0
+authors: midas
 date: 2025-02-25
 ---
 

--- a/apps/docs/blog/release-notes/3.0.0.mdx
+++ b/apps/docs/blog/release-notes/3.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 3.0.0
+authors: midas
 date: 2025-02-28
 ---
 

--- a/apps/docs/blog/release-notes/4.0.0.mdx
+++ b/apps/docs/blog/release-notes/4.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 4.0.0
+authors: midas
 date: 2025-03-10
 ---
 

--- a/apps/docs/blog/release-notes/5.0.0.mdx
+++ b/apps/docs/blog/release-notes/5.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 5.0.0
+authors: midas
 date: 2025-03-17
 ---
 

--- a/apps/docs/blog/release-notes/6.0.0.mdx
+++ b/apps/docs/blog/release-notes/6.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 6.0.0
+authors: midas
 date: 2025-03-24
 ---
 

--- a/apps/docs/blog/release-notes/7.0.0.mdx
+++ b/apps/docs/blog/release-notes/7.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 7.0.0
+authors: midas
 date: 2025-04-02
 ---
 

--- a/apps/docs/blog/release-notes/8.0.0.mdx
+++ b/apps/docs/blog/release-notes/8.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 8.0.0
+authors: midas
 date: 2025-04-15
 ---
 

--- a/apps/docs/blog/release-notes/9.0.0.mdx
+++ b/apps/docs/blog/release-notes/9.0.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 9.0.0
+authors: midas
 date: 2025-05-08
 ---
 

--- a/apps/docs/blog/release-notes/authors.yml
+++ b/apps/docs/blog/release-notes/authors.yml
@@ -1,0 +1,5 @@
+midas:
+  name: Midas
+  title: Midas Core Team
+  utl: https://github.com/migrationsverket/midas
+  imageURL: https://avatars.githubusercontent.com/u/110020437?s=200&v=4


### PR DESCRIPTION
## Description

The docs dev server makes an annoying warning that recommends a global configuration for author data.

## Changes

- Configure global authors
- Use global authors in old posts

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
