### PR TITLE
fix(layout): match API for NavigationLink and HeaderAction

### DIFF
--- a/apps/next/components/Navigation/Navigation.tsx
+++ b/apps/next/components/Navigation/Navigation.tsx
@@ -142,9 +142,9 @@ export const SidebarNavigation = () => (
               <NavLink
                 aria-label={resolvedAriaLabel}
                 href={href}
-                title={title}
+                icon={resolvedIcon}
               >
-                {resolvedIcon}
+                {title}
               </NavLink>
               <NavigationSubMenu items={children}>
                 {renderItem}
@@ -165,25 +165,25 @@ export const BottomNavigation = () => {
       <NavigationItem>
         <NavLink
           href='/'
-          title='Home'
+          icon={<House />}
         >
-          <House />
+          Home
         </NavLink>
       </NavigationItem>
       <NavigationItem>
         <NavLink
           href='/applications'
-          title='Applications'
+          icon={<FileText />}
         >
-          <FileText />
+          Applications
         </NavLink>
       </NavigationItem>
       <NavigationItem>
         <NavLink
           href='/profile'
-          title='Profile'
+          icon={<User />}
         >
-          <User />
+          Profile
         </NavLink>
       </NavigationItem>
       <NavigationItem>
@@ -194,12 +194,12 @@ export const BottomNavigation = () => {
               : 'Notifications'
           }
           href='/notifications'
-          title='Notifications'
-        >
-          <BadgeContainer aria-hidden>
+          icon={<BadgeContainer aria-hidden>
             <Bell />
             {unreadCount > 0 && <Badge>{unreadCount}</Badge>}
-          </BadgeContainer>
+          </BadgeContainer>}
+        >
+          Notifications
         </NavLink>
       </NavigationItem>
     </MidasNavigation>

--- a/examples/vite-react-router/src/components/Navigation.tsx
+++ b/examples/vite-react-router/src/components/Navigation.tsx
@@ -7,17 +7,17 @@ export const Navigation = () => (
     <NavigationItem>
       <NavigationLink
         to='/'
-        title='Home'
+        icon={<House />}
       >
-        <House />
+        Home
       </NavigationLink>
     </NavigationItem>
     <NavigationItem>
       <NavigationLink
         to='/applications'
-        title='Applications'
+        icon={<FileText />}
       >
-        <FileText />
+        Applications
       </NavigationLink>
     </NavigationItem>
   </MidasNavigation>

--- a/packages/layout/src/layout/Layout.stories.tsx
+++ b/packages/layout/src/layout/Layout.stories.tsx
@@ -69,17 +69,15 @@ export const Primary: Story = {
             <NavigationLink
               href='/'
               isActive
-              variant='navbar'
-              title='Hem'
+              icon={<House />}
             >
-              <House />
+              Hem
             </NavigationLink>
             <NavigationLink
               href='/categories'
-              variant='navbar'
-              title='Kategorier'
+              icon={<List />}
             >
-              <List />
+              Kategorier
             </NavigationLink>
           </ul>
         </Navbar>

--- a/packages/layout/src/navigation/Navigation.stories.tsx
+++ b/packages/layout/src/navigation/Navigation.stories.tsx
@@ -31,36 +31,36 @@ export const Primary: Story = {
       <>
         <NavigationLink
           href='/'
-          title='Hem'
+          icon={<House />}
           isActive
         >
-          <House />
+          Hem
         </NavigationLink>
         <NavigationSubMenu>
           <NavigationLink
             href='/ansokningar'
-            title='Ansökningar'
+            icon={<FileText />}
           >
-            <FileText />
+            Ansökningar
           </NavigationLink>
           <NavigationSubMenu>
             <NavigationLink
               href='/ansokningar/ny-ansokning'
-              title='Skapa ny ansökning'
+              icon={<Plus />}
             >
-              <Plus />
+              Skapa ny ansökning
             </NavigationLink>
             <NavigationLink
               href='/ansokningar/utkast'
-              title='Sparade utkast'
+              icon={<Save />}
             >
-              <Save />
+              Sparade utkast
             </NavigationLink>
             <NavigationLink
               href='/ansokningar/skickade'
-              title='Skickade ansökningar'
+              icon={<Send />}
             >
-              <Send />
+              Skickade ansökningar
             </NavigationLink>
           </NavigationSubMenu>
         </NavigationSubMenu>
@@ -68,22 +68,22 @@ export const Primary: Story = {
         <NavigationSubMenu>
           <NavigationLink
             href='/dokument/id-handling'
-            title='ID-handlingar'
+            icon={<IdCard />}
           >
-            <IdCard />
+            ID-handlingar
           </NavigationLink>
           <NavigationSubMenu>
             <NavigationLink
               href='/dokument/uppehallstillstand/arbetstillstand'
-              title='Arbetstillstånd'
+              icon={<Briefcase />}
             >
-              <Briefcase />
+              Arbetstillstånd
             </NavigationLink>
             <NavigationLink
               href='/dokument/uppehallstillstand/studiestillstand'
-              title='Studiestillstånd'
+              icon={<BookOpen />}
             >
-              <BookOpen />
+              Studiestillstånd
             </NavigationLink>
           </NavigationSubMenu>
         </NavigationSubMenu>
@@ -91,38 +91,40 @@ export const Primary: Story = {
         <NavigationSubMenu>
           <NavigationLink
             href='/konto/profil'
-            title='Min profil'
+            icon={<User />}
           >
-            <User />
+            Min profil
           </NavigationLink>
           <NavigationLink
             href='/konto/kontaktuppgifter'
-            title='Kontaktuppgifter'
+            icon={<Phone />}
           >
-            <Phone />
+            Kontaktuppgifter
           </NavigationLink>
           <NavigationLink
             href='/konto/meddelanden'
-            title='Meddelanden'
+            icon={
+              <BadgeContainer>
+                <Bell />
+                <Badge>3</Badge>
+              </BadgeContainer>
+            }
             aria-label='3 olästa meddelanden'
           >
-            <BadgeContainer>
-              <Bell />
-              <Badge>3</Badge>
-            </BadgeContainer>
+            Meddelanden
           </NavigationLink>
         </NavigationSubMenu>
         <NavigationLink
           href='/hjalp'
-          title='Hjälp och support'
+          icon={<HelpCircle />}
         >
-          <HelpCircle />
+          Hjälp och support
         </NavigationLink>
         <NavigationLink
           href='/kontakt'
-          title='Kontakta oss'
+          icon={<Mail />}
         >
-          <Mail />
+          Kontakta oss
         </NavigationLink>
       </>
     ),

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.stories.tsx
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.stories.tsx
@@ -10,9 +10,9 @@ export default {
   title: 'Components/Layout/Navigation/NavigationLink',
   tags: ['autodocs'],
   args: {
-    title: 'Hem',
+    children: 'Hem',
     href: '/',
-    children: <House />,
+    icon: <House />,
   },
   parameters: {
     layout: 'centered',

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.tsx
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.tsx
@@ -17,10 +17,10 @@ import { MobileMenuContext } from '../../header'
 import { SidebarContext } from '../../sidebar'
 
 export interface NavigationLinkComponentProps<C extends ElementType> {
-  /** The icon to display. */
-  children: ReactNode
   /** The visible label text and tooltip content. */
-  title: string
+  children?: ReactNode
+  /** The icon to display. */
+  icon: ReactNode
   isActive?: boolean
   variant?: 'sidebar' | 'navbar'
   className?: string
@@ -39,7 +39,7 @@ export const NavigationLink = <C extends ElementType = typeof Link>({
   children,
   className,
   isActive,
-  title,
+  icon,
   'aria-label': ariaLabel,
   ...rest
 }: NavigationLinkProps<C>) => {
@@ -57,8 +57,16 @@ export const NavigationLink = <C extends ElementType = typeof Link>({
     }
   }
 
+  const title = typeof children === 'string' ? children : undefined
+
+  if (!title && !ariaLabel && process.env.NODE_ENV !== 'production') {
+    console.warn(
+      "An 'aria-label' is required for <NavigationLink> elements with non plain text children",
+    )
+  }
+
   return (
-    <TooltipTrigger isDisabled={!isCollapsed}>
+    <TooltipTrigger isDisabled={!isCollapsed || (!title && !ariaLabel)}>
       <Focusable>
         <Component
           aria-current={isActive && 'page'}
@@ -83,8 +91,8 @@ export const NavigationLink = <C extends ElementType = typeof Link>({
               })}
           {...rest}
         >
-          {children}
-          <span className={styles.title}>{title}</span>
+          {icon}
+          <span className={styles.title}>{children}</span>
         </Component>
       </Focusable>
       <Tooltip placement='right'>{title}</Tooltip>


### PR DESCRIPTION
## Description

`NavigationLink` and `HeaderAction` are very similar but treat `icon` and `children` props different

## Changes

Align `NavigationLink` API with `HeaderAction`

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
