### PR TITLE
feat!: Automate ESLint versioning and remove deprecated features

### DIFF
--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -1,4 +1,6 @@
-{
+const { version } = require('./package.json');
+
+module.exports = {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
   "ignorePatterns": ["!**/*", "storybook-static"],
   "plugins": ["midas"],
@@ -9,7 +11,7 @@
         "midas/handle-deprecated-comments": [
           1,
           {
-            "version": "10.3.0"
+            version
           }
         ],
         "jsx-a11y/no-autofocus": "off"
@@ -24,4 +26,4 @@
       "rules": {}
     }
   ]
-}
+};

--- a/packages/components/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/components/src/breadcrumbs/Breadcrumbs.tsx
@@ -40,5 +40,4 @@ export const Breadcrumbs = <T extends BreadcrumbItem>({
   </AriaBreadcrumbs>
 )
 
-/** @deprecated since v10.3.0 please use `BreadcrumbsProps` instead */
-export type BreadcrumbProps<T extends BreadcrumbItem> = BreadcrumbsProps<T>
+

--- a/packages/components/src/combobox/ComboBox.tsx
+++ b/packages/components/src/combobox/ComboBox.tsx
@@ -121,10 +121,7 @@ export function ComboBoxItem<T extends ListBoxItemElement>(
   return <ListBoxItem {...props} />
 }
 
-/**
- * @deprecated since v.10.1.0 please use `ComboBoxSection` instead
- */
-export function ComboBoxSelection<T extends ListBoxSectionElement>(props: T) {
+export function ComboBoxSection<T extends ListBoxSectionElement>(props: T) {
   return (
     <ListBoxSection {...props}>
       <Collection items={props.children}>
@@ -132,8 +129,4 @@ export function ComboBoxSelection<T extends ListBoxSectionElement>(props: T) {
       </Collection>
     </ListBoxSection>
   )
-}
-
-export function ComboBoxSection<T extends ListBoxSectionElement>(props: T) {
-  return <ComboBoxSelection {...props} />
 }

--- a/packages/components/src/combobox/index.ts
+++ b/packages/components/src/combobox/index.ts
@@ -1,7 +1,6 @@
 export {
   ComboBox,
   ComboBoxItem,
-  ComboBoxSelection,
   ComboBoxSection,
 } from './ComboBox'
-export type { Section, Item } from './types'
+

--- a/packages/components/src/combobox/types.ts
+++ b/packages/components/src/combobox/types.ts
@@ -1,11 +1,3 @@
-/**
- * @deprecated since v.10.1.0 please use `ListBoxItemElement` instead
- */
-export type Item = { id: number; name: string }
 
-/**
- * @deprecated since v10.1.0 please use `ListBoxSectionElement` instead
- */
-export type Section<T> = Item & {
-  children?: Iterable<T>
-}
+
+

--- a/packages/components/src/file-upload/DropZone.stories.tsx
+++ b/packages/components/src/file-upload/DropZone.stories.tsx
@@ -6,7 +6,11 @@ import React from 'react'
 import { expect, fn, userEvent, within, fireEvent, waitFor } from '@storybook/test'
 import { DropEvent } from 'react-aria'
 
-const DropZoneTestContainer = (props: any) => {
+interface DropZoneTestContainerProps {
+  onSelect: (files: File[]) => void;
+}
+
+const DropZoneTestContainer = (props: DropZoneTestContainerProps) => {
   const [files, setFiles] = React.useState<File[]>([])
 
   const handleSelect = (selectedFileList: FileList | null) => {

--- a/packages/components/src/grid/Grid.tsx
+++ b/packages/components/src/grid/Grid.tsx
@@ -8,10 +8,7 @@ export interface GridProps
     HTMLDivElement
   > {
   children: React.ReactNode
-  /** Removes outer margins for nested use. First Grid on a page should have outer margins.
-   * @deprecated since v10.2.0 Use `isContained` prop instead.
-   */
-  fluid?: boolean
+  
   /** A contained grid has a max-width and centered positioning on large screens. */
   isContained?: boolean
   /** Removes outer margins. */
@@ -31,7 +28,6 @@ export interface GridProps
 
 export const Grid: React.FC<GridProps> = ({
   children,
-  fluid = false,
   isContained = false,
   removeMargins = false,
   ...rest
@@ -41,7 +37,6 @@ export const Grid: React.FC<GridProps> = ({
       {...rest}
       className={clsx(
         styles.container,
-        fluid && styles.fluid,
         isContained && styles.contained,
         removeMargins && styles.removeMargins,
         rest.className,
@@ -52,8 +47,4 @@ export const Grid: React.FC<GridProps> = ({
   )
 }
 
-/**
- * @deprecated since v10.2.0 Use `Grid` instead.
- */
 
-export const Flex = Grid

--- a/packages/components/src/grid/GridItem.tsx
+++ b/packages/components/src/grid/GridItem.tsx
@@ -9,10 +9,7 @@ export interface GridItemProps
     HTMLDivElement
   > {
   children: React.ReactNode
-  /** Column size and behaviour
-   * @deprecated since v10.2.0 Use `size` prop instead.
-   */
-  col?: ColumnSize
+  
   /** Column size and behaviour across different breakpoints   */
   size?:
     | ColumnSize
@@ -44,12 +41,10 @@ export interface GridItemProps
 
 export const GridItem: React.FC<GridItemProps> = ({
   children,
-  col,
   size,
   offset,
   ...props
 }) => {
-  const colClass = col ? `col-${col}` : ''
   const offsetClass = offset ? `offset-${offset}` : ''
 
   const sizeClasses = getSizeClasses(size)
@@ -60,7 +55,6 @@ export const GridItem: React.FC<GridItemProps> = ({
       {...props}
       className={clsx(
         styles.col,
-        styles[colClass],
         styles[offsetClass],
         sizeClasses.map(cls => styles[cls]),
         offsetClasses.map(cls => styles[cls]),
@@ -92,8 +86,4 @@ const getOffsetClasses = (offset?: GridItemProps['offset']): string[] => {
   return [`offset-${offset}`]
 }
 
-/**
- * @deprecated since v10.2.0 Use `GridItem` instead.
- */
 
-export const FlexItem = GridItem

--- a/packages/components/src/grid/index.ts
+++ b/packages/components/src/grid/index.ts
@@ -1,2 +1,2 @@
-export { Grid, Flex, type GridProps } from './Grid'
-export { GridItem, FlexItem, type GridItemProps } from './GridItem'
+export { Grid, type GridProps } from './Grid'
+export { GridItem, type GridItemProps } from './GridItem'

--- a/packages/components/src/info-banner/InfoBanner.tsx
+++ b/packages/components/src/info-banner/InfoBanner.tsx
@@ -23,11 +23,7 @@ export interface InfoBannerProps
   message?: string | React.ReactNode
   /** Additional elements displayed inside the banner */
   children?: React.ReactNode
-  /**
-   *  Specify if the InfoBanner should have a dismiss button in the top right corner
-   *  @deprecated since 10.0.1. Please use `isDismissable` instead
-   */
-  dismissable?: boolean
+  
   /**
    *  Specify if the InfoBanner should have a dismiss button in the top right corner
    */
@@ -42,7 +38,6 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
   message,
   type,
   children,
-  dismissable = false,
   isDismissable = false,
   ...rest
 }) => {
@@ -68,7 +63,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
             {children}
           </div>
         </div>
-        {(dismissable || isDismissable) && (
+        {isDismissable && (
           <div className={styles.dismissable}>
             <Button
               variant='icon'

--- a/packages/components/src/select/index.ts
+++ b/packages/components/src/select/index.ts
@@ -2,7 +2,4 @@ export * from './Select'
 export type {
   SelectContainerProps as SelectProps,
   SelectionMode,
-  Option,
-  OptionItem,
-  OptionSection,
 } from './types'

--- a/packages/components/src/select/types.ts
+++ b/packages/components/src/select/types.ts
@@ -21,9 +21,7 @@ import type { AriaButtonProps } from '@react-types/button'
 import type { AriaSelectProps } from '@react-types/select'
 import type { Size } from '../common/types'
 import type {
-  ListBoxItemElement,
   ListBoxOption,
-  ListBoxSectionElement,
 } from '../list-box/'
 
 /**
@@ -214,17 +212,4 @@ export type SelectContainerProps = Omit<SelectProps, 'children' | 'items'> & {
   options: ListBoxOption[]
 }
 
-/**
- * @deprecated since v10.1.0 please use `ListBoxOption` intead
- */
-export type Option = ListBoxOption
 
-/**
- * @deprecated since v10.1.0 please use `ListBoxItemElement` intead
- */
-export type OptionItem = ListBoxItemElement
-
-/**
- * @deprecated since v10.1.0 please use `ListBoxSectionElement` intead
- */
-export type OptionSection = ListBoxSectionElement

--- a/packages/components/src/table/Table.tsx
+++ b/packages/components/src/table/Table.tsx
@@ -32,11 +32,7 @@ import clsx from 'clsx'
 import { Size } from '../common/types'
 
 export interface TableProps extends AriaTableProps {
-  /**
-   *  A more compact version of the table
-   *  @deprecated since v10.1.1, please use the `size` prop instead.
-   */
-  narrow?: boolean
+  
   /** Row height (large: 48px, medium: 40px)
    *  @default 'large'
    * */
@@ -48,7 +44,6 @@ export interface TableProps extends AriaTableProps {
 }
 
 export const Table = ({
-  narrow = false,
   size = 'large',
   striped = false,
   className,
@@ -56,7 +51,6 @@ export const Table = ({
 }: TableProps) => (
   <AriaTable
     className={clsx(styles.table, className, {
-      [styles.narrow]: narrow,
       [styles.medium]: size === 'medium',
       [styles.striped]: striped,
     })}

--- a/packages/components/src/tabs/Tabs.tsx
+++ b/packages/components/src/tabs/Tabs.tsx
@@ -8,22 +8,11 @@ import {
 import clsx from 'clsx'
 import useObserveElement from '../utils/useObserveElement'
 import { windowSizes } from '../theme'
-import { Tab, TabList, TabPanel } from '.'
+
 import styles from './Tabs.module.css'
 
 export interface TabsProps extends AriaTabsProps {
-  /**
-   * An array of tab titles
-   * @deprecated since v.10.3.0 please use the declarative API
-   * @see {@link https://designsystem.migrationsverket.se/components/tabs/|Tabs}
-   */
-  tabs?: string[]
-  /**
-   * Label for accessibility
-   * @deprecated since v.10.3.0 please use the declarative API and use the `aria-label` prop on TabList instead
-   * @see {@link https://designsystem.migrationsverket.se/components/tabs/|Tabs}
-   */
-  label?: string
+  
   /**
    * The orientation of the tabs.
    * Will adjust to screen size automatically if omitted
@@ -32,14 +21,9 @@ export interface TabsProps extends AriaTabsProps {
   orientation?: AriaTabsProps['orientation']
 }
 
-interface TabPanelChildProps {
-  id?: string
-  children?: React.ReactNode
-}
+
 
 export const Tabs: React.FC<TabsProps> = ({
-  tabs,
-  label,
   children,
   className,
   ...rest
@@ -52,70 +36,12 @@ export const Tabs: React.FC<TabsProps> = ({
   const orientation: AriaTabsProps['orientation'] =
     rest.orientation || bodyWidth >= windowSizes.sm ? 'horizontal' : 'vertical'
 
-  if (!tabs?.length) {
-    return (
-      <AriaTabs
-        {...rest}
-        orientation={orientation}
-        className={clsx(styles.container, className)}
-        children={children}
-      />
-    )
-  }
-
-  if (typeof children === 'function') {
-    console.error(
-      'Only the declarative API supports passing a function to children, replace the "tabs" prop according to the documentation: https://designsystem.migrationsverket.se/components/tabs/ ',
-    )
-    return null
-  }
-
-  const childrenArray = React.Children.toArray(children)
-
-  if (childrenArray.length !== tabs.length) {
-    console.error(
-      `The number of children must match the number of tabs. Children: ${childrenArray.length} Tabs: ${tabs.length}`,
-    )
-    return null
-  }
-
-  const tabContentMap = childrenArray.reduce(
-    (acc, child, index) => {
-      if (React.isValidElement<TabPanelChildProps>(child)) {
-        const title = tabs[index]
-        if (title) {
-          acc[title] = React.cloneElement(child, { id: title })
-        }
-      }
-      return acc
-    },
-    {} as Record<string, React.ReactElement<TabPanelChildProps>>,
-  )
-
   return (
     <AriaTabs
       {...rest}
       orientation={orientation}
       className={clsx(styles.container, className)}
-    >
-      <TabList aria-label={label}>
-        {tabs.map(tab => (
-          <Tab
-            key={tab}
-            id={tab}
-          >
-            {tab}
-          </Tab>
-        ))}
-      </TabList>
-      {tabs.map(tab => (
-        <TabPanel
-          key={tab}
-          id={tab}
-        >
-          {tabContentMap[tab]}
-        </TabPanel>
-      ))}
-    </AriaTabs>
+      children={children}
+    />
   )
 }

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -194,10 +194,7 @@ export const semantic = {
   fieldActive02: `light-dark(${baseColors.gray30}, ${baseColors.gray140})`,
 
   fieldDisabled: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
-  /**
-   *  @deprecated since v10.2.0, please use the `skeleton01` instead.
-   */
-  fieldSkeleton: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
+  
   skeleton01: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
   skeleton02: `light-dark(${baseColors.gray30}, ${baseColors.gray160})`,
   iconPrimary: `light-dark(${baseColors.gray200}, ${baseColors.gray10})`,
@@ -248,10 +245,7 @@ export const semantic = {
   buttonBackgroundDangerHover: `light-dark(${baseColors.signalRed120}, ${baseColors.signalRed100})`,
   buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed130})`,
   buttonBackgroundDisabled: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
-  /**
-   *  @deprecated since v10.2.0, please use the `skeleton01` instead.
-   */
-  buttonBackgroundSkeleton: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
+  
   buttonBorderSecondary: `light-dark(${baseColors.blue150}, ${baseColors.gray10})`,
 
   badgeBackground: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed80})`,


### PR DESCRIPTION
This commit automates the ESLint versioning for the components package by converting the static .eslintrc.json to a dynamic .eslintrc.cjs file. The ESLint configuration now reads the package version directly from package.json, eliminating the need for manual updates.

Additionally, this commit removes several deprecated components, props, and types across the codebase to improve maintainability and adhere to the latest API standards. This includes:

 - Breadcrumbs: Removed deprecated `BreadcrumbProps` type.
 - ComboBox: Refactored `ComboBoxSelection` to `ComboBoxSection` and removed deprecated exports and types (`Item`, `Section`).
 - Grid: Removed deprecated `Flex` export and `fluid` prop.
 - GridItem: Removed deprecated `FlexItem` export and `col` prop.
 - InfoBanner: Removed deprecated `dismissable` prop.
 - Table: Removed deprecated `narrow` prop.
 - Tabs: Refactored to use declarative API, removing `tabs` and `label` props.
 - Select: Removed deprecated `Option`, `OptionItem`, `OptionSection` types.
 - Theme: Removed deprecated `fieldSkeleton` and `buttonBackgroundSkeleton` tokens.

 Unused imports and type definitions were also cleaned up, and a type issue in `DropZone.stories.tsx` was resolved.

BREAKING CHANGE:
The following deprecated features have been removed:
 - `BreadcrumbProps` type (use `BreadcrumbsProps` instead)
 - `ComboBoxSelection` component (use `ComboBoxSection` instead)
 - `Item` and `Section` types from `combobox/types.ts` (use `ListBoxItemElement` and `ListBoxSectionElement` respectively)
 - `Flex` export from `grid` (use `Grid` instead)
 - `fluid` prop from `GridProps` (use `isContained` instead)
 - `FlexItem` export from `grid` (use `GridItem` instead)
 - `col` prop from `GridItemProps` (use `size` instead)
 - `dismissable` prop from `InfoBannerProps` (use `isDismissable` instead)
 - `narrow` prop from `TableProps` (use `size` instead)
 - `tabs` and `label` props from `TabsProps` (use declarative API with `TabList` and `TabPanel` children)
 - `Option`, `OptionItem`, `OptionSection` types from `select/types.ts` (use `ListBoxOption`, `ListBoxItemElement`, `ListBoxSectionElement` respectively)
 - `fieldSkeleton` and `buttonBackgroundSkeleton` tokens from `theme/tokens.ts` (use `skeleton01` instead)
