### PR TITLE
feat(button): add loading state with aria-disabled

### DIFF
--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -153,3 +153,7 @@
     border-width: 2px;
   }
 }
+
+.loading {
+  cursor: wait;
+}

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -10,6 +10,7 @@ import {
 import clsx from '../utils/clsx'
 import { LucideIcon } from 'lucide-react'
 import { Size } from '../common/types'
+import { Spinner } from '../spinner/Spinner';
 
 export interface MidasButtonProps {
   /**
@@ -18,12 +19,16 @@ export interface MidasButtonProps {
    * @default 'primary'
    * */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'icon'
+  /** Shows a spinner and disables input */
+  isLoading?: boolean
   /**
    * Adds width: 100%; for the button to span entire width of parent
    *
    * @default false
    */
+
   fullwidth?: boolean
+
   /** Component size (large: height 48px, medium: height 40px)
    *  @default 'large'
    **/
@@ -68,6 +73,7 @@ export const Button: React.FC<MidasButton> = ({
   size = 'large',
   icon: IconComponent,
   iconSize,
+  isLoading,
   ...rest
 }) => {
   return (
@@ -79,20 +85,24 @@ export const Button: React.FC<MidasButton> = ({
         variant === 'tertiary' && styles.tertiary,
         variant === 'danger' && styles.danger,
         variant === 'icon' && styles.iconBtn,
+        isLoading && styles.loading,
         fullwidth && styles.fullwidth,
         size === 'medium' && styles.medium,
         iconPlacement === 'right' && styles.iconRight,
         className,
       )}
+      aria-disabled={isLoading}
+      onPress={isLoading ? undefined : rest.onPress}
       {...rest}
     >
       <>
-        {IconComponent && (
+        {IconComponent && !isLoading && (
           <IconComponent
             aria-hidden
             size={iconSize ?? 20}
           />
         )}
+        {isLoading && <Spinner small />}
         {rest.children}
       </>
     </AriaButton>


### PR DESCRIPTION
## Description

Adds a loading state to button that displays spinner, sets aria-disabled='true' and blocks input.   

This feature is meant to help developers when making a loading button according to our loading pattern detailed in https://github.com/migrationsverket/midas/pull/868, where the guideline is to make the button active looking but not interactive. Instead of everyone manually doing this, we are adding a prop.


## Changes

add `isLoading` prop 

## Additional Information

This has been dubber ducked by AI.
For this feature to make sense, we also need to change Spinner so that it uses the same color as the text in certain scenarios, such as the button
The docs need to be updated, but I wanted feedback on the feature first! 

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
