### PR TITLE
test(storybook): remove snapshot addon panel

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -17,16 +17,6 @@ export default {
     getAbsolutePath('@storybook/addon-a11y'),
     getAbsolutePath('@storybook/addon-docs'),
     getAbsolutePath('@storybook/addon-vitest'),
-    {
-      name: getAbsolutePath('storybook-addon-vis'),
-      options: {
-        visProjects: [
-          { snapshotRootDir: join(basePath, '__vis__/light/local') },
-          { snapshotRootDir: join(basePath, '__vis__/dark/local') },
-          { snapshotRootDir: join(basePath, '__vis__/forced-colors/local') },
-        ],
-      },
-    },
   ],
   core: {
     disableTelemetry: true,


### PR DESCRIPTION
## Description

storybook keeps crashing

## Changes

- disable the storybook snapshot addon

## Additional Information

Snapshot testing still works, but you cannot use storybook to look at the screenshots

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
