### PR TITLE
chore: create separate storybook configs for serve and build

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -4,6 +4,10 @@ import type { StorybookConfig } from '@storybook/react-vite'
 
 const require = createRequire(import.meta.url)
 
+const basePath = process.cwd().endsWith('/packages/components')
+  ? process.cwd()
+  : join(process.cwd(), 'packages', 'components')
+
 const config: StorybookConfig = {
   stories: [
     '../src/**/*.stories.@(js|jsx|ts|tsx)',
@@ -24,7 +28,7 @@ const config: StorybookConfig = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {
       builder: {
-        viteConfigPath: 'vite.config.ts',
+        viteConfigPath: join(basePath, 'vite.config.ts'),
       },
     },
   },
@@ -34,7 +38,7 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
-      tsconfigPath: 'tsconfig.lib.json',
+      tsconfigPath: join(basePath, 'tsconfig.lib.json'),
       propFilter: prop => {
         if (prop.parent) {
           return !prop.parent.fileName.includes('@types/react')

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -51,17 +51,16 @@
       }
     },
     "build-storybook": {
-      "executor": "nx:run-commands",
-      "outputs": ["{options.output-dir}"],
+      "executor": "@nx/storybook:build",
+      "outputs": ["{options.outputDir}"],
       "options": {
-        "cwd": "packages/components",
-        "command": "npx storybook build",
-        "output-dir": "../../dist/storybook/ui"
+        "outputDir": "dist/storybook/ui",
+        "configDir": "packages/components/.storybook"
       },
       "configurations": {
         "ci": {
-          "output-dir": "../../dist/docs/storybook",
-          "args": ["--quiet"]
+          "quiet": true,
+          "outputDir": "dist/docs/storybook"
         }
       }
     },


### PR DESCRIPTION
## Description

Our Chromatic config dont like us running storybook process from within `packages/components`

## Changes

A quick fix that configures Storybook different depending on the job

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
