### PR TITLE
docs(layout): add css installation examples

### DIFF
--- a/apps/docs/docs/dev/layout/index.mdx
+++ b/apps/docs/docs/dev/layout/index.mdx
@@ -100,18 +100,10 @@ Skissen nedan visar ett exempel på hur komponenterna kan sättas ihop. Vilket u
 npm install @midas-ds/layout
 ```
 
-Uppdatera er globala css med:
+Importera `default.css`. Denna fil innehåller global css för att layout-komponenterna ska få rätt utseende. Importera filen i roten av din applikation:
 
-```css
-html {
-  /* döljer scrollbars vid animation av paneler */
-  overflow: hidden;
-}
-
-body {
-  /* eventuell marginal hanteras av Midas layout */
-  margin: 0;
-}
+```tsx title="main.tsx"
+import '@midas-ds/layout/default.css'
 ```
 
 ## Snabbstart

--- a/apps/docs/docs/dev/layout/index.mdx
+++ b/apps/docs/docs/dev/layout/index.mdx
@@ -100,6 +100,20 @@ Skissen nedan visar ett exempel på hur komponenterna kan sättas ihop. Vilket u
 npm install @midas-ds/layout
 ```
 
+Uppdatera er globala css med:
+
+```css
+html {
+  /* döljer scrollbars vid animation av paneler */
+  overflow: hidden;
+}
+
+body {
+  /* eventuell marginal hanteras av Midas layout */
+  margin: 0;
+}
+```
+
 ## Snabbstart
 
 Så här ser ett komplett upplägg ut med sidhuvud, sidomeny, huvudinnehåll och navbar:

--- a/apps/next/app/global.css
+++ b/apps/next/app/global.css
@@ -1,11 +1,3 @@
-html {
-  overflow: hidden;
-}
-
-body {
-  margin: 0;
-}
-
 /* Debug labels for layout regions */
 [data-debug]::before {
   content: attr(data-debug);

--- a/apps/next/app/layout.tsx
+++ b/apps/next/app/layout.tsx
@@ -4,7 +4,6 @@ import { Logo } from '@midas-ds/components'
 import {
   Layout,
   Header,
-  Panel,
   Navbar,
   Main,
   MobileMenu,
@@ -18,6 +17,7 @@ import { AppProvider } from '../components/AppProvider/AppContext'
 import { AppLayoutProvider } from '../components/AppLayoutProvider/AppLayoutProvider'
 import { GlobalToastRegion } from '@midas-ds/components'
 import '@midas-ds/components/default.css'
+import '@midas-ds/layout/default.css'
 import './global.css'
 
 export const metadata: Metadata = {

--- a/apps/next/app/page.tsx
+++ b/apps/next/app/page.tsx
@@ -14,6 +14,9 @@ export default function Home() {
       <span data-midas-version={VERSION} />
       <Information />
       <AppSettings />
+      <div style={{ marginTop: 1000 }}>
+        Some content in the bottom of the page to create a scroll
+      </div>
     </>
   )
 }

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -32,6 +32,7 @@
   },
   "exports": {
     ".": "./index.js",
+    "./default.css": "./assets/default.css",
     "./*/index.js": "./*/index.js",
     "./*": "./*/index.js"
   },

--- a/packages/layout/src/default.css
+++ b/packages/layout/src/default.css
@@ -1,0 +1,9 @@
+html {
+  /* hide scrollbars when animating panels */
+  overflow: hidden;
+}
+
+body {
+  /* remove browser default margin */
+  margin: 0;
+}

--- a/packages/layout/vite.config.ts
+++ b/packages/layout/vite.config.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url'
 import preserveUseClientDirective from 'rollup-plugin-preserve-use-client'
 
 const src = resolve(__dirname, 'src')
+const defaultCss = resolve(src, 'default.css')
 
 export default defineConfig({
   root: __dirname,
@@ -36,6 +37,7 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(src, 'index.ts'),
+        default: defaultCss,
         ...Object.fromEntries(
           globSync(`${src}/*/index.ts`).map(file => [
             relative(src, file.slice(0, file.length - extname(file).length)),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,8 @@
       "@midas-ds/select-styles/*": ["packages/select-styles/src/*"],
       "@midas-ds/storybook/*": ["apps/storybook/src/*"],
       "@midas-ds/test-utils": ["tools/test-utils/src/index.ts"],
-      "@midas-ds/layout": ["packages/layout/src/index.ts"]
+      "@midas-ds/layout": ["packages/layout/src/index.ts"],
+      "@midas-ds/layout/*": ["packages/layout/src/*"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Description

Scrollable content adds double scrollbars if body has margin.

## Changes

- docs(layout): add css installation examples

## Additional Information

The new `Layout` component uses `Main` as the scroll container. The old used `body`.

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
