### PR TITLE
fix(select): remove selection indicators in legacy select

### DIFF
--- a/apps/storybook/src/stories/LegacySelect.stories.tsx
+++ b/apps/storybook/src/stories/LegacySelect.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { LegacySelect } from '@midas-ds/components'
+import { options } from '../utils/storybook'
+
+type Story = StoryObj<typeof LegacySelect>
+
+export default {
+  component: LegacySelect,
+  title: 'Components/Select/Legacy',
+  tags: ['autodocs'],
+  args: {
+    description: 'Description',
+    isDisabled: false,
+    isSelectableAll: false,
+    label: 'Label',
+    options: options,
+    placeholder: 'Select an option',
+    selectionMode: 'single',
+    showTags: false,
+    errorPosition: 'top',
+    size: 'large',
+  },
+} satisfies Meta<typeof LegacySelect>
+
+export const Primary: Story = {}

--- a/packages/components/src/legacy-select/SelectListBox.tsx
+++ b/packages/components/src/legacy-select/SelectListBox.tsx
@@ -1,7 +1,4 @@
-import * as React from 'react'
-import { Check } from 'lucide-react'
 import { Collection } from 'react-aria-components'
-import { Checkbox } from '../checkbox'
 import {
   ListBox,
   ListBoxItem,
@@ -13,7 +10,6 @@ import {
 import type { AriaListBoxOptions } from '@react-aria/listbox'
 import type { Node } from '@react-types/shared'
 import type { MultiSelectState } from './types'
-import styles from './Select.module.css'
 
 interface ListBoxProps<T extends ListBoxOption> extends AriaListBoxOptions<T> {
   state: MultiSelectState<T>
@@ -34,31 +30,7 @@ const Option = ({ item }: OptionProps) => (
     textValue={item.textValue}
     aria-label={item.textValue}
   >
-    {({ isDisabled, isSelected, selectionMode }) => (
-      <>
-        {selectionMode === 'multiple' ? (
-          <div
-            className={styles.checkboxContainer}
-            aria-hidden
-          >
-            <Checkbox
-              isDisabled={isDisabled}
-              isSelected={isSelected}
-              isReadOnly
-              excludeFromTabOrder
-              aria-label={item.textValue}
-            />
-          </div>
-        ) : null}
-        {item.rendered}
-        {isSelected && selectionMode === 'single' ? (
-          <Check
-            size={20}
-            className={styles.listBoxItemCheckmark}
-          />
-        ) : null}
-      </>
-    )}
+    {item.rendered}
   </ListBoxItem>
 )
 


### PR DESCRIPTION
## Description

Support ticket, `LegacySelect` shows double selection indicators

## Changes

- fix(select): remove selection indicators in legacy select

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
