### PR TITLE
fix(list-box): adjust selected styling for listBoxItem

### DIFF
--- a/packages/components/src/list-box/ListBox.module.css
+++ b/packages/components/src/list-box/ListBox.module.css
@@ -62,7 +62,6 @@
   margin-bottom: 0;
   padding: var(--midas-size-70) var(--midas-spacing-50);
   transition: background-color 60ms;
-  word-break: break-all;
   gap: var(--midas-spacing-50);
 
   &:hover:not([data-disabled]) {


### PR DESCRIPTION
## Description

Default behaviour for long strings without spaces in ListBoxOption

## Changes

- fix(list-box): add word-break: break-all for listBoxItem

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
