### PR TITLE
fix(docs): use exact pathname matching in NavigationLink examples

### DIFF
--- a/apps/docs/docs/dev/layout/components/navigation.mdx
+++ b/apps/docs/docs/dev/layout/components/navigation.mdx
@@ -16,13 +16,15 @@ import { Navigation, NavigationItem, NavigationLink } from '@midas-ds/layout'
 import { House, Settings } from 'lucide-react'
 
 export default function App() {
+  const pathname = usePathname() // or equivalent for your router
+
   return (
     <Navigation>
       <NavigationItem>
         <NavigationLink
           href='/'
           icon={<House />}
-          isActive
+          isActive={pathname === '/'}
         >
           Hem
         </NavigationLink>
@@ -31,6 +33,7 @@ export default function App() {
         <NavigationLink
           href='/installningar'
           icon={<Settings />}
+          isActive={pathname === '/installningar'}
         >
           Inställningar
         </NavigationLink>

--- a/apps/docs/docs/dev/layout/components/sidebar.mdx
+++ b/apps/docs/docs/dev/layout/components/sidebar.mdx
@@ -14,6 +14,8 @@ import { Sidebar, Navigation, NavigationItem, NavigationLink } from '@midas-ds/l
 import { House, Settings } from 'lucide-react'
 
 export default function App() {
+  const pathname = usePathname() // or equivalent for your router
+
   return (
     <Sidebar title='Min applikation'>
       <Navigation>
@@ -21,7 +23,7 @@ export default function App() {
           <NavigationLink
             href='/'
             icon={<House />}
-            isActive
+            isActive={pathname === '/'}
           >
             Hem
           </NavigationLink>
@@ -30,6 +32,7 @@ export default function App() {
           <NavigationLink
             href='/installningar'
             icon={<Settings />}
+            isActive={pathname === '/installningar'}
           >
             Inställningar
           </NavigationLink>


### PR DESCRIPTION
## Summary

- Both `navigation.mdx` and `sidebar.mdx` showed `isActive` hardcoded on the root `/` link
- This caused the root link to always appear selected regardless of current route
- Updated examples to use `isActive={pathname === '/'}` and show the same pattern consistently for all links

## Test plan

- [ ] Verify docs examples now show correct `isActive` usage