### PR TITLE
fix(layout, mobile-menu): add controlled state support

### DIFF
--- a/apps/docs/docs/dev/layout/components/header.mdx
+++ b/apps/docs/docs/dev/layout/components/header.mdx
@@ -89,7 +89,9 @@ function AppHeader() {
 
 ### MobileMenu
 
-| Prop       | Typ         | Beskrivning  |
-| ---------- | ----------- | ------------ |
-| `title`    | `string`    | Rubrik i menyn |
-| `children` | `ReactNode` | Menyinnehåll |
+| Prop           | Typ                         | Beskrivning                    |
+| -------------- | --------------------------- | ------------------------------ |
+| `title`        | `string`                    | Rubrik i menyn                 |
+| `isOpen`       | `boolean`                   | Kontrollerat öppet-läge        |
+| `onOpenChange` | `(isOpen: boolean) => void` | Callback vid öppning/stängning |
+| `children`     | `ReactNode`                 | Menyinnehåll                   |

--- a/apps/docs/docs/dev/layout/components/header.mdx
+++ b/apps/docs/docs/dev/layout/components/header.mdx
@@ -92,6 +92,7 @@ function AppHeader() {
 | Prop           | Typ                         | Beskrivning                    |
 | -------------- | --------------------------- | ------------------------------ |
 | `title`        | `string`                    | Rubrik i menyn                 |
+| `defaultOpen`  | `boolean`                   | Okontrollerat starttillstånd   |
 | `isOpen`       | `boolean`                   | Kontrollerat öppet-läge        |
 | `onOpenChange` | `(isOpen: boolean) => void` | Callback vid öppning/stängning |
 | `children`     | `ReactNode`                 | Menyinnehåll                   |

--- a/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { userEvent } from 'vitest/browser'
+import { MobileMenu } from './MobileMenu'
+import { useState } from 'react'
+
+describe('given an uncontrolled MobileMenu', async () => {
+  it('should be possible to open and close', async () => {
+    const { getByRole } = await render(<MobileMenu />)
+    await getByRole('button', { name: 'Open menu' }).click()
+    const dismissButton = getByRole('button', { name: 'Dismiss' })
+    await expect.element(dismissButton).toBeVisible()
+    await userEvent.keyboard('[Escape]')
+    await expect.element(dismissButton).not.toBeInTheDocument()
+  })
+})
+
+const ControlledMobileMenu = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <MobileMenu
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+    />
+  )
+}
+
+describe('given a controlled MobileMenu', async () => {
+  it('should be possible to open and close', async () => {
+    const { getByRole } = await render(<ControlledMobileMenu />)
+    await getByRole('button', { name: 'Open menu' }).click()
+    const dismissButton = getByRole('button', { name: 'Dismiss' })
+    await expect.element(dismissButton).toBeVisible()
+    await userEvent.keyboard('[Escape]')
+    await expect.element(dismissButton).not.toBeInTheDocument()
+  })
+})

