### PR TITLE
docs: remove color-scheme import to global stylesheet

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -4,26 +4,8 @@
  * work well for content-centric websites.
  */
 
-@import url('../../../../packages/components/src/default.css');
-
-@font-face {
-  /* stylelint-disable-next-line font-family-name-quotes */
-  font-family: 'Inter';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 100 900;
-  src: url('https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2')
-    format('woff2-variations');
-  unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-* {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@import url('../../../../packages/theme/src/lib/style-dictionary-dist/variables.css');
+@import url('../../../../packages/theme/src/lib/fonts.css');
 
 @font-face {
   font-family: 'Fira Code';


### PR DESCRIPTION
## Description

Unable to switch between dark/light mode in the docs app properly

## Changes

- remove color-scheme import to global stylesheet
- remove duplicate font face at-rule

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
