### PR TITLE
fix(components, date-picker): adjust icon button height

### DIFF
--- a/packages/components/src/date-picker/DatePicker.module.css
+++ b/packages/components/src/date-picker/DatePicker.module.css
@@ -52,11 +52,14 @@
   .buttonGroup {
     display: flex;
     margin-left: auto;
-    gap: 0;
+    height: 100%;
   }
 
   .iconButton {
+    align-self: stretch;
+    aspect-ratio: 1;
     border: none;
+    padding: 0;
 
     &[data-disabled] {
       background-color: transparent;


### PR DESCRIPTION
## Description

Icons have 46px height in the 48px container

## Changes

- fix(components, date-picker): adjust icon button height

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
