### PR TITLE
fix(components, date-picker): add forwardRef and generic type

### DIFF
--- a/apps/docs/src/components/examples/date-picker/DatePickerExamples.tsx
+++ b/apps/docs/src/components/examples/date-picker/DatePickerExamples.tsx
@@ -21,9 +21,7 @@ export const DatePickerExample = () => {
       <DatePicker
         label='Date (controlled)'
         value={value}
-        onChange={newValue =>
-          setValue(newValue ? parseDate(newValue.toString()) : null)
-        }
+        onChange={setValue}
       />
       <pre>Du valde datum: {value?.toString()}</pre>
     </>

--- a/packages/components/src/date-picker/DatePicker.stories.tsx
+++ b/packages/components/src/date-picker/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { parseDate, CalendarDate } from '@internationalized/date'
 import { DatePicker } from './DatePicker'
 
-const meta: Meta<typeof DatePicker> = {
+const meta: Meta<typeof DatePicker<CalendarDate>> = {
   component: DatePicker,
   title: 'Components/DatePicker',
   tags: ['autodocs'],
@@ -32,7 +32,7 @@ const meta: Meta<typeof DatePicker> = {
   },
 }
 export default meta
-type Story = StoryObj<typeof DatePicker>
+type Story = StoryObj<typeof DatePicker<CalendarDate>>
 
 export const Primary: Story = {}
 
@@ -108,13 +108,12 @@ export const ControlledState: Story = {
     const [value, setValue] = React.useState<CalendarDate | null>(
       parseDate('2026-05-29'),
     )
+
     return (
       <DatePicker
         {...args}
         value={value}
-        onChange={newValue =>
-          setValue(newValue ? parseDate(newValue.toString()) : null)
-        }
+        onChange={setValue}
       />
     )
   },

--- a/packages/components/src/date-picker/DatePicker.tsx
+++ b/packages/components/src/date-picker/DatePicker.tsx
@@ -19,7 +19,9 @@ import styles from './DatePicker.module.css'
 import { Size } from '../common/types'
 import { LabelWrapper } from '../label/LabelWrapper'
 
-export interface DatePickerProps extends AriaDatePickerProps<DateValue> {
+export interface DatePickerProps<
+  T extends DateValue,
+> extends AriaDatePickerProps<T> {
   description?: string
   errorMessage?: string | ((validation: ValidationResult) => string)
   errorPosition?: 'top' | 'bottom'
@@ -36,44 +38,52 @@ export interface DatePickerProps extends AriaDatePickerProps<DateValue> {
   isClearable?: boolean
 }
 
-export const DatePicker: React.FC<DatePickerProps> = ({
-  className,
-  description,
-  errorMessage,
-  errorPosition = 'top',
-  label,
-  popover,
-  isClearable = false,
-  isReadOnly,
-  isDisabled,
-  size,
-  ...rest
-}) => {
-  return (
-    <AriaDatePicker
-      className={clsx(styles.datePicker, className)}
-      isReadOnly={isReadOnly}
-      isDisabled={isDisabled}
-      {...rest}
-    >
-      <LabelWrapper popover={popover}>
-        {label && <Label>{label}</Label>}
-      </LabelWrapper>
-      {description && <Text slot='description'>{description}</Text>}
-      {errorPosition === 'top' && <FieldError>{errorMessage}</FieldError>}
-      <DatePickerInputField
-        isClearable={isClearable}
+export const DatePicker = React.forwardRef(
+  <T extends DateValue>(
+    {
+      className,
+      description,
+      errorMessage,
+      errorPosition = 'top',
+      label,
+      popover,
+      isClearable = false,
+      isReadOnly,
+      isDisabled,
+      size,
+      ...rest
+    }: DatePickerProps<T>,
+    ref: React.ForwardedRef<HTMLDivElement>,
+  ) => {
+    return (
+      <AriaDatePicker
+        className={clsx(styles.datePicker, className)}
         isReadOnly={isReadOnly}
         isDisabled={isDisabled}
-        size={size}
+        ref={ref}
         {...rest}
       >
-        <DateInput>{segment => <DateSegment segment={segment} />}</DateInput>
-      </DatePickerInputField>
-      {errorPosition === 'bottom' && <FieldError>{errorMessage}</FieldError>}
-      <DatePickerPopover>
-        <Calendar />
-      </DatePickerPopover>
-    </AriaDatePicker>
-  )
-}
+        <LabelWrapper popover={popover}>
+          {label && <Label>{label}</Label>}
+        </LabelWrapper>
+        {description && <Text slot='description'>{description}</Text>}
+        {errorPosition === 'top' && <FieldError>{errorMessage}</FieldError>}
+        <DatePickerInputField
+          isClearable={isClearable}
+          isReadOnly={isReadOnly}
+          isDisabled={isDisabled}
+          size={size}
+          {...rest}
+        >
+          <DateInput>{segment => <DateSegment segment={segment} />}</DateInput>
+        </DatePickerInputField>
+        {errorPosition === 'bottom' && <FieldError>{errorMessage}</FieldError>}
+        <DatePickerPopover>
+          <Calendar />
+        </DatePickerPopover>
+      </AriaDatePicker>
+    )
+  },
+) as <T extends DateValue>(
+  props: DatePickerProps<T> & { ref?: React.Ref<HTMLDivElement> },
+) => React.ReactElement | null

--- a/packages/components/src/date-picker/DatePickerInputField.tsx
+++ b/packages/components/src/date-picker/DatePickerInputField.tsx
@@ -3,6 +3,7 @@ import {
   Group,
   DatePickerStateContext,
   DateRangePickerStateContext,
+  DateValue,
 } from 'react-aria-components'
 import { CalendarDays } from 'lucide-react'
 import { clsx } from 'clsx'
@@ -15,11 +16,10 @@ import { FocusScope, useFocusManager } from '@react-aria/focus'
 import { isRangePickerState } from './utils'
 import { Button } from '../button'
 
-interface DatePickerInputFieldProps
-  extends Pick<
-    DatePickerProps,
-    'isDisabled' | 'isInvalid' | 'isReadOnly' | 'size' | 'isClearable'
-  > {
+interface DatePickerInputFieldProps extends Pick<
+  DatePickerProps<DateValue>,
+  'isDisabled' | 'isInvalid' | 'isReadOnly' | 'size' | 'isClearable'
+> {
   children?: React.ReactNode
 }
 
@@ -58,14 +58,14 @@ const DatePickerClearButton = ({
   ) : null
 }
 
-export const DatePickerInputField: React.FC<DatePickerInputFieldProps> = ({
+export const DatePickerInputField = ({
   children,
   isDisabled,
   isInvalid,
   isReadOnly,
   size = 'large',
   isClearable = false,
-}) => {
+}: DatePickerInputFieldProps) => {
   const strings = useLocalizedStringFormatter(messages)
   return (
     <Group


### PR DESCRIPTION
## Description

We're not forwarding the ref, developers are forced to workaround typescript errors for the onChange event

## Changes

add forwardRef, add generic to the type interface

## Additional Information

just as we did for DateField and Timefield.

## Checklist

- [ ] Tests added if applicable
- [x] Documentation updated
- [x] Conventional commit messages
