### PR TITLE
fix(textfield): omit intersecting prop definitions

### DIFF
--- a/packages/components/src/textfield/TextArea.tsx
+++ b/packages/components/src/textfield/TextArea.tsx
@@ -8,9 +8,10 @@ import {
 } from 'react-aria-components'
 import clsx from '../utils/clsx'
 import styles from './TextField.module.css'
+import { Complement } from '../utils/types'
 
 export type TextAreaProps = Omit<TextFieldBaseProps, 'type' | 'pattern'> &
-  AriaTextAreaProps
+  Complement<TextFieldBaseProps, AriaTextAreaProps>
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, cols, rows, wrap, ...rest }, ref) => (

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -4,8 +4,10 @@ import * as React from 'react'
 import { TextFieldBase, type TextFieldBaseProps } from './TextFieldBase'
 import { Input, type InputProps } from './Input'
 import clsx from '../utils/clsx'
+import { Complement } from '../utils/types'
 
-export type TextFieldProps = TextFieldBaseProps & Omit<InputProps, 'size'>
+export type TextFieldProps = TextFieldBaseProps &
+  Complement<TextFieldBaseProps, InputProps>
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   ({ className, list, type, ...rest }, ref) => (

--- a/packages/components/src/utils/types.ts
+++ b/packages/components/src/utils/types.ts
@@ -5,3 +5,9 @@ export type ExcludeKeysFrom<
   T extends object,
   ToExlude extends PropertyKey,
 > = Omit<T, ToExlude> & Partial<Record<ToExlude, never>>
+
+/**
+ * Get keys in B but not in A
+ * ![img](https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Relative_compliment.svg/50px-Relative_compliment.svg.png)
+ */
+export type Complement<A, B> = Omit<B, keyof A & keyof B>


### PR DESCRIPTION
## Description

support ticket

## Changes

- omit intersecting types between `TextFieldBaseProps` and `InputProps`
- omit intersecting types between `TextFieldBaseProps` and `TextAreaProps`

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