--- a/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { userEvent } from 'vitest/browser'
-import { MobileMenu } from './MobileMenu'
-import { useState } from 'react'
+import { composeStories } from '@storybook/react-vite'
+import * as stories from './MobileMenu.stories'
+
+const { Primary, Controlled } = composeStories(stories)
 
 describe('given an uncontrolled MobileMenu', async () => {
   it('should be possible to open and close', async () => {
-    const { getByRole } = await render(<MobileMenu />)
+    const { getByRole } = await render(<Primary />)
     await getByRole('button', { name: 'Open menu' }).click()
     const dismissButton = getByRole('button', { name: 'Dismiss' })
     await expect.element(dismissButton).toBeVisible()
@@ -15,20 +17,9 @@ describe('given an uncontrolled MobileMenu', async () => {
   })
 })
 
-const ControlledMobileMenu = () => {
-  const [isOpen, setIsOpen] = useState(false)
-
-  return (
-    <MobileMenu
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-    />
-  )
-}
-
 describe('given a controlled MobileMenu', async () => {
   it('should be possible to open and close', async () => {
-    const { getByRole } = await render(<ControlledMobileMenu />)
+    const { getByRole } = await render(<Controlled />)
     await getByRole('button', { name: 'Open menu' }).click()
     const dismissButton = getByRole('button', { name: 'Dismiss' })
     await expect.element(dismissButton).toBeVisible()

--- a/packages/layout/src/header/mobile-menu/MobileMenu.stories.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.stories.tsx
@@ -1,0 +1,33 @@
+import { composeStories, type Meta, type StoryObj } from '@storybook/react-vite'
+import * as navigationStories from '../../navigation/Navigation.stories'
+import { MobileMenu } from '.'
+import { useState } from 'react'
+
+type Story = StoryObj<typeof MobileMenu>
+
+const { Primary: PrimaryNavigation } = composeStories(navigationStories)
+
+export default {
+  component: MobileMenu,
+  title: 'Components/Layout/MobileMenu',
+  tags: ['autodocs'],
+  args: {
+    children: <PrimaryNavigation />,
+  },
+} satisfies Meta<typeof MobileMenu>
+
+export const Primary: Story = {}
+
+export const Controlled: Story = {
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+      <MobileMenu
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        {...args}
+      />
+    )
+  },
+}

--- a/packages/layout/src/header/mobile-menu/MobileMenu.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.tsx
@@ -8,9 +8,16 @@ import {
   ModalOverlay,
   ModalOverlayProps,
 } from 'react-aria-components'
-import { Button, clsx, DialogTrigger, Text } from '@midas-ds/components'
+import {
+  Button,
+  clsx,
+  DialogTrigger,
+  Text,
+  useLocalizedStringFormatter,
+} from '@midas-ds/components'
 import { useIsMobileDevice } from '../../utils'
 import { MobileMenuContext } from './MobileMenuContext'
+import messages from './intl/translations.json'
 import styles from './MobileMenu.module.css'
 
 export interface MobileMenuProps extends ModalOverlayProps {
@@ -23,21 +30,34 @@ export interface MobileMenuProps extends ModalOverlayProps {
 export const MobileMenu = ({
   children,
   className,
+  isOpen,
+  onOpenChange,
   title,
   ...rest
 }: MobileMenuProps) => {
   const isMobile = useIsMobileDevice()
+  const strings = useLocalizedStringFormatter(messages)
+
+  const handlePress = () => {
+    if (typeof onOpenChange === 'function' && typeof isOpen === 'boolean') {
+      onOpenChange(!isOpen)
+    }
+  }
 
   return isMobile ? (
     <MobileMenuContext.Provider value={{}}>
       <DialogTrigger>
         <Button
+          aria-label={strings.format('openMenu')}
           icon={Menu}
+          onPress={handlePress}
           variant='icon'
         />
         <ModalOverlay
           className={clsx(className, styles.overlay)}
           isDismissable
+          isOpen={isOpen}
+          onOpenChange={onOpenChange}
           {...rest}
         >
           {composeRenderProps(children, children => (

--- a/packages/layout/src/header/mobile-menu/MobileMenu.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { Menu } from 'lucide-react'
 import {
   composeRenderProps,
   Dialog,
+  DialogTriggerProps,
   Modal,
   ModalOverlay,
   ModalOverlayProps,
@@ -20,7 +21,12 @@ import { MobileMenuContext } from './MobileMenuContext'
 import messages from './intl/translations.json'
 import styles from './MobileMenu.module.css'
 
-export interface MobileMenuProps extends ModalOverlayProps {
+type StateValues = 'isOpen' | 'defaultOpen' | 'onOpenChange'
+
+export interface MobileMenuProps
+  extends
+    Omit<ModalOverlayProps, StateValues>,
+    Pick<DialogTriggerProps, StateValues> {
   /**
    * A visible title for the menu
    */
@@ -30,6 +36,7 @@ export interface MobileMenuProps extends ModalOverlayProps {
 export const MobileMenu = ({
   children,
   className,
+  defaultOpen,
   isOpen,
   onOpenChange,
   title,
@@ -38,26 +45,21 @@ export const MobileMenu = ({
   const isMobile = useIsMobileDevice()
   const strings = useLocalizedStringFormatter(messages)
 
-  const handlePress = () => {
-    if (typeof onOpenChange === 'function' && typeof isOpen === 'boolean') {
-      onOpenChange(!isOpen)
-    }
-  }
-
   return isMobile ? (
     <MobileMenuContext.Provider value={{}}>
-      <DialogTrigger>
+      <DialogTrigger
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        defaultOpen={defaultOpen}
+      >
         <Button
           aria-label={strings.format('openMenu')}
           icon={Menu}
-          onPress={handlePress}
           variant='icon'
         />
         <ModalOverlay
           className={clsx(className, styles.overlay)}
           isDismissable
-          isOpen={isOpen}
-          onOpenChange={onOpenChange}
           {...rest}
         >
           {composeRenderProps(children, children => (

--- a/packages/layout/src/header/mobile-menu/intl/translations.json
+++ b/packages/layout/src/header/mobile-menu/intl/translations.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "openMenu": "Open menu"
+  },
+  "sv": {
+    "openMenu": "Öppna meny"
+  }
+}


### PR DESCRIPTION
## Description

It's impossible to open the `MobileMenu` using the built in button in a controlled state

## Changes

Add a press handler to the built in menu button in `MobileMenu`

## Checklist

- [x] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
