### PR TITLE
fix(components, calendar): align date vertically using flex

### DIFF
--- a/packages/components/src/calendar/Calendar.module.css
+++ b/packages/components/src/calendar/Calendar.module.css
@@ -30,16 +30,18 @@
     width: var(--midas-size-130);
     height: var(--midas-size-130);
     box-sizing: border-box;
-    line-height: initial;
   }
 
   th {
     font-weight: 500;
     padding: 0.625rem 0;
+    line-height: initial;
   }
 
   & .day {
-    padding: 0.5rem 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   background-color: var(--midas-layer-01-base);


### PR DESCRIPTION
## Description

date number was not centered vertically, this should fix it


