### PR TITLE
fix(components,card): prevent CardBody margin-bottom from collapsing out of card

### DIFF
--- a/packages/components/src/card/Card.module.css
+++ b/packages/components/src/card/Card.module.css
@@ -1,6 +1,7 @@
 .card {
   font-family: var(--midas-typography-font-family);
   position: relative;
+  display: flow-root;
   background-color: var(--midas-card-background-base);
   box-shadow: var(--midas-card-shadow);
 


### PR DESCRIPTION
## Problem

When `CardBody` is the last child of `Card` (no `CardActions` after it), the `margin-bottom` on `.cardBody` collapses out of the card due to CSS margin collapsing. The card has no `padding-bottom`, `border-bottom`, or block formatting context to contain it, so the margin escapes to the outside — leaving zero bottom spacing inside the card.

Cards with `CardActions` were unaffected since `CardActions` uses `padding-bottom` (which never collapses).

## Fix

Added `display: flow-root` to `.card`. This establishes a block formatting context, which prevents child margins from collapsing through the card boundary. One line, no side effects, browser support is universal (Chrome 58+, Firefox 53+, Safari 13+, Edge 79+).

## Affected components

| Component | Impact |
|-----------|--------|
| **Card** | Bottom padding now correctly visible when `CardBody` is the last child |

## Test plan

- [x] `WithCustomBody` story — card bottom should now have correct spacing (was flush/missing before)
- [x] `Example` / `WithHeaderAndBody` stories — no regression, bottom spacing unchanged
- [x] `WithHeaderImageAndBody` / `WithImageHeaderAndBody` — card image still bleeds to edges correctly