### PR TITLE
Replace static version label with live npm badge

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -8,11 +8,6 @@ import { createAliases } from './aliases'
 const packagesDir = path.resolve(__dirname, '../../packages')
 const toolsDir = path.resolve(__dirname, '../../tools')
 
-// eslint-disable-next-line
-const version: string = require(
-  `${packagesDir}/components/package.json`,
-).version
-
 const isUnreleased = !!process.env.UNRELEASED
 
 const packageAliases = {
@@ -165,9 +160,7 @@ const config: Config = {
         {
           type: 'html',
           position: 'right',
-          value: isUnreleased
-            ? `<code class="unreleased">Version ${version} (unreleased)</code>`
-            : `<a href="https://github.com/migrationsverket/midas/releases" target="_blank" rel="noopener noreferrer"><code>Version ${version}</code></a>`,
+          value: `<a href="https://www.npmjs.com/package/@midas-ds/components" target="_blank" rel="noopener noreferrer" style="display:flex;align-items:center;"><img src="https://img.shields.io/npm/v/@midas-ds/components?label=components&style=flat-square" alt="npm version" /></a>`,
         },
         {
           href:


### PR DESCRIPTION
## Summary
- The previous version label was read from `package.json` at build time, meaning the docs could show a version that hadn't actually been published to npm yet (e.g. if a publish job failed or docs deployed before npm finished)
- Replaced with a shields.io badge that fetches the live published version from the npm registry at render time — always reflects what users can actually install
- Badge links directly to the npm package page instead of GitHub releases

## Test plan
- [ ] Badge renders correctly in navbar
- [ ] Badge links to `@midas-ds/components` on npm
- [ ] No regressions in navbar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)