### PR TITLE
fix(select): fix flying popover animation bug

### DIFF
--- a/packages/components/src/select/Select.module.css
+++ b/packages/components/src/select/Select.module.css
@@ -167,7 +167,9 @@
     /* RAC passes this variable via the style prop, making it available during runtime only */
     /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
     min-width: var(--trigger-width);
-    transition: all 0.2s ease-in-out;
+    transition:
+      transform 0.2s ease-in-out,
+      opacity 0.2s ease-in-out;
     opacity: 1;
 
     &[data-entering] {


### PR DESCRIPTION
## Description

The popover animates the css `top` property which sometimes is `0` for a split second

## Changes

- animate on transform and opacity only

## Additional Information

Svår att testa, lyckas inte återskapa felet nu iaf. 🤞 

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
