### PR TITLE
fix(select): change padding

### DIFF
--- a/packages/components/src/select/Select.module.css
+++ b/packages/components/src/select/Select.module.css
@@ -22,8 +22,8 @@
   gap: var(--midas-spacing-20);
   justify-content: space-between;
   min-height: var(--midas-size-150);
-  padding-left: var(--midas-size-70);
-  padding-right: var(--midas-size-70);
+  padding-left: var(--midas-size-80);
+  padding-right: var(--midas-size-80);
   transition: all 100ms ease-in;
 
   &.medium {


### PR DESCRIPTION
## Description

Select has different left padding than all other field type components (Date picker, Combobox etc). This PR fixes that issue

## Changes

changed to --midas-size-80 for left and right padding


## Additional Information

Combobox uses an icon button to wrap the icon, while Select doesn't. Unsure if we need to do anything about this as the whole field is acting as a button, but it's something I noticed

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
