### PR TITLE
feat(dropdown): add custom icon support

### DIFF
--- a/packages/components/src/dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/dropdown/Dropdown.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Dropdown, DropdownItem } from './Dropdown'
 import { LinkButton } from '../link-button'
 import { userEvent, expect } from '@storybook/test'
+import { Ellipsis } from 'lucide-react'
 
 const meta: Meta<typeof Dropdown> = {
   component: Dropdown,
@@ -37,5 +38,13 @@ export const WithoutTitle: Story = {
   args: {
     title: undefined,
     label: 'Meny',
+  },
+}
+
+export const CustomIcon: Story = {
+  args: {
+    title: undefined,
+    label: 'Meny',
+    icon: Ellipsis,
   },
 }

--- a/packages/components/src/dropdown/Dropdown.tsx
+++ b/packages/components/src/dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import {
   type MenuTriggerProps,
 } from 'react-aria-components'
 import { Button } from '../button'
-import { EllipsisVertical } from 'lucide-react'
+import { EllipsisVertical, LucideIcon } from 'lucide-react'
 import styles from './Dropdown.module.css'
 import clsx from 'clsx'
 
@@ -17,12 +17,18 @@ export interface MidasMenuButtonProps<T>
     Omit<MenuTriggerProps, 'children'> {
   label?: string
   title?: string
+  /**
+   * The icon to use for the menu button
+   * @default EllipsisVertical
+   */
+  icon?: LucideIcon
 }
 
 export function Dropdown<T extends object>({
   label,
   title,
   children,
+  icon: Icon = EllipsisVertical,
   ...props
 }: MidasMenuButtonProps<T>) {
   return (
@@ -32,7 +38,7 @@ export function Dropdown<T extends object>({
         variant='icon'
       >
         {title}
-        <EllipsisVertical
+        <Icon
           size={20}
           aria-hidden
         />


### PR DESCRIPTION
## Description

The dropdown only has the vertical ellipsis icon. The horizontal one seems much more popular

## Changes

Add custom icon support for Dropdown

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
