### PR TITLE
fix(textfield): remove duplicate props spreading

### DIFF
--- a/packages/components/src/textfield/Input.tsx
+++ b/packages/components/src/textfield/Input.tsx
@@ -1,15 +1,29 @@
-import { Input as AriaInput, InputProps } from 'react-aria-components'
+import {
+  Input as AriaInput,
+  InputProps as AriaInputProps,
+} from 'react-aria-components'
 import * as React from 'react'
 import clsx from 'clsx'
 import styles from './TextField.module.css'
 import { useContextProps, InputContext } from 'react-aria-components'
 import { PasswordField } from './PasswordField'
 
-export type { InputProps }
+export interface InputProps extends AriaInputProps {
+  /** If the component should use local props and ref instead of a parent context
+   * @default false
+   */
+  skipContext?: boolean
+}
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (props, ref) => {
-    ;[props, ref] = useContextProps(props, ref, InputContext)
+  ({ skipContext = false, ...localProps }, localRef) => {
+    const [contextProps, contextRef] = useContextProps(
+      localProps,
+      localRef,
+      InputContext,
+    )
+    const ref = skipContext ? localRef : contextRef
+    const props = skipContext ? localProps : contextProps
 
     return (
       <div className={styles.wrap}>

--- a/packages/components/src/textfield/PasswordField.tsx
+++ b/packages/components/src/textfield/PasswordField.tsx
@@ -5,29 +5,33 @@ import { Text } from '../text'
 import styles from './TextField.module.css'
 import { Button } from '../button'
 import { InputProps } from './Input'
+import { InputContext, useContextProps } from 'react-aria-components'
 
-export const PasswordField: React.FC<InputProps> = ({ value }) => {
-  const [showPassword, setShowPassword] = React.useState(false)
-  const handlePress = () => setShowPassword(previousValue => !previousValue)
-  const strings = useLocalizedStringFormatter(messages)
+export const PasswordField = React.forwardRef<HTMLInputElement, InputProps>(
+  (props, ref) => {
+    ;[props, ref] = useContextProps(props, ref, InputContext)
+    const [showPassword, setShowPassword] = React.useState(false)
+    const handlePress = () => setShowPassword(previousValue => !previousValue)
+    const strings = useLocalizedStringFormatter(messages)
 
-  return (
-    <>
-      {showPassword && (
-        <Text
-          slot='description'
-          className={styles.passwordText}
+    return (
+      <>
+        {showPassword && (
+          <Text
+            slot='description'
+            className={styles.passwordText}
+          >
+            {props.value}
+          </Text>
+        )}
+        <Button
+          variant='tertiary'
+          onPress={handlePress}
+          className={styles.passwordButton}
         >
-          {value}
-        </Text>
-      )}
-      <Button
-        variant='tertiary'
-        onPress={handlePress}
-        className={styles.passwordButton}
-      >
-        {showPassword ? strings.format('hide') : strings.format('show')}
-      </Button>
-    </>
-  )
-}
+          {showPassword ? strings.format('hide') : strings.format('show')}
+        </Button>
+      </>
+    )
+  },
+)

--- a/packages/components/src/textfield/TextArea.stories.tsx
+++ b/packages/components/src/textfield/TextArea.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { TextArea } from './TextArea'
 import { RunOptions } from 'axe-core'
-import { expect, userEvent } from 'storybook/test'
+import { expect, fn, userEvent } from 'storybook/test'
 import styles from './TextField.module.css'
 
 const stringOfLength = (length: number) => new Array(length + 1).join('x')
@@ -193,5 +193,33 @@ export const ShowCounterWithDefaultValue: Story = {
         ).toBeInTheDocument()
       },
     )
+  },
+}
+
+export const DS1326: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    onBlur: fn(),
+    onFocus: fn(),
+  },
+  play: async ({ args, step }) => {
+    await step('focus textarea', async () => {
+      await userEvent.tab()
+    })
+
+    await step('it should call onFocus once', async () => {
+      await expect(args.onFocus).toHaveBeenCalledOnce()
+    })
+
+    await step('blur textarea', async () => {
+      await userEvent.tab()
+    })
+
+    await step('it should call onBlur once', async () => {
+      await expect(args.onBlur).toHaveBeenCalledOnce()
+    })
   },
 }

--- a/packages/components/src/textfield/TextField.stories.tsx
+++ b/packages/components/src/textfield/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { RunOptions } from 'axe-core'
-import { expect, userEvent } from 'storybook/test'
+import { expect, fn, userEvent } from 'storybook/test'
 import { TextField } from '../textfield'
 
 export default {
@@ -256,5 +256,33 @@ export const WithHelpPopover: Story = {
         'An assistive text that helps the user understand the field better.',
       'aria-label': 'Mer information',
     },
+  },
+}
+
+export const DS1326: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    onBlur: fn(),
+    onFocus: fn(),
+  },
+  play: async ({ args, step }) => {
+    await step('focus textfield', async () => {
+      await userEvent.tab()
+    })
+
+    await step('it should call onFocus once', async () => {
+      await expect(args.onFocus).toHaveBeenCalledOnce()
+    })
+
+    await step('blur textfield', async () => {
+      await userEvent.tab()
+    })
+
+    await step('it should call onBlur once', async () => {
+      await expect(args.onBlur).toHaveBeenCalledOnce()
+    })
   },
 }

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -12,13 +12,15 @@ export interface TextFieldProps extends Omit<TextFieldBaseProps, 'children'> {
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ className, form, list, ...rest }, ref) => (
+  ({ className, form, list, type, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <Input
         className={clsx(className)}
         form={form}
         list={list}
         ref={ref}
+        type={type}
+        skipContext
       />
     </TextFieldBase>
   ),


### PR DESCRIPTION
## Description

Our component `TextField` calls event handlers two times instead of one

## Changes

Make the context optional for Input

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
