### PR TITLE
fix(layout): sidebar collapse animation + scrollbar stability

### DIFF
--- a/apps/next/components/Navigation/Navigation.tsx
+++ b/apps/next/components/Navigation/Navigation.tsx
@@ -50,13 +50,13 @@ const sections: Section[] = [
       },
       {
         id: 2,
-        title: 'Applications',
+        title: 'My Very Important Applications And Other Stuff',
         href: '/applications',
         icon: <FileText />,
         children: [
           {
             id: 4,
-            title: 'New application',
+            title: 'Submit A Brand New Application',
             href: '/applications/new',
             icon: <Plus />,
           },
@@ -68,7 +68,7 @@ const sections: Section[] = [
           },
           {
             id: 6,
-            title: 'Sent',
+            title: 'Previously Sent Applications',
             href: '/applications/sent',
             icon: <Send />,
           },
@@ -82,7 +82,7 @@ const sections: Section[] = [
     children: [
       {
         id: 8,
-        title: 'Profile',
+        title: 'My Personal Profile Settings',
         href: '/profile',
         icon: <User />,
       },
@@ -98,7 +98,7 @@ const sections: Section[] = [
     children: [
       {
         id: 10,
-        title: 'Help',
+        title: 'Help And Support Center',
         href: '/help',
         icon: <HelpCircle />,
       },

--- a/packages/layout/src/main/Main.module.css
+++ b/packages/layout/src/main/Main.module.css
@@ -4,6 +4,7 @@
   min-width: 0;
   height: 100%;
   overflow: hidden auto;
+  scrollbar-gutter: stable;
   padding: 1rem;
 
   &:focus-visible {

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.module.css
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.module.css
@@ -23,7 +23,8 @@
     flex-direction: row;
     justify-content: flex-start;
     padding: 0.625rem var(--midas-spacing-30);
-    transition: padding-inline-start var(--midas-transition-duration-fast) ease-out;
+    transition: padding-inline-start var(--midas-transition-duration-fast)
+      ease-out;
 
     &[data-active] {
       border-color: var(--midas-border-color-tertiary);

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.module.css
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.module.css
@@ -19,26 +19,54 @@
   }
 
   &.sidebar {
+    align-items: flex-start;
     flex-direction: row;
     justify-content: flex-start;
     padding: 0.625rem var(--midas-spacing-30);
+    transition: padding-inline-start var(--midas-transition-duration-fast) ease-out;
 
     &[data-active] {
       border-color: var(--midas-border-color-tertiary);
       font-weight: var(--midas-typography-weight-bold);
     }
+
+    &.collapsed {
+      /* Center the icon within the collapsed sidebar width (80px)
+         minus sidebar content padding on both sides */
+      padding-inline-start: calc(
+        (80px - 2 * var(--midas-space-small) - var(--midas-size-90)) / 2
+      );
+    }
   }
 
   svg {
+    flex-shrink: 0;
     height: var(--midas-size-90);
     width: var(--midas-size-90);
   }
 
-  &.collapsed {
-    justify-content: center;
+  .title {
+    display: block;
+    height: auto;
+    interpolate-size: allow-keywords;
+    opacity: 1;
+    overflow: hidden;
+    transition:
+      display var(--midas-transition-duration-fast) allow-discrete,
+      height var(--midas-transition-duration-fast) ease-out,
+      opacity var(--midas-transition-duration-instant) ease-out;
 
+    @starting-style {
+      height: 0;
+      opacity: 0;
+    }
+  }
+
+  &.collapsed {
     .title {
       display: none;
+      height: 0;
+      opacity: 0;
     }
   }
 }

--- a/packages/layout/src/sidebar/Sidebar.module.css
+++ b/packages/layout/src/sidebar/Sidebar.module.css
@@ -24,8 +24,27 @@
 }
 
 .sidebarTitle {
-  font-size: var(--midas-typography-font-size-20);
   display: block;
+  font-size: var(--midas-typography-font-size-20);
+  height: auto;
+  interpolate-size: allow-keywords;
+  opacity: 1;
+  overflow: hidden;
+  transition:
+    display var(--midas-transition-duration-fast) allow-discrete,
+    height var(--midas-transition-duration-fast) ease-out,
+    opacity var(--midas-transition-duration-instant) ease-out;
+
+  @starting-style {
+    height: 0;
+    opacity: 0;
+  }
+
+  &.collapsed {
+    display: none;
+    height: 0;
+    opacity: 0;
+  }
 }
 
 .sidebarContent {

--- a/packages/layout/src/sidebar/Sidebar.module.css
+++ b/packages/layout/src/sidebar/Sidebar.module.css
@@ -31,7 +31,6 @@
   opacity: 1;
   overflow: hidden;
   transition:
-    display var(--midas-transition-duration-fast) allow-discrete,
     height var(--midas-transition-duration-fast) ease-out,
     opacity var(--midas-transition-duration-instant) ease-out;
 

--- a/packages/layout/src/sidebar/Sidebar.module.css
+++ b/packages/layout/src/sidebar/Sidebar.module.css
@@ -1,6 +1,7 @@
 .sidebar {
   background-color: var(--midas-background-base);
   border-right: 1px solid var(--midas-border-color-subtle);
+  flex-shrink: 0;
   transition: width var(--midas-transition-duration-fast) ease-out;
   width: 15rem;
 

--- a/packages/layout/src/sidebar/Sidebar.spec.tsx
+++ b/packages/layout/src/sidebar/Sidebar.spec.tsx
@@ -33,7 +33,7 @@ describe('Sidebar', () => {
       </Sidebar>,
     )
 
-    await expect.element(page.getByText('My Sidebar')).not.toBeInTheDocument()
+    await expect.element(page.getByText('My Sidebar')).not.toBeVisible()
   })
 
   it('should collapse when the collapse button is pressed', async () => {
@@ -41,7 +41,7 @@ describe('Sidebar', () => {
 
     await page.getByRole('button', { name: 'Collapse sidebar' }).click()
 
-    await expect.element(page.getByText('My Sidebar')).not.toBeInTheDocument()
+    await expect.element(page.getByText('My Sidebar')).not.toBeVisible()
   })
 
   it('should expand when the expand button is pressed', async () => {

--- a/packages/layout/src/sidebar/Sidebar.tsx
+++ b/packages/layout/src/sidebar/Sidebar.tsx
@@ -57,9 +57,11 @@ export const Sidebar = ({
             [styles.collapsed]: isCollapsed,
           })}
         >
-          {!isCollapsed && title ? (
+          {title ? (
             <PanelTitle
-              className={styles.panelTitle}
+              className={clsx(styles.sidebarTitle, {
+                [styles.collapsed]: isCollapsed,
+              })}
               title={title}
             />
           ) : (


### PR DESCRIPTION
## Summary

- **Scrollbar layout shift**: sidebar was missing `flex-shrink: 0` so it could compress under flex pressure when a classic scrollbar appeared in `Main`; added `scrollbar-gutter: stable` to `Main` so the gutter is always reserved
- **Collapse animation**: replaced the instant `display: none` snap on nav labels with a smooth `height` + `opacity` + deferred `display` transition using `interpolate-size`, `allow-discrete`, and `@starting-style`; icon now slides to center via `padding-inline-start` transition instead of the non-animatable `justify-content`
- **Multiline label fixes**: `align-items: flex-start` in sidebar mode so the icon pins to the top of wrapped text; `flex-shrink: 0` on SVG so the icon never compresses
- **Test data**: multiword nav labels added to the `next` app so the animation can be reviewed live without extra setup

## Test plan

- [ ] Collapse and expand sidebar — labels should fade + collapse smoothly, no jump or scramble
- [ ] Multiword labels should wrap normally in expanded state
- [ ] Icon should stay same size and top-align with multiline labels
- [ ] Icon should slide smoothly to center on collapse, no jump at start or end
- [ ] Sidebar width should stay stable when main content gains/loses a scrollbar
- [ ] Verify in `nx e2e next` that existing tests still pass