### PR TITLE
docs(table): add row actions section

### DIFF
--- a/apps/docs/docs/components/table.mdx
+++ b/apps/docs/docs/components/table.mdx
@@ -9,6 +9,8 @@ import {
   BasicExample,
   FullExample,
   ControlledExample,
+  RowOnActionExample,
+  TableOnRowActionExample,
   SortingExample,
 } from '@site/src/components/examples/table/TableExamples'
 
@@ -193,6 +195,47 @@ const [selectedKeys, setSelectedKeys] = React.useState<Selection>(new Set(['appl
 ```
 
 <ControlledExample />
+
+## Radåtgärder
+
+Det finns två sätt att hantera klick på en rad.
+
+### onAction på Row
+
+Sätt `onAction` direkt på varje `Row`. Callbacken är `() => void` — ingen nyckel behövs eftersom raddatan redan finns i scope via closure.
+
+```tsx
+<TableBody items={rows}>
+  {item => (
+    // highlight-next-line
+    <Row columns={columns} onAction={() => console.log(item)}>
+      {column => <Cell>{item[column.id]}</Cell>}
+    </Row>
+  )}
+</TableBody>
+```
+
+<RowOnActionExample />
+
+### onRowAction på Table
+
+Använd `onRowAction` på `Table`-komponenten för en enda hanterare för hela tabellen. Den tar emot radens `id` som nyckel, så raderna måste ha ett explicit `id`-prop.
+
+```tsx
+// highlight-next-line
+<Table aria-label='Fruit' onRowAction={(key) => console.log(key)}>
+  <TableBody items={rows}>
+    {item => (
+      // highlight-next-line
+      <Row id={item.id} columns={columns}>
+        {column => <Cell>{item[column.id]}</Cell>}
+      </Row>
+    )}
+  </TableBody>
+</Table>
+```
+
+<TableOnRowActionExample />
 
 ## Sortering
 

--- a/apps/docs/src/components/examples/table/TableExamples.tsx
+++ b/apps/docs/src/components/examples/table/TableExamples.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { Selection, SortDescriptor } from 'react-aria-components'
+import type { Key, Selection, SortDescriptor } from 'react-aria-components'
 import {
   Cell,
   Column,
@@ -95,6 +95,73 @@ export const ControlledExample: React.FC<TableProps> = props => {
       />
       Valda rader: {Array.from(selectedKeys).join(', ')}
     </>
+  )
+}
+
+export const RowOnActionExample = () => {
+  const [lastClicked, setLastClicked] = React.useState<(typeof rows)[0] | null>(
+    null,
+  )
+
+  return (
+    <div className='card'>
+      <Table aria-label='Fruit'>
+        <TableHeader columns={columns}>
+          {column => (
+            <Column isRowHeader={column.isRowHeader}>{column.name}</Column>
+          )}
+        </TableHeader>
+        <TableBody items={rows}>
+          {item => (
+            <Row
+              columns={columns}
+              onAction={() => setLastClicked(item)}
+            >
+              {column => <Cell>{item[column.id]}</Cell>}
+            </Row>
+          )}
+        </TableBody>
+      </Table>
+      {lastClicked && (
+        <p style={{ marginTop: '0.75rem' }}>
+          Klickad rad: <strong>{lastClicked.name}</strong>
+        </p>
+      )}
+    </div>
+  )
+}
+
+export const TableOnRowActionExample = () => {
+  const [lastKey, setLastKey] = React.useState<Key | null>(null)
+
+  return (
+    <div className='card'>
+      <Table
+        aria-label='Fruit'
+        onRowAction={setLastKey}
+      >
+        <TableHeader columns={columns}>
+          {column => (
+            <Column isRowHeader={column.isRowHeader}>{column.name}</Column>
+          )}
+        </TableHeader>
+        <TableBody items={rows}>
+          {item => (
+            <Row
+              id={item.id}
+              columns={columns}
+            >
+              {column => <Cell>{item[column.id]}</Cell>}
+            </Row>
+          )}
+        </TableBody>
+      </Table>
+      {lastKey && (
+        <p style={{ marginTop: '0.75rem' }}>
+          Klickad nyckel: <strong>{String(lastKey)}</strong>
+        </p>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

- Adds a new **Radåtgärder** section to the Table docs
- Documents both `Row.onAction` (row-level closure, no key needed) and `Table.onRowAction` (single table-level handler with key)
- Includes live interactive examples for both patterns

## Test plan

- [ ] Check docs site renders the new section correctly
- [ ] Verify both live examples respond to row clicks