### PR TITLE
feat(tabs): add size prop with large/medium variants

### DIFF
--- a/packages/components/src/tabs/Tab.tsx
+++ b/packages/components/src/tabs/Tab.tsx
@@ -12,7 +12,7 @@ import styles from './Tabs.module.css'
 import { TabsContext } from './TabsContext'
 
 export const Tab: React.FC<TabProps> = ({ className, ...props }) => {
-  const { variant } = React.useContext(TabsContext)
+  const { variant, size } = React.useContext(TabsContext)
 
   return (
     <AriaTab
@@ -21,6 +21,7 @@ export const Tab: React.FC<TabProps> = ({ className, ...props }) => {
         styles.tab,
         {
           [styles.contained]: variant === 'contained',
+          [styles.medium]: size === 'medium',
         },
         className,
       )}

--- a/packages/components/src/tabs/TabPanel.tsx
+++ b/packages/components/src/tabs/TabPanel.tsx
@@ -7,7 +7,7 @@ import styles from './Tabs.module.css'
 import { TabsContext } from './TabsContext'
 
 export const TabPanel: React.FC<TabPanelProps> = ({ className, ...props }) => {
-  const { variant } = React.useContext(TabsContext)
+  const { variant, size } = React.useContext(TabsContext)
 
   return (
     <AriaTabPanel
@@ -15,6 +15,7 @@ export const TabPanel: React.FC<TabPanelProps> = ({ className, ...props }) => {
         styles.tabPanel,
         {
           [styles.contained]: variant === 'contained',
+          [styles.medium]: size === 'medium',
         },
         className,
       )}

--- a/packages/components/src/tabs/Tabs.module.css
+++ b/packages/components/src/tabs/Tabs.module.css
@@ -18,7 +18,7 @@
 }
 
 .tab {
-  padding: var(--midas-space-small) var(--midas-space-medium);
+  padding: var(--midas-space-70) var(--midas-space-medium);
   cursor: default;
   outline: none;
   position: relative;
@@ -70,6 +70,10 @@
     &:not([data-selected]) + &.contained:not([data-selected]) {
       border-color: var(--midas-border-color-subtle);
     }
+  }
+
+  &.medium {
+    padding: var(--midas-space-50) var(--midas-space-small);
   }
 }
 
@@ -137,5 +141,9 @@
 
   &.contained {
     background-color: var(--midas-layer-01-base);
+  }
+
+  &.medium {
+    padding: var(--midas-space-small);
   }
 }

--- a/packages/components/src/tabs/Tabs.stories.tsx
+++ b/packages/components/src/tabs/Tabs.stories.tsx
@@ -38,9 +38,13 @@ export default {
   component: Tabs,
   title: 'Components/Tabs',
   tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'radio', options: ['large', 'medium'] },
+  },
   args: {
     orientation: 'horizontal',
     variant: 'uncontained',
+    size: 'large',
   },
   render: args => (
     <Tabs {...args}>
@@ -68,6 +72,10 @@ export default {
 } satisfies Meta<typeof Tabs>
 
 export const Primary: Story = {}
+
+export const Medium: Story = {
+  args: { size: 'medium' },
+}
 
 export const Contained: Story = {
   args: {

--- a/packages/components/src/tabs/Tabs.tsx
+++ b/packages/components/src/tabs/Tabs.tsx
@@ -8,18 +8,22 @@ import {
 import clsx from '../utils/clsx'
 import { TabsContext } from './TabsContext'
 import styles from './Tabs.module.css'
+import { type Size } from '../common/types'
 
 export interface TabsProps extends AriaTabsProps {
   variant?: 'uncontained' | 'contained'
+  /** @default 'large' */
+  size?: Size
 }
 
 export const Tabs: React.FC<TabsProps> = ({
   className,
   variant = 'uncontained',
+  size = 'large',
   ...rest
 }) => {
   return (
-    <TabsContext.Provider value={{ variant }}>
+    <TabsContext.Provider value={{ variant, size }}>
       <AriaTabs
         className={clsx(styles.tabs, className)}
         {...rest}

--- a/packages/components/src/tabs/TabsContext.ts
+++ b/packages/components/src/tabs/TabsContext.ts
@@ -1,8 +1,9 @@
 import { createContext } from 'react'
 import { type TabsProps } from './Tabs'
 
-export type TabsContextValue = Pick<TabsProps, 'variant'>
+export type TabsContextValue = Pick<TabsProps, 'variant' | 'size'>
 
 export const TabsContext = createContext<TabsContextValue>({
   variant: 'uncontained',
+  size: 'large',
 })


### PR DESCRIPTION
## Summary

- Adds `size` prop (`'large' | 'medium'`, default `'large'`) to `Tabs`
- Large: 48px tab height (14px vertical padding via `space-70`)
- Medium: 40px tab height (10px vertical padding via `space-50`), 8px inline padding
- `size` is passed via context so `Tab` and `TabPanel` pick it up automatically
- Adds `Medium` story and radio control in Storybook

## Test plan

- [ ] `npx nx build components` passes with no TS errors
- [ ] `npx nx test components` — all 156 tests pass
- [ ] Storybook: `Medium` story shows compact tabs, existing stories unchanged