### PR TITLE
test(layout): migrate legacy tests

### DIFF
--- a/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import { render } from 'vitest-browser-react'
 import { userEvent } from 'vitest/browser'
 import { composeStories } from '@storybook/react-vite'
@@ -6,24 +6,33 @@ import * as stories from './MobileMenu.stories'
 
 const { Primary, Controlled } = composeStories(stories)
 
-describe('given an uncontrolled MobileMenu', async () => {
-  it('should be possible to open and close', async () => {
-    const { getByRole } = await render(<Primary />)
-    await getByRole('button', { name: 'Open menu' }).click()
-    const dismissButton = getByRole('button', { name: 'Dismiss' })
-    await expect.element(dismissButton).toBeVisible()
-    await userEvent.keyboard('[Escape]')
-    await expect.element(dismissButton).not.toBeInTheDocument()
+describe('MobileMenu', () => {
+  beforeEach(({ skip, task }) => {
+    skip(
+      task.file.projectName === 'desktop',
+      'MobileMenu is only relevant for mobile',
+    )
   })
-})
 
-describe('given a controlled MobileMenu', async () => {
-  it('should be possible to open and close', async () => {
-    const { getByRole } = await render(<Controlled />)
-    await getByRole('button', { name: 'Open menu' }).click()
-    const dismissButton = getByRole('button', { name: 'Dismiss' })
-    await expect.element(dismissButton).toBeVisible()
-    await userEvent.keyboard('[Escape]')
-    await expect.element(dismissButton).not.toBeInTheDocument()
+  describe('given an uncontrolled MobileMenu', async () => {
+    it('should be possible to open and close', async () => {
+      const { getByRole } = await render(<Primary />)
+      await getByRole('button', { name: 'Open menu' }).click()
+      const dismissButton = getByRole('button', { name: 'Dismiss' })
+      await expect.element(dismissButton).toBeVisible()
+      await userEvent.keyboard('[Escape]')
+      await expect.element(dismissButton).not.toBeInTheDocument()
+    })
+  })
+
+  describe('given a controlled MobileMenu', async () => {
+    it('should be possible to open and close', async () => {
+      const { getByRole } = await render(<Controlled />)
+      await getByRole('button', { name: 'Open menu' }).click()
+      const dismissButton = getByRole('button', { name: 'Dismiss' })
+      await expect.element(dismissButton).toBeVisible()
+      await userEvent.keyboard('[Escape]')
+      await expect.element(dismissButton).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/layout/src/layout/Layout.spec.tsx
+++ b/packages/layout/src/layout/Layout.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { composeStories } from '@storybook/react-vite'
 import { render } from 'vitest-browser-react'
+import styles from './Layout.module.css'
 import * as stories from './Layout.stories'
 
 const { Primary } = composeStories(stories)
@@ -10,5 +11,13 @@ describe('given a primary Layout', async () => {
     const { getByText } = await render(<Primary />)
 
     await expect.element(getByText('Content')).toBeVisible()
+  })
+
+  it('should accept a custom className', async () => {
+    const { container } = await render(<Primary className='custom-class' />)
+
+    await expect
+      .element(container.querySelector(`.${styles.layout}`) as HTMLElement)
+      .toHaveClass(styles.layout, 'custom-class')
   })
 })

--- a/packages/layout/src/layout/Layout.spec.tsx
+++ b/packages/layout/src/layout/Layout.spec.tsx
@@ -3,21 +3,22 @@ import { composeStories } from '@storybook/react-vite'
 import { render } from 'vitest-browser-react'
 import styles from './Layout.module.css'
 import * as stories from './Layout.stories'
+import { userEvent } from 'vitest/browser'
 
 const { Primary } = composeStories(stories)
 
 describe('given a primary Layout', async () => {
-  it('should render', async () => {
-    const { getByText } = await render(<Primary />)
-
-    await expect.element(getByText('Content')).toBeVisible()
-  })
-
   it('should accept a custom className', async () => {
     const { container } = await render(<Primary className='custom-class' />)
-
     await expect
       .element(container.querySelector(`.${styles.layout}`) as HTMLElement)
       .toHaveClass(styles.layout, 'custom-class')
+  })
+
+  it('should be possible to skip to content (DS1375)', async () => {
+    const { getByRole } = await render(<Primary />)
+    await userEvent.tab()
+    await userEvent.keyboard('[Enter]')
+    await expect.element(getByRole('main')).toHaveFocus()
   })
 })

--- a/packages/layout/src/layout/Layout.tsx
+++ b/packages/layout/src/layout/Layout.tsx
@@ -1,17 +1,21 @@
 import clsx from 'clsx'
 import { DetailedHTMLProps, HTMLAttributes } from 'react'
 import styles from './Layout.module.css'
+import { SkipToContent } from './skip-to-content'
 
 export type LayoutProps = DetailedHTMLProps<
   HTMLAttributes<HTMLDivElement>,
   HTMLDivElement
 >
 
-export const Layout = ({ className, ...rest }: LayoutProps) => {
+export const Layout = ({ children, className, ...rest }: LayoutProps) => {
   return (
     <div
       className={clsx(className, styles.layout)}
       {...rest}
-    />
+    >
+      <SkipToContent />
+      {children}
+    </div>
   )
 }

--- a/packages/layout/src/layout/skip-to-content/SkipToContent.module.css
+++ b/packages/layout/src/layout/skip-to-content/SkipToContent.module.css
@@ -1,0 +1,12 @@
+.skipToContent {
+  position: absolute;
+  top: 0;
+  right: 100%;
+  z-index: var(--midas-z-index-skip-to-content);
+
+  &[data-focus-visible] {
+    right: auto;
+    left: 5px;
+    top: 5px;
+  }
+}

--- a/packages/layout/src/layout/skip-to-content/SkipToContent.tsx
+++ b/packages/layout/src/layout/skip-to-content/SkipToContent.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Button, useLocalizedStringFormatter } from '@midas-ds/components'
+import messages from './intl/translations.json'
+import styles from './SkipToContent.module.css'
+
+export interface SkipToContentProps {
+  /**
+   * A CSS selector that identifies the element to focus when the skip link is activated.
+   * @default 'main:first-of-type'
+   */
+  selector?: string
+}
+
+export const SkipToContent = ({
+  selector = 'main:first-of-type',
+}: SkipToContentProps) => {
+  const handlePress = () => {
+    const container = document.querySelector<HTMLElement>(selector)
+
+    if (container) {
+      container.tabIndex = -1
+      container.focus()
+      container.addEventListener(
+        'blur',
+        () => container.removeAttribute('tabindex'),
+        { once: true },
+      )
+    }
+  }
+
+  const strings = useLocalizedStringFormatter(messages)
+
+  return (
+    <Button
+      onPress={handlePress}
+      className={styles.skipToContent}
+    >
+      {strings.format('skipToContent')}
+    </Button>
+  )
+}

--- a/packages/layout/src/layout/skip-to-content/index.ts
+++ b/packages/layout/src/layout/skip-to-content/index.ts
@@ -1,0 +1,1 @@
+export * from './SkipToContent'

--- a/packages/layout/src/layout/skip-to-content/intl/translations.json
+++ b/packages/layout/src/layout/skip-to-content/intl/translations.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "skipToContent": "Skip to main content"
+  },
+  "sv": {
+    "skipToContent": "Hoppa till huvudinnehåll"
+  }
+}

--- a/packages/layout/src/main/Main.module.css
+++ b/packages/layout/src/main/Main.module.css
@@ -5,4 +5,14 @@
   height: 100%;
   overflow: hidden auto;
   padding: 1rem;
+
+  &:focus-visible {
+    box-shadow: var(--midas-state-focus-inset);
+    outline: none;
+
+    @media (forced-colors: active) {
+      outline: var(--midas-state-focus-contrast-mode-outline) solid highlight;
+      outline-offset: calc(var(--midas-state-focus-contrast-mode-outline) * -1);
+    }
+  }
 }

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.spec.tsx
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.spec.tsx
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { House } from 'lucide-react'
+import { NavigationLink } from './NavigationLink'
+
+describe('NavigationLink active state', () => {
+  it('should set data-active when isActive is true', async () => {
+    await render(
+      <NavigationLink
+        href='/app'
+        icon={<House />}
+        isActive
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await expect.element(page.getByRole('link')).toHaveAttribute('data-active')
+  })
+
+  it('should NOT set data-active when isActive is false', async () => {
+    await render(
+      <NavigationLink
+        href='/app'
+        icon={<House />}
+        isActive={false}
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .not.toHaveAttribute('data-active')
+  })
+
+  it('should NOT set data-active when isActive is undefined', async () => {
+    await render(
+      <NavigationLink
+        href='/app'
+        icon={<House />}
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .not.toHaveAttribute('data-active')
+  })
+
+  it('should set aria-current="page" when isActive', async () => {
+    await render(
+      <NavigationLink
+        href='/app'
+        icon={<House />}
+        isActive
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .toHaveAttribute('aria-current', 'page')
+  })
+
+  it('should render link with correct href', async () => {
+    await render(
+      <NavigationLink
+        href='/test-path'
+        icon={<House />}
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .toHaveAttribute('href', '/test-path')
+  })
+
+  it('should render with an explicit aria-label', async () => {
+    await render(
+      <NavigationLink
+        href='/app'
+        icon={<House />}
+        aria-label='Test Link'
+      >
+        <span>Link</span>
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .toHaveAttribute('aria-label', 'Test Link')
+  })
+})
+
+describe('NavigationLink with external target', () => {
+  it('should preserve target="_blank" on external links', async () => {
+    await render(
+      <NavigationLink
+        href='https://example.com'
+        icon={<House />}
+        target='_blank'
+      >
+        External Link
+      </NavigationLink>,
+    )
+
+    await expect
+      .element(page.getByRole('link'))
+      .toHaveAttribute('target', '_blank')
+  })
+})
+
+describe('NavigationLink with onPress handler', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should call the press handler when clicked', async () => {
+    const handlePress = vi.fn()
+
+    await render(
+      <NavigationLink
+        href='#'
+        icon={<House />}
+        onPress={handlePress}
+      >
+        Test Link
+      </NavigationLink>,
+    )
+
+    await page.getByRole('link').click()
+
+    expect(handlePress).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/layout/src/sidebar/Sidebar.spec.tsx
+++ b/packages/layout/src/sidebar/Sidebar.spec.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { Sidebar } from './Sidebar'
+
+describe('Sidebar', () => {
+  beforeEach(({ skip, task }) => {
+    skip(
+      task.file.projectName === 'mobile',
+      'Sidebar is only relevant for desktop',
+    )
+  })
+
+  it('should render children', async () => {
+    await render(<Sidebar title='Test'>Sidebar content</Sidebar>)
+
+    await expect.element(page.getByText('Sidebar content')).toBeVisible()
+  })
+
+  it('should show title when not collapsed', async () => {
+    await render(<Sidebar title='My Sidebar'>Content</Sidebar>)
+
+    await expect.element(page.getByText('My Sidebar')).toBeVisible()
+  })
+
+  it('should hide title when defaultCollapsed', async () => {
+    await render(
+      <Sidebar
+        title='My Sidebar'
+        defaultCollapsed
+      >
+        Content
+      </Sidebar>,
+    )
+
+    await expect.element(page.getByText('My Sidebar')).not.toBeInTheDocument()
+  })
+
+  it('should collapse when the collapse button is pressed', async () => {
+    await render(<Sidebar title='My Sidebar'>Content</Sidebar>)
+
+    await page.getByRole('button', { name: 'Collapse sidebar' }).click()
+
+    await expect.element(page.getByText('My Sidebar')).not.toBeInTheDocument()
+  })
+
+  it('should expand when the expand button is pressed', async () => {
+    await render(
+      <Sidebar
+        title='My Sidebar'
+        defaultCollapsed
+      >
+        Content
+      </Sidebar>,
+    )
+
+    await page.getByRole('button', { name: 'Expand sidebar' }).click()
+
+    await expect.element(page.getByText('My Sidebar')).toBeVisible()
+  })
+})

--- a/packages/layout/vitest.config.ts
+++ b/packages/layout/vitest.config.ts
@@ -17,7 +17,18 @@ export default mergeConfig(
               enabled: true,
               headless: true,
               provider: playwright(),
-              instances: [{ browser: 'chromium' }],
+              instances: [
+                {
+                  name: 'desktop',
+                  browser: 'chromium',
+                  viewport: { width: 1024, height: 768 },
+                },
+                {
+                  name: 'mobile',
+                  browser: 'chromium',
+                  viewport: { width: 320, height: 568 },
+                },
+              ],
               screenshotFailures: false,
             },
             setupFiles: ['vitest.setup.ts'],


### PR DESCRIPTION
## Description

The new layout package needs basic tests 

## Changes

- test(layout): migrate legacy tests
- test(layout): create multiple viewport setups
- test(layout): add skip to content test

## Checklist

- [x] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
