### PR TITLE
fix(modal): accept controlled open state props

### DIFF
--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -79,18 +79,21 @@ Använd `isOpen` och `onOpenChange()` för att via state kontrollera om modalen 
 /* imports and rest of app */
 const [open, setOpen] = React.useState<boolean>(false)
 
-/* trigger modal from anywhere */
-<Button onPress={() => setOpen(true))}>Open</Button>
-
-//highlight-start
-<DialogTrigger isOpen={open} onOpenChange={setOpen}>
-//highlight-end
-  <Modal
-    title="Modal Title"
-  >
-    /* Modal content */
-  </Modal>
-</DialogTrigger>
+return (
+  <>
+    {/* trigger modal from anywhere */}
+    <Button onPress={() => setOpen(true)}>Open</Button>
+    // highlight-start
+    <Modal
+      title='Modal Title'
+      isOpen={open}
+      onOpenChange={setOpen}
+    >
+      // highlight-end
+      {/* Modal content */}
+    </Modal>
+  </>
+)
 ```
 
 ## Avancerat innehåll

--- a/packages/components/src/modal/Dialog.tsx
+++ b/packages/components/src/modal/Dialog.tsx
@@ -10,12 +10,14 @@ import * as React from 'react'
 import { Button } from '../button'
 import styles from './Dialog.module.css'
 import { X } from 'lucide-react'
-import { AriaModalOverlayProps } from '@react-aria/overlays'
 import { Heading } from '../heading'
 import { useLocalizedStringFormatter } from '../utils/intl'
 import messages from './intl/translations.json'
 import clsx from 'clsx'
 
+/**
+ * @deprecated since v13.0.1 please use ModalProps instead
+ */
 export interface DialogProps extends AriaDialogProps {
   /**
    * An optional title for the dialog. If omitted, please provide an aria-label for accessibility.
@@ -24,9 +26,15 @@ export interface DialogProps extends AriaDialogProps {
   children: React.ReactNode
 }
 
-export type ModalProps = AriaModalOverlayProps &
-  DialogProps &
-  Pick<ModalOverlayProps, 'className'>
+export interface ModalProps
+  extends ModalOverlayProps,
+    React.RefAttributes<HTMLDivElement> {
+  /**
+   * An optional title for the dialog. If omitted, please provide an aria-label for accessibility.
+   */
+  title?: React.ReactNode
+  children: React.ReactNode
+}
 
 export { DialogTrigger }
 
@@ -43,17 +51,15 @@ export const Modal: React.FC<ModalProps> = ({
       {...props}
       className={clsx(styles.overlay, className)}
     >
-      <AriaModal
-        {...props}
-        className={styles.modal}
-      >
-        <AriaDialog {...props}>
+      <AriaModal className={styles.modal}>
+        <AriaDialog>
           <div className={styles.modalHeader}>
             <div className={styles.modalTitle}>
               {title && (
                 <Heading
                   level={3}
                   elementType='h2'
+                  slot='title'
                 >
                   {title}
                 </Heading>


### PR DESCRIPTION
## Description

`<DialogTrigger>` emits a warning if no clickable children is present

## Changes

- add isOpen and onOpenChange props to Modal component

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
