### PR TITLE
ops: add missing permissions to workflow

### DIFF
--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
## Description

Dependabot is angry with us for not declaring permissions 
https://github.com/migrationsverket/midas/security/code-scanning/17

## Changes

add missing permissions to workflow

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
