### PR TITLE
chore: add noIndex meta data to pr previews and dev-env

### DIFF
--- a/apps/docs/changelog/source/11.2.0.md
+++ b/apps/docs/changelog/source/11.2.0.md
@@ -1,0 +1,38 @@
+---
+mdx:
+  format: md
+date: 2025-08-14T20:00
+---
+
+# 11.2.0
+
+<!-- truncate -->
+
+## 🚀 Features
+
+- **listbox:** set `font-size` to 14px and set darkmode colors [run-chromatic] ([0352aedaf4](https://github.com/migrationsverket/midas/commit/0352aedaf4))
+
+## 🩹 Fixes
+
+- **date-picker:** remove custom portal element ([51f82497ae](https://github.com/migrationsverket/midas/commit/51f82497ae))
+- **grid:** add export for GridProps type ([9ebd6168d5](https://github.com/migrationsverket/midas/commit/9ebd6168d5))
+- **modal:** re-arrange component to work with nested modals and tables ([#733](https://github.com/migrationsverket/midas/pull/733))
+
+## 📖 Documentation changes
+
+- add changelog source ([e8702a488d](https://github.com/migrationsverket/midas/commit/e8702a488d))
+- add authors map file and update all release notes ([fdfb2fa8e2](https://github.com/migrationsverket/midas/commit/fdfb2fa8e2))
+- **tabs:** add code example for closable tabs ([b32c1b9d88](https://github.com/migrationsverket/midas/commit/b32c1b9d88))
+
+## 🔧 Maintenance
+
+- remove whitespace ([d56b8680b9](https://github.com/migrationsverket/midas/commit/d56b8680b9))
+- **chromatic:** trigger chromatic on push on feature and fix branches ([39039efa1a](https://github.com/migrationsverket/midas/commit/39039efa1a))
+
+## 🧪 Tests updated
+
+- **date-picker:** add test for controlled state portal bug ([4d07dd8350](https://github.com/migrationsverket/midas/commit/4d07dd8350))
+
+## 🎨 Styles
+
+- **layout:** remove background color ([#732](https://github.com/migrationsverket/midas/pull/732))

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -44,6 +44,7 @@ const getBaseUrl = (): string => {
 }
 
 const config: Config = {
+  noIndex: process.env.GITHUB_REF_NAME === 'dev' || !!process.env.PR_NUMBER,
   title: 'Migrationsverkets designsystem',
   tagline: 'Midas',
   url: 'https://designsystem.migrationsverket.se',


### PR DESCRIPTION
## Description

Keeps search engines away from the documentation for PR previews and dev env

## Changes

chore: add noIndex meta data to pr previews and dev-env

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
