### PR TITLE
fix(components, grid): change flex-wrap behavior for columns

### DIFF
--- a/packages/components/src/grid/Grid.module.css
+++ b/packages/components/src/grid/Grid.module.css
@@ -30,7 +30,7 @@
 
 .flex > * {
   display: flex;
-  flex-flow: column wrap;
+  flex-flow: column nowrap;
   flex: 0 0 auto;
   width: calc(
     (100% / var(--columns)) - var(--gutter) + (var(--gutter) / var(--columns))


### PR DESCRIPTION
## Description

Columns with text content containing dashes (why?) create vertical white space

## Changes

- change flex-wrap behavior for columns to `nowrap`

## Additional Information

För att få ut effekt av `flex-flow: column wrap` behöver kolumnen ett explicit värde för `height`. Eftersom vi inte sätter någon höjd för kolumnerna anser jag det bättre att köra `flex-flow: column nowrap` för att slippa buggen som addresseras. 

Om annat overflowbeteende önskas så finns ju alltid className och style, men jag gissar att det är edge case

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
