### PR TITLE
fix(layout): add basepath to active link comparison

### DIFF
--- a/packages/components/src/layout/components/SidebarLink.tsx
+++ b/packages/components/src/layout/components/SidebarLink.tsx
@@ -16,14 +16,17 @@ export const SidebarLink: React.FC<SidebarLinkProps> = ({
   active,
   hasBadge,
 }) => {
-  const { isCollapsed, setIsOpened } = useLayoutContext()
+  const { isCollapsed, setIsOpened, clientSideHref } = useLayoutContext()
+
+  const hrefWithBasePath = clientSideHref ? clientSideHref(href) : href
+
   const [isActive, setIsActive] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
-      setIsActive(active ?? window.location.pathname === href)
+      setIsActive(active ?? window.location.pathname === hrefWithBasePath)
     }
-  }, [active, href])
+  }, [active, hrefWithBasePath])
 
   if (isCollapsed)
     return (


### PR DESCRIPTION
## Description

Support ticket, active state not showing properly in environments using a basepath other than `/`

## Changes

add basepath to active link comparison

## Additional Information

Tested in playground app with a different basepath, hard to test otherwise!

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
