### PR TITLE
feat(components, button): add inactive state

### DIFF
--- a/apps/docs/docs/components/button.mdx
+++ b/apps/docs/docs/components/button.mdx
@@ -8,6 +8,7 @@ import { Button, ButtonGroup } from '@midas-ds/components'
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 import { Plus } from 'lucide-react'
 import { ButtonContext } from 'react-aria-components'
+import { InactiveExample } from '@site/src/components/examples/button/ButtonExamples'
 
 <ComponentHeader
   name='Button'
@@ -137,6 +138,19 @@ För att visa att systemet laddas kan `isPending` användas, läs mer under [mö
 >
   <Button isPending>Laddar...</Button>
 </div>
+
+### isInactive
+
+För att visa en ej klickbar knapp kan `isInactive` användas. Använd då en tooltip för att förklara vad användaren behöver uppnå för att få knappen att fungera.
+
+```tsx
+<TooltipTrigger shouldCloseOnPress={false}>
+  <Button isInactive>Lägg beställning</Button>
+  <Tooltip>Knappen är inte tillgänglig pga xyz</Tooltip>
+</TooltipTrigger>
+```
+
+<InactiveExample />
 
 ## Grupp av knappar
 

--- a/apps/docs/src/components/examples/button/ButtonExamples.tsx
+++ b/apps/docs/src/components/examples/button/ButtonExamples.tsx
@@ -1,0 +1,12 @@
+import { Button, Tooltip, TooltipTrigger } from '@midas-ds/components'
+
+export const InactiveExample = () => {
+  return (
+    <div className='card'>
+      <TooltipTrigger shouldCloseOnPress={false}>
+        <Button isInactive>Lägg beställning</Button>
+        <Tooltip>Knappen är inte tillgänglig pga xyz</Tooltip>
+      </TooltipTrigger>
+    </div>
+  )
+}

--- a/docs/adr/0004-inactive-button-prop.md
+++ b/docs/adr/0004-inactive-button-prop.md
@@ -1,0 +1,32 @@
+# 0003. Inactive Button Prop
+
+**Date:** 2026-03-10
+**Status:** Accepted
+
+## Context
+
+Sometimes we want to avoid using disabled buttons. Disabled buttons cannot be reached by system focus nor do they provide an explanation of their disabled state.
+We need an "inactive" `Button` that can recieve focus and be explained by a `Tooltip` component.
+
+## Decision
+
+We decided implement a pseudo disabled state to our `Button` with a prop called `isInactive`. This prop adds `aria-disabled="true"`, blocks the onPress handler and removes the hover and press styles.
+The `TooltipTrigger` and `Tooltip` are provided by the app rather than us bloating our standard `Button` with the two components.
+How to implement the inactive button pattern will be documented with code examples.
+
+## Consequences
+
+**Positive:**
+
+- No extra component export
+- Our original `Button` component is left unbloated
+- We offer full control of the `Tooltip` component via composition
+
+**Negative:**
+
+- More code for developers to write
+- Risk for code duplication in several apps
+
+**Future Considerations:**
+
+- If this pattern is widely adopted we can consider exporting an `InactiveButton` compoenent that extends `ButtonProps`, `TooltipTriggerProps` and `TooltipProps`.

--- a/packages/components/src/button/Button.module.css
+++ b/packages/components/src/button/Button.module.css
@@ -29,11 +29,15 @@
     }
   }
 
