### PR TITLE
fix(link-button): replace background color for danger variant

### DIFF
--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -19,16 +19,6 @@ const meta: Meta<typeof Button> = {
       control: { type: 'radio' },
     },
   },
-  play: async ({ canvas, step }) => {
-    await step('it should have focus when clicked', async () => {
-      const button = canvas.getByRole('button')
-      await userEvent.click(button)
-      await expect(button).toBeEnabled()
-      button.focus()
-      await userEvent.keyboard('{Enter}')
-      await expect(button).toHaveFocus()
-    })
-  },
 }
 
 export default meta
@@ -99,5 +89,26 @@ export const Danger: Story = {
   args: {
     children: 'Button',
     variant: 'danger',
+  },
+}
+
+export const Tests: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    children: 'Button',
+    className: 'test-class',
+  },
+  play: async ({ canvas, step }) => {
+    await step('it should have focus when clicked', async () => {
+      const button = canvas.getByRole('button')
+      await userEvent.click(button)
+      await expect(button).toBeEnabled()
+      button.focus()
+      await userEvent.keyboard('{Enter}')
+      await expect(button).toHaveFocus()
+    })
   },
 }

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -90,10 +90,4 @@ export const Danger: Story = {
     children: 'Radera',
     variant: 'danger',
   },
-  parameters: {
-    a11y: {
-      // This color combo violates WCAG 2 AA contrast ratio threshold in dark mode
-      test: 'todo',
-    },
-  },
 }

--- a/packages/components/src/modal/Dialog.tsx
+++ b/packages/components/src/modal/Dialog.tsx
@@ -43,7 +43,14 @@ export const Modal: React.FC<AriaModalOverlayProps & DialogProps> = ({
         <AriaDialog {...props}>
           <div className={styles.modalHeader}>
             <div className={styles.modalTitle}>
-              {title && <Heading level={3} elementType={'h2'}>{title}</Heading>}
+              {title && (
+                <Heading
+                  level={3}
+                  elementType='h2'
+                >
+                  {title}
+                </Heading>
+              )}
             </div>
             <Button
               slot='close'

--- a/packages/components/src/theme/tokens.css
+++ b/packages/components/src/theme/tokens.css
@@ -253,9 +253,9 @@
 @value --button-background-secondary-active: light-dark(--gray-30, --gray-180);
 @value --button-background-tertiary-hover: light-dark(--white-hover, --gray-190);
 @value --button-background-tertiary-active: light-dark(--gray-30, --gray-180);
-@value --button-background-danger: light-dark(--signal-red-100, --signal-red-80);
-@value --button-background-danger-hover: light-dark(--signal-red-120, --signal-red-100);
-@value --button-background-danger-active: light-dark(--signal-red-150, --signal-red-130);
+@value --button-background-danger: light-dark(--signal-red-100, --signal-red-100);
+@value --button-background-danger-hover: light-dark(--signal-red-120, --signal-red-120);
+@value --button-background-danger-active: light-dark(--signal-red-150, --signal-red-150);
 @value --button-background-disabled: light-dark(--gray-10, --gray-180);
 @value --button-border-secondary: light-dark(--border-tertiary, --gray-10);
 @value --button-background-icon-hover: light-dark(rgba(0 0 0 / 10%), rgba(255 255 255 / 10%));

--- a/packages/components/src/theme/tokens.ts
+++ b/packages/components/src/theme/tokens.ts
@@ -243,9 +243,9 @@ export const semantic = {
   buttonBackgroundSecondaryActive: `light-dark(${baseColors.gray30}, ${baseColors.gray180})`,
   buttonBackgroundTertiaryHover: `light-dark(${baseColors.whiteHover}, ${baseColors.gray190})`,
   buttonBackgroundTertiaryActive: `light-dark(${baseColors.gray30}, ${baseColors.gray180})`,
-  buttonBackgroundDanger: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed80})`,
-  buttonBackgroundDangerHover: `light-dark(${baseColors.signalRed120}, ${baseColors.signalRed100})`,
-  buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed130})`,
+  buttonBackgroundDanger: `light-dark(${baseColors.signalRed100}, ${baseColors.signalRed100})`,
+  buttonBackgroundDangerHover: `light-dark(${baseColors.signalRed120}, ${baseColors.signalRed120})`,
+  buttonBackgroundDangerActive: `light-dark(${baseColors.signalRed150}, ${baseColors.signalRed150})`,
   buttonBackgroundDisabled: `light-dark(${baseColors.gray10}, ${baseColors.gray180})`,
 
   buttonBorderSecondary: `light-dark(${baseColors.blue150}, ${baseColors.gray10})`,


### PR DESCRIPTION
## Description

`LinkButton` danger variant has color contrast violations in dark mode
 
## Changes

- Revert "fix(theme): change dark mode values for danger button"
- test(link-button): remove a11y test bypass
- test(button): move interaction test to a separate story (because it interfered with a11y tests)

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
