### PR TITLE
fix(popover): prevent line breaks too early

### DIFF
--- a/packages/components/src/popover/Popover.module.css
+++ b/packages/components/src/popover/Popover.module.css
@@ -7,7 +7,8 @@
   outline: none;
   transform: translate3d(0, 0, 0);
   box-shadow: 0 4px 5px rgba(0 0 0 / 20%);
-  inline-size: min-content;
+  display: inline-block;
+  max-width: min(90vw, 320px);
   transition:
     transform 200ms,
     opacity 200ms;


### PR DESCRIPTION
## Description

Fixes this issue:
<img width="576" height="302" alt="image" src="https://github.com/user-attachments/assets/2e648998-0b7c-4e0c-8119-75c488d02e0f" />
To look like:
<img width="387" height="253" alt="image" src="https://github.com/user-attachments/assets/984d387e-154b-4481-b188-bd0a2cd012ba" />

