### PR TITLE
fix(components): use correct background color token for row

### DIFF
--- a/packages/components/src/table/Table.module.css
+++ b/packages/components/src/table/Table.module.css
@@ -43,7 +43,7 @@
       background-color: var(--midas-layer-01-hover);
     }
 
-    background-color: var(--midas-layer-01-hover);
+    background-color: var(--midas-layer-01-base);
 
     .cell {
       border-top: 1px var(--midas-border-color-subtle) solid;


### PR DESCRIPTION
## Description

Noticed that we used hover token for background color on rows. 

## Changes

Corrected to base token `--midas-layer-01-base`


## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
