### PR TITLE
fix(components): externalize dependencies

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@midas-ds/theme": "3.8.0",
-    "react-aria-components": "1.13.0",
-    "react-stately": "3.42.0"
+    "react-aria-components": "1.13.0"
   }
 }

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
           globSync(`${src}/*/index.ts`).map(file => [
             relative(src, file.slice(0, file.length - extname(file).length)),
             fileURLToPath(new URL(relative(__dirname, file), import.meta.url)),
-          ])
+          ]),
         ),
       },
       formats: ['es'],
@@ -49,23 +49,23 @@ export default defineConfig({
       transformMixedEsModules: true,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-aria-components',
+        'react-aria',
+        'react-stately',
+        /@react-aria/,
+        /@react-stately/,
+        /@internationalized/,
+        '@midas-ds/theme',
+      ],
       output: {
         assetFileNames: 'assets/[name][extname]',
         entryFileNames: '[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
         format: 'es',
-        manualChunks: (id) => {
-          if (id.includes('node_modules/react-aria-components')) {
-            return 'react-aria-components'
-          }
-          if (id.includes('node_modules/@internationalized')) {
-            return 'internationalized'
-          }
-          if (id.includes('node_modules/react-stately')) {
-            return 'react-stately'
-          }
-        },
       },
     },
   },


### PR DESCRIPTION
## Description

Support ticket

Unable to combine RAC with Midas components due to version mismatch.

## Changes

- fix(components): externalize dependencies



## Additional Information

This following example works fine in our playground app but the `Popover` is unavailable (inert) in an external app installing our package:

```tsx
import { Button, DialogTrigger, Modal } from '@midas-ds/components'
import { ChevronDown } from 'lucide-react'
import {
  Button as AriaButton,
  ComboBox,
  Input,
  Label,
  ListBox,
  ListBoxItem,
  Popover,
} from 'react-aria-components'

export default function App() {
  return (
    <DialogTrigger>
      <Button>Öppna modal</Button>
      <Modal title='Rubrik'>
        <ComboBox>
          <Label>Favorite Animal</Label>
          <Input />
          <AriaButton>
            <ChevronDown size={16} />
          </AriaButton>
          <Popover>
            <ListBox>
              <ListBoxItem>Aardvark</ListBoxItem>
              <ListBoxItem>Cat</ListBoxItem>
              <ListBoxItem>Dog</ListBoxItem>
              <ListBoxItem>Kangaroo</ListBoxItem>
              <ListBoxItem>Panda</ListBoxItem>
              <ListBoxItem>Snake</ListBoxItem>
            </ListBox>
          </Popover>
        </ComboBox>
      </Modal>
    </DialogTrigger>
  )
}
```
## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
