### PR TITLE
fix(components,layout): add missing @react-aria and @react-stately dependencies

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,6 +42,9 @@
   },
   "dependencies": {
     "@midas-ds/theme": "3.14.1",
+    "@react-aria/focus": "^3.21.5",
+    "@react-stately/toggle": "^3.9.5",
+    "@react-stately/utils": "^3.11.0",
     "react-aria-components": "1.16.0"
   }
 }

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -37,6 +37,9 @@
     "./*": "./*/index.js"
   },
   "dependencies": {
-    "@midas-ds/components": "17.13.2"
+    "@midas-ds/components": "17.13.2",
+    "@react-aria/collections": "^3.0.3",
+    "@react-aria/utils": "^3.33.1",
+    "@react-stately/utils": "^3.11.0"
   }
 }


### PR DESCRIPTION
## Summary

- Installing `@midas-ds/components` or `@midas-ds/layout` in a fresh project caused a build error: `failed to resolve import "@react-stately/toggle"`
- The vite build config correctly externalizes all `@react-aria/*` and `@react-stately/*` sub-packages, but several were imported directly in source without being declared as `dependencies` — so consumers never had them installed
- Adds the missing packages to both `components` and `layout`

**components:** `@react-aria/focus`, `@react-stately/toggle`, `@react-stately/utils`
**layout:** `@react-aria/collections`, `@react-aria/utils`, `@react-stately/utils`

## Test plan
- [ ] Create a fresh Vite project, install `@midas-ds/components`, add a component, `vite build` passes
- [ ] Same for `@midas-ds/layout`