### PR TITLE
docs: fix RAC link in breadcrumbs documentation

### DIFF
--- a/apps/docs/docs/components/breadcrumbs.mdx
+++ b/apps/docs/docs/components/breadcrumbs.mdx
@@ -10,7 +10,6 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 <ComponentHeader
   name='Breadcrumbs'
   friendlyName='Brödsmulor'
-  overrideHeadlessLink=''
 />
 
 Komponent som används för att visa användaren var den är i ett djupt navigationsträd.


### PR DESCRIPTION
## Description

Link to RAC was missing in header

## Changes

Fixed it


