### PR TITLE
fix(docs): hide Storybook link for FileTrigger

### DIFF
--- a/apps/docs/docs/components/file-trigger.mdx
+++ b/apps/docs/docs/components/file-trigger.mdx
@@ -13,6 +13,7 @@ import { PropTable } from '@site/src/components/PropsTable'
   name='FileTrigger'
   friendlyName='Filuppladdning, filväljare'
   overrideHeadlessLink='https://react-spectrum.adobe.com/react-aria/FileTrigger.html'
+  hideStorybookLink
 />
 
 [FileTrigger](https://react-spectrum.adobe.com/react-aria/FileTrigger.html) från React Aria gör det möjligt för en användare

--- a/apps/docs/src/components/getComponentMetaData.tsx
+++ b/apps/docs/src/components/getComponentMetaData.tsx
@@ -9,11 +9,13 @@ export const ComponentHeader = ({
   friendlyName,
   overrideHeadlessLink,
   overrideHeadlessLinkTitle,
+  hideStorybookLink,
 }: {
   name: string
   friendlyName: string
   overrideHeadlessLink?: string
   overrideHeadlessLinkTitle?: string
+  hideStorybookLink?: boolean
 }) => {
   const baseUrl = useBaseUrl
   const componentPath = `?path=/docs/components-${name.toLowerCase()}--docs`
@@ -32,22 +34,24 @@ export const ComponentHeader = ({
         >
           <b>{friendlyName}</b>
         </GridItem>
-        <GridItem
-          size='auto'
-          className='headerLink'
-        >
-          <LinkButton
-            href={storybookLink}
-            variant='tertiary'
-            icon={EmptyIcon as any}
+        {!hideStorybookLink && (
+          <GridItem
+            size='auto'
+            className='headerLink'
           >
-            <StorybookIcon
-              size={24}
-              color='#FF4785'
-            />
-            Storybook
-          </LinkButton>
-        </GridItem>
+            <LinkButton
+              href={storybookLink}
+              variant='tertiary'
+              icon={EmptyIcon as any}
+            >
+              <StorybookIcon
+                size={24}
+                color='#FF4785'
+              />
+              Storybook
+            </LinkButton>
+          </GridItem>
+        )}
         <GridItem
           size='auto'
           className='headerLink'


### PR DESCRIPTION
## Summary

- `FileTrigger` is a direct re-export from React Aria with no Midas wrapper — there are no stories to link to
- Adds a `hideStorybookLink` prop to `ComponentHeader` for cases like this
- Uses it on the FileTrigger docs page

## Test plan

- [ ] Verify the Storybook link is gone from the FileTrigger docs page
- [ ] Verify all other component pages are unaffected