### PR TITLE
fix(next): remove default config spread

### DIFF
--- a/apps/next/next.config.ts
+++ b/apps/next/next.config.ts
@@ -16,11 +16,7 @@ const addImportPath = (path: string) => (moduleName: string) => [
   `${path}/${moduleName}`,
 ]
 
-export default (
-  phase: PHASE_TYPE,
-  { defaultConfig }: { defaultConfig: NextConfig },
-): NextConfig => ({
-  ...defaultConfig,
+export default (phase: PHASE_TYPE): NextConfig => ({
   turbopack: {
     root: workspaceRoot,
     resolveAlias:


### PR DESCRIPTION
## Description

We have a deprecation warning when running `nx dev next`

⚠ `experimental.browserDebugInfoInTerminal` has been moved to `logging.browserToTerminal`. Please update your next.config.ts file accordingly.

## Changes

- fix(next): remove default config spread

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