-  &[data-hovered] {
+  &[data-hovered]:not([data-inactive]) {
     background-color: var(--midas-button-background-primary-hover);
   }
 
-  &[data-pressed]:not([aria-expanded='true'], [aria-haspopup='true']) {
+  &[data-pressed]:not(
+      [aria-expanded='true'],
+      [aria-haspopup='true'],
+      [data-inactive]
+    ) {
     background-color: var(--midas-button-background-primary-active);
     outline: none;
   }
@@ -43,6 +47,10 @@
     cursor: not-allowed;
     background-color: var(--midas-button-background-disabled);
   }
+
+  &[data-inactive] {
+    cursor: not-allowed;
+  }
 }
 
 .secondary {
@@ -51,7 +59,7 @@
   border-color: var(--midas-button-border-secondary);
   opacity: 1;
 
-  &[data-hovered] {
+  &[data-hovered]:not([data-inactive]) {
     background-color: var(--midas-button-background-secondary-hover);
   }
 
@@ -62,7 +70,11 @@
     border-color: var(--midas-border-color-disabled);
   }
 
-  &[data-pressed]:not([aria-expanded='true'], [aria-haspopup='true']) {
+  &[data-pressed]:not(
+      [aria-expanded='true'],
+      [aria-haspopup='true'],
+      [data-inactive]
+    ) {
     background-color: var(--midas-button-background-secondary-active);
     border-color: var(--midas-text-tertiary);
   }
@@ -73,7 +85,7 @@
   background-color: transparent;
   opacity: 1;
 
-  &[data-hovered] {
+  &[data-hovered]:not([data-inactive]) {
     background-color: var(--midas-button-background-tertiary-hover);
   }
 
@@ -83,7 +95,11 @@
     background-color: transparent;
   }
 
-  &[data-pressed]:not([aria-expanded='true'], [aria-haspopup='true']) {
+  &[data-pressed]:not(
+      [aria-expanded='true'],
+      [aria-haspopup='true'],
+      [data-inactive]
+    ) {
     background-color: var(--midas-button-background-tertiary-active);
   }
 }
@@ -95,7 +111,7 @@
   display: flex;
   align-items: center;
 
-  &[data-hovered] {
+  &[data-hovered]:not([data-inactive]) {
     background-color: var(--midas-button-icon-hover);
   }
 
@@ -104,7 +120,11 @@
     cursor: not-allowed;
   }
 
-  &[data-pressed]:not([aria-expanded='true'], [aria-haspopup='true']) {
+  &[data-pressed]:not(
+      [aria-expanded='true'],
+      [aria-haspopup='true'],
+      [data-inactive]
+    ) {
     background-color: var(--midas-button-icon-active);
   }
 
@@ -118,7 +138,7 @@
   background-color: var(--midas-button-background-danger-base);
   opacity: 1;
 
-  &[data-hovered] {
+  &[data-hovered]:not([data-inactive]) {
     color: var(--midas-color-white-base);
     background-color: var(--midas-button-background-danger-hover);
   }
@@ -129,7 +149,11 @@
     background-color: var(--midas-button-background-disabled);
   }
 
-  &[data-pressed]:not([aria-expanded='true'], [aria-haspopup='true']) {
+  &[data-pressed]:not(
+      [aria-expanded='true'],
+      [aria-haspopup='true'],
+      [data-inactive]
+    ) {
     background-color: var(--midas-button-background-danger-active);
     outline: none;
   }

--- a/packages/components/src/button/Button.spec.tsx
+++ b/packages/components/src/button/Button.spec.tsx
@@ -7,6 +7,10 @@ import { page, userEvent } from 'vitest/browser'
 const { Primary, Secondary, Inactive } = composeStories(stories)
 
 const handlePress = vi.fn()
+const handlePressChange = vi.fn()
+const handlePressEnd = vi.fn()
+const handlePressStart = vi.fn()
+const handlePressUp = vi.fn()
 
 describe('given a basic Button', async () => {
   it('should have focus when clicked', async () => {
@@ -37,7 +41,15 @@ describe('given a disabled secondary Button', async () => {
 
 describe('given an inactive Button', async () => {
   beforeEach(async () => {
-    await render(<Inactive onPress={handlePress} />)
+    await render(
+      <Inactive
+        onPress={handlePress}
+        onPressChange={handlePressChange}
+        onPressEnd={handlePressEnd}
+        onPressStart={handlePressStart}
+        onPressUp={handlePressUp}
+      />,
+    )
   })
 
   afterEach(() => {
@@ -49,9 +61,14 @@ describe('given an inactive Button', async () => {
     await expect.element(page.getByRole('tooltip')).toBeVisible()
   })
 
-  it('should not fire the onPress event', async () => {
+  it('should not fire any onPress event', async () => {
     await userEvent.tab()
     await userEvent.keyboard('[Enter]')
+
     expect(handlePress).toHaveBeenCalledTimes(0)
+    expect(handlePressChange).toHaveBeenCalledTimes(0)
+    expect(handlePressEnd).toHaveBeenCalledTimes(0)
+    expect(handlePressStart).toHaveBeenCalledTimes(0)
+    expect(handlePressUp).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/components/src/button/Button.spec.tsx
+++ b/packages/components/src/button/Button.spec.tsx
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { composeStories } from '@storybook/react-vite'
 import * as stories from './Button.stories'
 import { render } from '../../test-utils'
+import { page, userEvent } from 'vitest/browser'
 
-const { Primary, Secondary } = composeStories(stories)
+const { Primary, Secondary, Inactive } = composeStories(stories)
+
+const handlePress = vi.fn()
 
 describe('given a basic Button', async () => {
   it('should have focus when clicked', async () => {
@@ -29,5 +32,26 @@ describe('given a disabled secondary Button', async () => {
     const { getByRole } = await render(<Secondary isDisabled />)
 
     await expect.element(getByRole('button')).toBeDisabled()
+  })
+})
+
+describe('given an inactive Button', async () => {
+  beforeEach(async () => {
+    await render(<Inactive onPress={handlePress} />)
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should show a tooltip on hover', async () => {
+    await page.getByRole('button').hover()
+    await expect.element(page.getByRole('tooltip')).toBeVisible()
+  })
+
+  it('should not fire the onPress event', async () => {
+    await userEvent.tab()
+    await userEvent.keyboard('[Enter]')
+    expect(handlePress).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -93,7 +93,7 @@ export const Inactive: Story = {
     isInactive: true,
   },
   render: args => (
-    <TooltipTrigger>
+    <TooltipTrigger shouldCloseOnPress={false}>
       <Button {...args} />
       <Tooltip>Det saknas ett beslut</Tooltip>
     </TooltipTrigger>

--- a/packages/components/src/button/Button.stories.tsx
+++ b/packages/components/src/button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Plus, X } from 'lucide-react'
 import { Button } from './Button'
+import { Tooltip, TooltipTrigger } from '../tooltip'
 
 const meta: Meta<typeof Button> = {
   component: Button,
@@ -81,4 +82,20 @@ export const Danger: Story = {
     children: 'Button',
     variant: 'danger',
   },
+}
+
+export const Inactive: Story = {
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Lägg till',
+    isInactive: true,
+  },
+  render: args => (
+    <TooltipTrigger>
+      <Button {...args} />
+      <Tooltip>Det saknas ett beslut</Tooltip>
+    </TooltipTrigger>
+  ),
 }

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -50,6 +50,11 @@ export interface ButtonProps extends AriaButtonProps {
   iconSize?: number
   /** Display the icon on the left or right side of the button text */
   iconPlacement?: 'left' | 'right'
+  /**
+   * A pseudo-disabled state that enable focus but disables the `onPress` event.
+   * If combined with `isDisabled`, `isDisabled` takes precedence.
+   */
+  isInactive?: boolean
 }
 
 /**
@@ -67,10 +72,19 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconPlacement,
       iconSize,
       isPending,
+      onPress,
       size = 'large',
       variant = 'primary',
       ...rest
     } = mergedProps
+
+    const isInactive = !mergedProps.isDisabled && mergedProps.isInactive
+
+    const handlePress = (event: PressEvent) => {
+      if (!isInactive) {
+        onPress?.(event)
+      }
+    }
 
     return (
       <AriaButton
@@ -86,7 +100,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           iconPlacement === 'right' && styles.iconRight,
           className,
         )}
+        data-inactive={isInactive || undefined}
+        aria-disabled={isInactive}
         ref={mergedRef}
+        onPress={handlePress}
         {...rest}
       >
         {composeRenderProps(mergedProps.children, children => (

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -72,19 +72,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconPlacement,
       iconSize,
       isPending,
-      onPress,
       size = 'large',
       variant = 'primary',
       ...rest
     } = mergedProps
 
     const isInactive = !mergedProps.isDisabled && mergedProps.isInactive
-
-    const handlePress = (event: PressEvent) => {
-      if (!isInactive) {
-        onPress?.(event)
-      }
-    }
 
     return (
       <AriaButton
@@ -103,8 +96,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         data-inactive={isInactive || undefined}
         aria-disabled={isInactive}
         ref={mergedRef}
-        onPress={handlePress}
         {...rest}
+        onPress={e => !isInactive && props.onPress?.(e)}
+        onPressChange={e => !isInactive && props.onPressChange?.(e)}
+        onPressEnd={e => !isInactive && props.onPressEnd?.(e)}
+        onPressStart={e => !isInactive && props.onPressStart?.(e)}
+        onPressUp={e => !isInactive && props.onPressUp?.(e)}
       >
         {composeRenderProps(mergedProps.children, children => (
           <>


### PR DESCRIPTION
## Description

Disabled buttons cannot be focused

## Changes

- create an example of how to implement inactive buttons

## Additional Information

Ett alternativ skulle kunna vara att lyfta ut tooltip till apparna, för ökad kontroll. Just nu kan ju inga inställningar på `TooltipTrigger` eller `Tooltip` göras. 

Alternativ två är att ta emot props enligt `tooltipTriggerProps`, `tooltipProps` om man vill justera något. 

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
