### PR TITLE
docs(components, calendar): add aria-labels to examples

### DIFF
--- a/apps/docs/docs/components/calendar.mdx
+++ b/apps/docs/docs/components/calendar.mdx
@@ -21,14 +21,14 @@ import { Calendar } from '@midas-ds/components'
 ```
 
 ```tsx
-<Calendar />
+<Calendar aria-label='Kalender' />
 ```
 
 <div
   className='card'
   style={{ display: 'block' }}
 >
-  <Calendar />
+  <Calendar aria-label='Kalender' />
 </div>
 
 ## Användning
@@ -59,6 +59,7 @@ export const RangeCalendarExample = () => {
   return (
     <>
       <RangeCalendar
+        aria-label='Kalender'
         value={selected}
         onChange={setSelected}
       />
@@ -77,7 +78,7 @@ export const RangeCalendarExample = () => {
   className='card'
   style={{ display: 'block' }}
 >
-  <RangeCalendarExample />
+  <RangeCalendarExample aria-label='Kalender' />
 </div>
 
 ## API

--- a/apps/docs/src/components/examples/calendar/CalendarExamples.tsx
+++ b/apps/docs/src/components/examples/calendar/CalendarExamples.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { RangeCalendar } from '@midas-ds/components'
+import { RangeCalendar, RangeCalendarProps } from '@midas-ds/components'
 import { DateValue } from 'react-aria-components'
 
-export const RangeCalendarExample = () => {
+export const RangeCalendarExample = (props: Partial<RangeCalendarProps>) => {
   const [selected, setSelected] = React.useState<{
     start: DateValue
     end: DateValue
@@ -13,6 +13,7 @@ export const RangeCalendarExample = () => {
       <RangeCalendar
         value={selected}
         onChange={setSelected}
+        {...props}
       />
       <pre style={{ marginTop: '1rem' }}>
         Valda datum:{' '}


### PR DESCRIPTION
## Description

`Calendar` and `RangeCalendar`  has a default aria-label of the current month and year. 
Developers can prepend information to the aria-label.

```tsx
<Calendar aria-label="Kalender" />
```
Gives
```html
<div aria-label="Kalender, december 2025" role="application" />
``` 

## Changes

docs(components, calendar): add aria-labels to examples

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
