### PR TITLE
fix(components, accordion): adjust padding of uncontained content container

### DIFF
--- a/packages/components/src/accordion/AccordionItem.module.css
+++ b/packages/components/src/accordion/AccordionItem.module.css
@@ -1,6 +1,6 @@
 .item {
   --item-padding: 0;
-  --content-padding: var(--midas-spacing-20) var(--midas-spacing-50)
+  --content-padding: var(--midas-spacing-30) var(--midas-spacing-50)
     var(--midas-spacing-50) 1.85rem;
   --border: none;
   --accordion-background: transparent;


### PR DESCRIPTION
## Description

Too little white space between the heading and the content for uncontained accordions

## Changes

- fix(components, accordion): adjust padding of uncontained content containe

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
