### PR TITLE
fix(theme): swap icon and icon-sm size token values

### DIFF
--- a/packages/components/src/checkbox/Checkbox.module.css
+++ b/packages/components/src/checkbox/Checkbox.module.css
@@ -2,8 +2,8 @@
   --border-color: var(--midas-border-color-primary);
 
   display: flex;
-  width: var(--midas-size-icon);
-  height: var(--midas-size-icon);
+  width: var(--midas-size-icon-sm);
+  height: var(--midas-size-icon-sm);
   box-sizing: border-box;
   border: 1px solid var(--border-color);
   transition:

--- a/packages/components/src/combobox/ComboBox.module.css
+++ b/packages/components/src/combobox/ComboBox.module.css
@@ -12,7 +12,7 @@
   box-sizing: border-box;
   width: -webkit-fill-available;
   padding-left: var(--midas-space-medium);
-  padding-right: calc(var(--midas-size-icon-sm) + 2 * var(--midas-space-70));
+  padding-right: calc(var(--midas-size-icon) + 2 * var(--midas-space-70));
   border: none;
   border-bottom: 1px solid var(--midas-border-color-primary);
   border-radius: 0;

--- a/packages/components/src/list-box/ListBox.module.css
+++ b/packages/components/src/list-box/ListBox.module.css
@@ -117,10 +117,10 @@
       &::after {
         content: '';
         background-color: var(--midas-text-primary);
-        width: var(--midas-size-icon);
-        height: var(--midas-size-icon);
+        width: var(--midas-size-icon-sm);
+        height: var(--midas-size-icon-sm);
         mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrLWljb24gbHVjaWRlLWNoZWNrIj48cGF0aCBkPSJNMjAgNiA5IDE3bC01LTUiLz48L3N2Zz4=');
-        mask-size: var(--midas-size-icon) var(--midas-size-icon);
+        mask-size: var(--midas-size-icon-sm) var(--midas-size-icon-sm);
         flex-shrink: 0;
 
         @media (forced-colors: active) {
@@ -139,14 +139,14 @@
       box-sizing: border-box;
       content: '';
       border: 1px solid var(--midas-border-color-primary);
-      min-width: var(--midas-size-icon);
-      height: var(--midas-size-icon);
+      min-width: var(--midas-size-icon-sm);
+      height: var(--midas-size-icon-sm);
     }
 
     &[data-selected] {
       &::before {
-        min-width: var(--midas-size-icon);
-        min-height: var(--midas-size-icon);
+        min-width: var(--midas-size-icon-sm);
+        min-height: var(--midas-size-icon-sm);
         background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1jaGVjay1pY29uIGx1Y2lkZS1jaGVjayI+PHBhdGggZD0iTTIwIDYgOSAxN2wtNS01Ii8+PC9zdmc+');
         background-size: contain;
         background-color: var(--midas-button-background-primary-base);

--- a/packages/components/src/skeleton/Skeleton.module.css
+++ b/packages/components/src/skeleton/Skeleton.module.css
@@ -62,7 +62,7 @@
 }
 
 .formLabel {
-  height: var(--midas-size-icon-sm); /* ~20px - typical label height */
+  height: var(--midas-typography-line-height-30);
   width: 40%;
   margin-bottom: var(--midas-space-xsmall);
 }

--- a/packages/components/src/tag/Tag.module.css
+++ b/packages/components/src/tag/Tag.module.css
@@ -96,8 +96,8 @@
   min-height: 1.875rem;
 
   svg {
-    width: var(--midas-size-icon-sm);
-    height: var(--midas-size-icon-sm);
+    width: var(--midas-size-icon);
+    height: var(--midas-size-icon);
   }
 }
 

--- a/packages/select-styles/src/lib/react-select.css
+++ b/packages/select-styles/src/lib/react-select.css
@@ -106,10 +106,10 @@
     &::after {
       content: '';
       background-color: var(--midas-text-primary);
-      width: var(--midas-size-icon-sm);
-      height: var(--midas-size-icon-sm);
+      width: var(--midas-size-icon);
+      height: var(--midas-size-icon);
       mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXgtaWNvbiBsdWNpZGUteCI+PHBhdGggZD0iTTE4IDYgNiAxOCIvPjxwYXRoIGQ9Im02IDYgMTIgMTIiLz48L3N2Zz4=');
-      mask-size: var(--midas-size-icon-sm) var(--midas-size-icon-sm);
+      mask-size: var(--midas-size-icon) var(--midas-size-icon);
       flex-shrink: 0;
 
       @media (forced-colors: active) {
@@ -142,10 +142,10 @@
     &::after {
       content: '';
       background-color: var(--midas-text-primary);
-      width: var(--midas-size-icon-sm);
-      height: var(--midas-size-icon-sm);
+      width: var(--midas-size-icon);
+      height: var(--midas-size-icon);
       mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXgtaWNvbiBsdWNpZGUteCI+PHBhdGggZD0iTTE4IDYgNiAxOCIvPjxwYXRoIGQ9Im02IDYgMTIgMTIiLz48L3N2Zz4=');
-      mask-size: var(--midas-size-icon-sm) var(--midas-size-icon-sm);
+      mask-size: var(--midas-size-icon) var(--midas-size-icon);
       flex-shrink: 0;
 
       @media (forced-colors: active) {
@@ -172,10 +172,10 @@
     &::after {
       content: '';
       background-color: var(--midas-text-primary);
-      width: var(--midas-size-icon-sm);
-      height: var(--midas-size-icon-sm);
+      width: var(--midas-size-icon);
+      height: var(--midas-size-icon);
       mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZXZyb24tZG93bi1pY29uIGx1Y2lkZS1jaGV2cm9uLWRvd24iPjxwYXRoIGQ9Im02IDkgNiA2IDYtNiIvPjwvc3ZnPg==');
-      mask-size: var(--midas-size-icon-sm) var(--midas-size-icon-sm);
+      mask-size: var(--midas-size-icon) var(--midas-size-icon);
       flex-shrink: 0;
       transition: transform var(--midas-transition-duration-normal) ease;
 
@@ -246,10 +246,10 @@
       &::after {
         content: '';
         background-color: var(--midas-text-primary);
-        width: var(--midas-size-icon);
-        height: var(--midas-size-icon);
+        width: var(--midas-size-icon-sm);
+        height: var(--midas-size-icon-sm);
         mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrLWljb24gbHVjaWRlLWNoZWNrIj48cGF0aCBkPSJNMjAgNiA5IDE3bC01LTUiLz48L3N2Zz4=');
-        mask-size: var(--midas-size-icon) var(--midas-size-icon);
+        mask-size: var(--midas-size-icon-sm) var(--midas-size-icon-sm);
         flex-shrink: 0;
 
         @media (forced-colors: active) {
@@ -270,15 +270,15 @@
         box-sizing: border-box;
         content: '';
         border: 1px solid var(--midas-border-color-primary);
-        min-width: var(--midas-size-icon);
-        height: var(--midas-size-icon);
+        min-width: var(--midas-size-icon-sm);
+        height: var(--midas-size-icon-sm);
       }
     }
 
     .midas__option--is-selected {
       &::before {
-        min-width: var(--midas-size-icon);
-        min-height: var(--midas-size-icon);
+        min-width: var(--midas-size-icon-sm);
+        min-height: var(--midas-size-icon-sm);
         background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0ibHVjaWRlIGx1Y2lkZS1jaGVjay1pY29uIGx1Y2lkZS1jaGVjayI+PHBhdGggZD0iTTIwIDYgOSAxN2wtNS01Ii8+PC9zdmc+');
         background-size: contain;
         background-color: var(--midas-button-background-primary-base);

--- a/packages/theme/tokens/size.json
+++ b/packages/theme/tokens/size.json
@@ -3,12 +3,12 @@
     "$description": "Storlekstokens för bredd och höjd på interaktiva element och ikoner. Används för width/height, inte för spacing.",
     "$type": "dimension",
     "icon": {
-      "$value": "{base.80}",
-      "$description": "Standardstorlek för ikoner. 1rem / 16px."
+      "$value": "{base.90}",
+      "$description": "Standardstorlek för ikoner. 1.25rem / 20px."
     },
     "icon-sm": {
-      "$value": "{base.90}",
-      "$description": "Liten ikonstorlek. 1.25rem / 20px."
+      "$value": "{base.80}",
+      "$description": "Liten ikonstorlek för kompakta kontexter. 1rem / 16px."
     },
     "option": {
       "$value": "{base.120}",


### PR DESCRIPTION
## Background

`size.icon-sm` was resolving to `1.25rem / 20px` and `size.icon` to `1rem / 16px` — the values were swapped. The token names implied the opposite relationship.

## Changes

**`packages/theme`**
- `size.icon`: `{base.80}` → `{base.90}` (1rem → 1.25rem / 16px → 20px)
- `size.icon-sm`: `{base.90}` → `{base.80}` (1.25rem → 1rem / 20px → 16px)
- Updated `$description` on both tokens

**No visual change** — all consumer CSS has been updated to reference the semantically correct token name for the same pixel value.

## Affected components

| Component | File | Change |
|-----------|------|--------|
| **Checkbox** | `Checkbox.module.css` | Checkbox box: `icon` → `icon-sm` (16px) |
| **ComboBox** | `ComboBox.module.css` | Input padding for chevron button: `icon-sm` → `icon` (20px) |
| **ListBox** | `ListBox.module.css` | Single-select checkmark + multi-select checkbox boxes: `icon` → `icon-sm` (16px) |
| **Skeleton** | `Skeleton.module.css` | Form label height: was `icon-sm` (wrong token type entirely), now `--midas-typography-line-height-30` (1.25rem / 20px) |
| **Tag** | `Tag.module.css` | SVG icon: `icon-sm` → `icon` (20px) |
| **Select** | `react-select.css` | Chevron/X indicators: `icon-sm` → `icon` (20px); single-select checkmark + multi-select boxes: `icon` → `icon-sm` (16px) |

## Test plan

- [ ] Checkbox renders at correct size visually
- [ ] ComboBox dropdown button does not overlap input text
- [ ] ListBox single/multi-select indicators look correct
- [ ] Skeleton form label height matches actual label text
- [ ] Tag icon renders correctly
- [ ] Select (react-select) indicators and checkmarks render correctly