### PR TITLE
fix(theme,tailwind): exclude deprecated and numeric spacing tokens from @theme

### DIFF
--- a/tools/style-dictionary/src/executors/formats/tailwindTheme.spec.ts
+++ b/tools/style-dictionary/src/executors/formats/tailwindTheme.spec.ts
@@ -1,0 +1,78 @@
+import { TransformedToken } from 'style-dictionary'
+import { describe, expect, it } from 'vitest'
+import { tailwindTheme } from './tailwindTheme'
+
+const makeToken = (name: string, value: string, description?: string): TransformedToken => ({
+  name,
+  value,
+  $value: value,
+  original: { $value: value, $description: description },
+  $description: description,
+  path: name.split('-'),
+  filePath: 'tokens/test.json',
+  isSource: true,
+})
+
+const runFormat = async (tokens: TransformedToken[]) => {
+  const result = await tailwindTheme.format({
+    dictionary: {
+      allTokens: tokens,
+      tokens: {},
+      tokenMap: new Map(),
+    },
+    file: {},
+    options: { outputReferences: false },
+    platform: {},
+  } as any)
+  return result
+}
+
+describe('tailwindTheme format', () => {
+  it('includes regular tokens', async () => {
+    const output = await runFormat([
+      makeToken('color-blue-100', '#0055cc'),
+      makeToken('space-medium', '1rem'),
+    ])
+    expect(output).toContain('--color-blue-100: #0055cc')
+    expect(output).toContain('--space-medium: 1rem')
+  })
+
+  it('excludes deprecated tokens', async () => {
+    const output = await runFormat([
+      makeToken('color-blue-100', '#0055cc'),
+      makeToken('spacing-small', '0.5rem', '@deprecated Use space.small instead'),
+    ])
+    expect(output).toContain('--color-blue-100')
+    expect(output).not.toContain('--spacing-small')
+  })
+
+  it('excludes numeric spacing tokens that conflict with Tailwind scale', async () => {
+    const output = await runFormat([
+      makeToken('color-blue-100', '#0055cc'),
+      makeToken('spacing-30', '0.5rem'),
+      makeToken('spacing-90', '2rem'),
+    ])
+    expect(output).not.toContain('--spacing-30')
+    expect(output).not.toContain('--spacing-90')
+  })
+
+  it('keeps named spacing tokens', async () => {
+    const output = await runFormat([
+      makeToken('spacing-xsmall', '0.25rem'),
+      makeToken('spacing-small', '0.5rem'),
+      makeToken('spacing-medium', '1rem'),
+      makeToken('spacing-large', '1.5rem'),
+      makeToken('spacing-xlarge', '2rem'),
+    ])
+    expect(output).toContain('--spacing-xsmall')
+    expect(output).toContain('--spacing-small')
+    expect(output).toContain('--spacing-medium')
+    expect(output).toContain('--spacing-large')
+    expect(output).toContain('--spacing-xlarge')
+  })
+
+  it('wraps output in @theme block', async () => {
+    const output = await runFormat([makeToken('color-blue-100', '#0055cc')])
+    expect(output).toMatch(/@theme \{[\s\S]+\}/)
+  })
+})

--- a/tools/style-dictionary/src/executors/formats/tailwindTheme.ts
+++ b/tools/style-dictionary/src/executors/formats/tailwindTheme.ts
@@ -18,8 +18,20 @@ export const tailwindTheme: Format = {
     const { outputReferences } = options
     const header = await fileHeader({ file })
 
-    // Generate @theme block with all tokens using their original names
+    // Generate @theme block with all tokens using their original names.
+    // Excluded:
+    // - Deprecated tokens: still available as CSS vars in variables.css but shouldn't
+    //   get Tailwind utilities since they're on their way out.
+    // - Numeric spacing tokens (e.g. spacing-10, spacing-30): in Tailwind v4,
+    //   --spacing-{n} in @theme overrides the generated spacing scale, so w-30 would
+    //   resolve to our value (~0.5rem) instead of calc(0.25rem * 30) = 7.5rem.
+    //   Named spacing tokens (spacing-small, spacing-xsmall, etc.) are safe to keep.
+    const isDeprecated = (token: (typeof dictionary.allTokens)[number]) =>
+      token.$description?.startsWith('@deprecated')
+    const isTailwindSpacingConflict = (name: string) => /^spacing-\d+$/.test(name)
+
     const themeVariables = dictionary.allTokens
+      .filter((token) => !isDeprecated(token) && !isTailwindSpacingConflict(token.name))
       .map((token) => {
         const name = token.name
         const value = outputReferences && token.original.$value


### PR DESCRIPTION
## Description

Numeric `--spacing-{n}` and deprecated tokens in `@theme` were overriding Tailwind v4's spacing scale, causing e.g. `w-30` to resolve to `0.5rem` instead of `7.5rem`.

## Changes

- Filter deprecated tokens and numeric spacing tokens from `@theme` output in the Style Dictionary tailwind format
- Add tests to prevent regression

## Additional Information

CSS vars still available in `variables.css` for arbitrary value usage.

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages