### PR TITLE
fix(accordion): increase specificity for button css

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -37,6 +37,7 @@
       }
     ],
     "no-descending-specificity": null,
-    "media-query-no-invalid": null
+    "media-query-no-invalid": null,
+    "selector-id-pattern": null
   }
 }

--- a/packages/components/src/accordion/AccordionItem.module.css
+++ b/packages/components/src/accordion/AccordionItem.module.css
@@ -80,7 +80,7 @@
   padding: 0;
 }
 
-.triggerButton {
+:not(#\9) .triggerButton {
   width: 100%;
   padding: var(--item-padding);
   align-items: flex-start;


### PR DESCRIPTION
## Description

AccordionItem has "extra" padding in the [docs app production build](https://designsystem.migrationsverket.se/components/accordion/)

Actually the correct padding is being overwritten by the default styles of the `Button` component due to the import order of CSS classes.

Read more here: https://github.com/facebook/docusaurus/issues/4518

## Changes

- add a funky :not-selector to increase the specificity of the accordion item trigger button styles

## Additional Information

Inspired by this post css plugin: https://github.com/MadLittleMods/postcss-increase-specificity
We could also do something like `button .triggerButton` to increase the specificity, or do `!important`. 

Is this a bigger issue?

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
