### PR TITLE
fix(info-banner): prevent double useEffect run in strict mode

### DIFF
--- a/apps/storybook/src/stories/InfoBanner.stories.tsx
+++ b/apps/storybook/src/stories/InfoBanner.stories.tsx
@@ -131,8 +131,7 @@ export const ControlledTests: Story = {
         await userEvent.click(closeButton)
         await expect(args.onOpenChange).toHaveBeenCalledWith(false)
         await userEvent.click(canvas.getByRole('button'))
-        await expect(args.onOpenChange).toHaveBeenCalledWith(true)
-        await expect(args.onOpenChange).toHaveBeenCalledTimes(2)
+        await expect(args.onOpenChange).toHaveBeenCalledTimes(1)
       },
     )
   },

--- a/packages/components/src/info-banner/InfoBanner.tsx
+++ b/packages/components/src/info-banner/InfoBanner.tsx
@@ -55,13 +55,10 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
   onOpenChange,
   ...rest
 }) => {
-  const isInitialRender = React.useRef(true)
-
   const isControlled = typeof controlledIsOpen !== 'undefined'
 
-  const [isOpen, setIsOpen] = React.useState<boolean>(
-    isControlled ? controlledIsOpen : defaultOpen,
-  )
+  const [isOpen, setIsOpen] = React.useState<boolean>(defaultOpen)
+
   const Icon = iconMap[type]
 
   const strings = useLocalizedStringFormatter(messages)
@@ -74,25 +71,7 @@ export const InfoBanner: React.FC<InfoBannerProps> = ({
     }
   }
 
-  React.useEffect(() => {
-    if (isInitialRender.current) {
-      isInitialRender.current = false
-      return
-    }
-
-    setIsOpen(previousOpen => {
-      const isOpening =
-        (isControlled && controlledIsOpen) || (!isControlled && !previousOpen)
-
-      if (isOpening) {
-        onOpenChange?.(true)
-      }
-
-      return isOpening
-    })
-  }, [controlledIsOpen, isControlled, onOpenChange])
-
-  if (isOpen)
+  if ((isControlled && controlledIsOpen) || (!isControlled && isOpen))
     return (
       <div
         {...rest}


### PR DESCRIPTION
## Description

Component mounts and immediately unmounts in development using StrictMode in React 18+.
See [stackoverflow](https://stackoverflow.com/a/72238236)

## Changes

- Remove the useEffect and useRef fiddle completely
- Separate the internal and external "isOpen" states

## Additional Information

Can be tested in an exernal app or the playground

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
