### PR TITLE
ops: add concurrency rules to publish-docs.yml

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-docs:
     name: Publish docs


### PR DESCRIPTION
## Description

Only allow one concurrent run of the publish-docs workflow, cancel any running jobs.

## Additional information

- [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action/tree/v4/?tab=readme-ov-file#getting-started-airplane)
- [Concurrency](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)

## Changes

- ops: add concurrency rules to publish-docs.yml