### PR TITLE
test: remove size test from button linkButton and table

### DIFF
--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Button> = {
       control: { type: 'radio' },
     },
   },
-  play: async ({ canvas, step, args }) => {
+  play: async ({ canvas, step }) => {
     await step('it should have focus when clicked', async () => {
       const button = canvas.getByRole('button')
       await userEvent.click(button)
@@ -27,11 +27,6 @@ const meta: Meta<typeof Button> = {
       button.focus()
       await userEvent.keyboard('{Enter}')
       await expect(button).toHaveFocus()
-    })
-    await step('it should change size according to size prop', async () => {
-      await expect(canvas.getByRole('button')).toHaveStyle({
-        height: args.size === 'large' ? '48px' : '40px',
-      })
     })
   },
 }

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -27,13 +27,6 @@ const meta: Meta<typeof LinkButton> = {
   args: {
     size: 'large',
   },
-  play: async ({ canvas, step, args }) => {
-    await step('it should change size according to size prop', async () => {
-      await expect(
-        canvas.getByTestId('link-button').getBoundingClientRect().height,
-      ).toBe(args.size === 'large' ? 48 : 40)
-    })
-  },
 }
 export default meta
 type Story = StoryObj<typeof LinkButton>

--- a/packages/components/src/table/Table.stories.tsx
+++ b/packages/components/src/table/Table.stories.tsx
@@ -75,29 +75,7 @@ export default {
   },
 } satisfies Meta<typeof Table>
 
-export const Primary: Story = {
-  play: async ({ canvas, step, globals: { size } }) => {
-    await step(
-      'table headers should change size according to size prop',
-      async () => {
-        const tableHeaders = await canvas.findAllByRole('columnheader')
-
-        tableHeaders.forEach(async column => {
-          const { height } = column.getBoundingClientRect()
-          await expect(height).toBe(size === 'large' ? 48 : 40)
-        })
-      },
-    )
-    await step('cells should change size according to size prop', async () => {
-      const cells = await canvas.findAllByRole('gridcell')
-
-      cells.forEach(async cell => {
-        const { height } = cell.getBoundingClientRect()
-        await expect(height).toBe(size === 'large' ? 48 : 40)
-      })
-    })
-  },
-}
+export const Primary: Story = {}
 
 export const Striped: Story = {
   args: {


### PR DESCRIPTION
## Description

The interaction test to size in button, linkButton, and tabel are working perfectly when it be change in display scaling—either browser zoom or OS display settings.
## Changes

remove the size test from the components ( button, linkButton, and tabel) in storybook

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [ ] Conventional commit messages
