### PR TITLE
fix(layout, mobile-menu): add display block to modal overlay

### DIFF
--- a/packages/layout/src/header/mobile-menu/MobileMenu.module.css
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.module.css
@@ -1,4 +1,6 @@
 .overlay {
+  display: block;
+
   &[data-entering] {
     animation: drawer-blur var(--midas-transition-duration-quick);
   }


### PR DESCRIPTION
## Description

The `Navigation` is a bit off in the `MobileMenu`

## Changes

fix(layout, mobile-menu): add display block to modal overlay

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
