### PR TITLE
fix(list-box): add breaks for long words

### DIFF
--- a/apps/storybook/src/stories/Select.stories.tsx
+++ b/apps/storybook/src/stories/Select.stories.tsx
@@ -211,3 +211,40 @@ export const RequiredSingleSelect: Story = {
     </form>
   ),
 }
+
+export const LongWords: Story = {
+  tags: ['!dev', '!autodocs'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    label: 'Long words',
+    description: 'just for test',
+    children: (
+      <>
+        <ListBoxItem>JavaScript&shy;Select&shy;Component</ListBoxItem>
+        <ListBoxItem>
+          En lång mening utan några långa ord, bara mellanslag
+        </ListBoxItem>
+        <ListBoxItem>
+          En lång mening med ett jättelångt ord:
+          pneumonoultramicroscopicsilicovolcanoconiosis
+        </ListBoxItem>
+        <ListBoxItem>
+          In an extraordinary demonstration of interdisciplinary collaboration,
+          the hypermetropolitan university's neurophysiological research
+          consortium unveiled a revolutionary apparatus designed to facilitate
+          intercommunicational synchronization between artificially intelligent
+          entities and biologically conscious organisms. The device, operating
+          through electroencephalographic transmodulation and algorithmic
+          contextualization, promises unprecedented advancements in cognitive
+          enhancement, neuroplastic rehabilitation, and computational
+          linguistics. Such an innovation, while theoretically transformative,
+          also precipitates multifaceted bioethical deliberations concerning
+          technopsychological autonomy and the potential dehumanization of
+          consciousness through overmechanization.
+        </ListBoxItem>
+      </>
+    ),
+  },
+}

--- a/packages/components/src/list-box/ListBox.module.css
+++ b/packages/components/src/list-box/ListBox.module.css
@@ -55,6 +55,7 @@
 .listBoxItem {
   align-items: center;
   background-color: var(--midas-layer-01-base);
+  box-sizing: border-box;
   color: var(--midas-text-primary);
   display: flex;
   font-family: var(--midas-typography-font-family);
@@ -63,6 +64,12 @@
   padding: var(--midas-size-70) var(--midas-spacing-50);
   transition: background-color 60ms;
   gap: var(--midas-spacing-50);
+
+  .textContent {
+    hyphens: auto;
+    overflow-wrap: break-word;
+    width: 100%;
+  }
 
   &:hover:not([data-disabled]) {
     background-color: var(--midas-layer-01-hover);
@@ -104,6 +111,10 @@
 
     &[data-selection-mode='single'] {
       &[data-selected] {
+        .textContent {
+          max-width: calc(100% - 3rem);
+        }
+
         &::after {
           content: '';
           background-color: var(--midas-text-primary);

--- a/packages/components/src/list-box/ListBoxItem.tsx
+++ b/packages/components/src/list-box/ListBoxItem.tsx
@@ -18,13 +18,21 @@ export const ListBoxItem = <T extends object>({
   children,
   className,
   hideSelectionIndicator,
+  textValue,
   ...rest
 }: ListBoxItemProps<T>) => (
   <AriaListBoxItem
     className={clsx(styles.listBoxItem, className)}
     data-show-selection={!hideSelectionIndicator || undefined}
+    textValue={
+      textValue || (typeof children === 'string' ? children : undefined)
+    }
     {...rest}
   >
-    {children}
+    {renderProps => (
+      <div className={styles.textContent}>
+        {typeof children === 'function' ? children(renderProps) : children}
+      </div>
+    )}
   </AriaListBoxItem>
 )

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -54,10 +54,7 @@ export interface MidasSelectProps<
   size?: Size
 }
 
-export function Select<
-  T extends object,
-  M extends SelectionMode = 'single',
->({
+export function Select<T extends object, M extends SelectionMode = 'single'>({
   children,
   description,
   errorMessage,
@@ -95,7 +92,7 @@ export function Select<
               props.selectionMode !== 'multiple' ? (
                 <div className={clsx(styles.placeholder)}>
                   <span className={clsx(styles.truncate)}>
-                    {renderProps.defaultChildren}
+                    {renderProps.selectedText || renderProps.defaultChildren}
                   </span>
                 </div>
               ) : (


### PR DESCRIPTION
## Description

Allow long sentences and long words in listbox items

## Changes

- fix(list-box): add breaks for long words

## Additional information

https://designsystem.migrationsverket.se/pr-preview/pr-913/storybook/iframe.html?globals=&args=&id=components-select--long-words&viewMode=story

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
