### PR TITLE
fix(textfield): honor min and max for number fields

### DIFF
--- a/apps/storybook/src/stories/TextField.spec.tsx
+++ b/apps/storybook/src/stories/TextField.spec.tsx
@@ -125,14 +125,23 @@ describe('given DS1243', async () => {
 })
 
 describe('given a TextField with type="number"', async () => {
-  beforeEach(async () => {
-    await Number.run()
-  })
-
   it('should not allow any non number input', async () => {
+    await Number.run()
     await userEvent.tab()
     await userEvent.keyboard('abc')
     expect(page.getByRole('spinbutton')).toHaveValue(null)
+  })
+
+  it('should not allow numbers below the "min" threshold', async () => {
+    await Number.run({
+      args: {
+        ...Number.args,
+        min: 0,
+      },
+    })
+    await userEvent.tab()
+    await userEvent.keyboard('[ArrowDown]')
+    expect(page.getByRole('spinbutton')).toHaveValue(0)
   })
 })
 

--- a/packages/components/src/textfield/TextField.tsx
+++ b/packages/components/src/textfield/TextField.tsx
@@ -10,11 +10,13 @@ export type TextFieldProps = TextFieldBaseProps &
   Complement<TextFieldBaseProps, InputProps>
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ className, list, type, ...rest }, ref) => (
+  ({ className, list, type, min, max, ...rest }, ref) => (
     <TextFieldBase {...rest}>
       <Input
         className={clsx(className)}
         list={list}
+        min={min}
+        max={max}
         ref={ref}
         type={type}
         skipContext


### PR DESCRIPTION
## Description

Support ticket: `<TextField type="number" min={0} />` allows negative values

## Changes

fix(textfield): honor min and max for number fields

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
