### PR TITLE
fix(components,select): import TagList from midas instead of react-aria-components

### DIFF
--- a/packages/components/src/select/SelectTags.tsx
+++ b/packages/components/src/select/SelectTags.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
-import { type Key, SelectStateContext, TagList } from 'react-aria-components'
-import { Tag, TagGroup } from '../tag'
+import { type Key, SelectStateContext } from 'react-aria-components'
+import { Tag, TagGroup, TagList } from '../tag'
 import { useLocalizedStringFormatter } from '../utils/intl'
 import { MidasSelectProps } from './'
 import messages from './intl/translations.json'


### PR DESCRIPTION
## Summary

- `SelectTags` was importing `TagList` directly from `react-aria-components` instead of our Midas wrapper
- `TagGroup`'s deprecation check uses reference equality (`child.type === TagList`) against our own `TagList` — so the check always failed, firing a false positive deprecation warning for any `Select` with `showTags`
- As a side effect, `TagGroup` was also double-wrapping: it didn't detect the provided `TagList` and wrapped children in another one

## Fix

Import `TagList` from `../tag` (our Midas wrapper) so the identity check passes correctly and the correct CSS styling is applied.

## Test plan

- [ ] `nx test components -- select/Select.spec` passes
- [ ] `Select` with `showTags` and `selectionMode='multiple'` no longer logs deprecation warning in dev