### PR TITLE
docs: increase width when propstable should collapse

### DIFF
--- a/apps/docs/src/css/propstable.module.css
+++ b/apps/docs/src/css/propstable.module.css
@@ -19,7 +19,7 @@
   table {
     grid-template-columns: 2fr 2fr 1fr 3fr;
 
-    @media (width < 996px) {
+    @media (width < 1200px) {
       grid-template-columns: subgrid;
     }
   }
@@ -30,19 +30,19 @@
         var(--ifm-table-border-color);
     }
 
-    @media (width < 996px) {
+    @media (width < 1200px) {
       display: none;
     }
   }
 
   tbody {
-    @media (width > 996px) {
+    @media (width > 1200px) {
       tr:first-of-type {
         border-top: none;
       }
     }
 
-    @media (width < 996px) {
+    @media (width < 1200px) {
       td:not(:last-of-type) {
         display: flex;
       }


### PR DESCRIPTION
## Description

Description was not visible at some screen sizes, this should fix that problem

<img width="870" height="436" alt="image" src="https://github.com/user-attachments/assets/c06620a2-5dfe-4693-b235-b6516a802459" />
