### PR TITLE
fix(select-styles): add medium size support

### DIFF
--- a/apps/docs/docs/dev/react-select.mdx
+++ b/apps/docs/docs/dev/react-select.mdx
@@ -94,3 +94,19 @@ import '@midas-ds/select-styles/lib/react-select.css'
   />
 </div>
 ```
+
+### Medium size
+
+Midas formulärkomponenter stödjer två storlekar `"large" | "medium"`. Använd klassnamnet `"medium"` för att åstadkomma samma resultat för react-select.
+
+<div
+  className='card'
+  style={{ overflow: 'visible' }}
+>
+  <MultiComboBox id='multi-combo-box-medium' className="select medium" />
+</div>
+```tsx
+<Select className="select medium"
+// ...
+>
+```

--- a/apps/docs/src/components/examples/react-select/MultiComboBox.tsx
+++ b/apps/docs/src/components/examples/react-select/MultiComboBox.tsx
@@ -5,15 +5,18 @@ import '@midas-ds/select-styles/lib/react-select.css'
 
 import { mockPersonData } from '../mockData'
 
-type MultiComboBoxProps = { id?: string }
+type MultiComboBoxProps = { id?: string; className?: string }
 
-export const MultiComboBox = ({ id = 'basic-example' }: MultiComboBoxProps) => {
+export const MultiComboBox = ({
+  id = 'basic-example',
+  className = 'select',
+}: MultiComboBoxProps) => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Label htmlFor={id}>Select employee</Label>
       <Text slot='description'>Employees from all departments</Text>
       <Select
-        className='select'
+        className={className}
         classNamePrefix='midas'
         closeMenuOnSelect={false}
         hideSelectedOptions={false}

--- a/apps/storybook/src/stories/ReactSelect.stories.tsx
+++ b/apps/storybook/src/stories/ReactSelect.stories.tsx
@@ -52,3 +52,10 @@ export const MultiSelect: Story = {
     },
   },
 }
+
+export const MultiSelectMedium: Story = {
+  args: {
+    ...MultiSelect.args,
+    className: 'select medium',
+  },
+}

--- a/packages/select-styles/src/lib/react-select.css
+++ b/packages/select-styles/src/lib/react-select.css
@@ -11,6 +11,10 @@
     .midas__control {
       min-height: var(--midas-size-130);
     }
+
+    .midas__value-container--is-multi {
+      padding: 4px;
+    }
   }
 
   .midas__control {


### PR DESCRIPTION
## Description

Medium size makes a little jump when adding values in a multi select.

## Changes

change padding

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
