### PR TITLE
fix(components,layout): badge pattern docs + sidebar transition fix

### DIFF
--- a/apps/docs/docs/dev/layout/components/header.mdx
+++ b/apps/docs/docs/dev/layout/components/header.mdx
@@ -3,6 +3,15 @@ title: Header
 description: Sidhuvud med stöd för logotyp, åtgärdsknappar och mobilmeny.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+
+<ComponentHeader
+  name='Header'
+  friendlyName='Sidhuvud, Applikationshuvud'
+  overrideStorybookPath='?path=/docs/layout-header--docs'
+  overrideHeadlessLink=''
+/>
+
 # Header
 
 Sidhuvudet innehåller logotypen och plats för åtgärdsknappar. På mobil används `MobileMenu` för att visa navigationen som ett drawer-mönster.

--- a/apps/docs/docs/dev/layout/components/layout.mdx
+++ b/apps/docs/docs/dev/layout/components/layout.mdx
@@ -3,6 +3,15 @@ title: Layout, LayoutContent & Main
 description: Grundläggande strukturkomponenter för sidor.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+
+<ComponentHeader
+  name='Layout'
+  friendlyName='Sidlayout, Grundstruktur'
+  overrideStorybookPath='?path=/docs/layout-layout--docs'
+  overrideHeadlessLink=''
+/>
+
 # Layout, LayoutContent & Main
 
 Dessa tre komponenter utgör grundstommen i en sida.

--- a/apps/docs/docs/dev/layout/components/navbar.mdx
+++ b/apps/docs/docs/dev/layout/components/navbar.mdx
@@ -3,6 +3,15 @@ title: Navbar
 description: Navigationsbar längst ned på sidan för mobila enheter.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+
+<ComponentHeader
+  name='Navbar'
+  friendlyName='Navigationsbar, Mobilnavigering'
+  overrideStorybookPath='?path=/docs/layout-navbar--docs'
+  overrideHeadlessLink=''
+/>
+
 # Navbar
 
 En navigationsbar längst ned på sidan, primärt avsedd för mobilanvändare. Håll antalet länkar till 3–5 för att undvika trängsel på små skärmar.

--- a/apps/docs/docs/dev/layout/components/navigation.mdx
+++ b/apps/docs/docs/dev/layout/components/navigation.mdx
@@ -3,6 +3,16 @@ title: Navigation
 description: Navigationskomponenter för sidomeny och navbar.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+import { NavigationBadgeExample } from '@site/src/components/examples/layout/NavigationExamples'
+
+<ComponentHeader
+  name='NavigationLink'
+  friendlyName='Sidolänk, Navlänk'
+  overrideStorybookPath='?path=/docs/layout-navigation-navigationlink--docs'
+  overrideHeadlessLink=''
+/>
+
 # Navigation
 
 Navigationskomponenterna används både i `Sidebar` och i `Navbar`. De är identiska — kontexten avgör utseendet.
@@ -67,6 +77,32 @@ En enskild länk med ikon, etikett och aktivt läge. Anpassar sig automatiskt ef
 | `href`       | `string`      | —        | URL (standard)                                                     |
 | `as`         | `ElementType` | —        | Ersättningskomponent (t.ex. Next.js `Link`)                        |
 | `aria-label` | `string`      | —        | Krävs om `children` inte är ren text                               |
+
+### Notisindikator (Badge)
+
+Skicka in `BadgeContainer` som `icon`-prop för att visa en notisindikator på länken.
+
+<NavigationBadgeExample />
+
+```tsx
+import { Badge, BadgeContainer } from '@midas-ds/components'
+import { Bell } from 'lucide-react'
+
+<NavigationItem>
+  <NavigationLink
+    href='/meddelanden'
+    icon={
+      <BadgeContainer>
+        <Bell />
+        <Badge>12</Badge>
+      </BadgeContainer>
+    }
+    isActive={pathname === '/meddelanden'}
+  >
+    Meddelanden
+  </NavigationLink>
+</NavigationItem>
+```
 
 ## NavigationSection
 

--- a/apps/docs/docs/dev/layout/components/panel.mdx
+++ b/apps/docs/docs/dev/layout/components/panel.mdx
@@ -3,6 +3,15 @@ title: Panel
 description: Animerad sidopanel för att visa extra innehåll bredvid huvudinnehållet.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+
+<ComponentHeader
+  name='Panel'
+  friendlyName='Sidopanel, Detaljpanel'
+  overrideStorybookPath='?path=/docs/layout-panel--docs'
+  overrideHeadlessLink=''
+/>
+
 # Panel
 
 En animerad sidopanel som visas bredvid `Main` i `LayoutContent`. Vanlig användning är för detaljvyer, formulär eller annan kontextuell information.

--- a/apps/docs/docs/dev/layout/components/sidebar.mdx
+++ b/apps/docs/docs/dev/layout/components/sidebar.mdx
@@ -3,6 +3,15 @@ title: Sidebar
 description: Kollapsbar sidomeny för desktop.
 ---
 
+import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+
+<ComponentHeader
+  name='Sidebar'
+  friendlyName='Sidomeny, Kollapsbar meny'
+  overrideStorybookPath='?path=/docs/layout-sidebar--docs'
+  overrideHeadlessLink=''
+/>
+
 # Sidebar
 
 En kollapsbar sidomeny som visas på desktop. På mobil döljs den automatiskt — använd `MobileMenu` i `Header` för mobilnavigering.

--- a/apps/docs/src/components/examples/layout/NavigationExamples.tsx
+++ b/apps/docs/src/components/examples/layout/NavigationExamples.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { NavigationItem, NavigationLink, SidebarContext } from '@midas-ds/layout'
+import { Badge, BadgeContainer } from '@midas-ds/components'
+import { Bell } from 'lucide-react'
+
+export const NavigationBadgeExample: React.FC = () => (
+  <div className='card'>
+    <div style={{ width: 240 }}>
+      <SidebarContext.Provider value={{ isCollapsed: false }}>
+        <NavigationItem>
+          <NavigationLink
+            icon={
+              <BadgeContainer>
+                <Bell />
+                <Badge>12</Badge>
+              </BadgeContainer>
+            }
+          >
+            Meddelanden
+          </NavigationLink>
+        </NavigationItem>
+      </SidebarContext.Provider>
+    </div>
+  </div>
+)

--- a/apps/docs/src/components/getComponentMetaData.tsx
+++ b/apps/docs/src/components/getComponentMetaData.tsx
@@ -10,15 +10,17 @@ export const ComponentHeader = ({
   overrideHeadlessLink,
   overrideHeadlessLinkTitle,
   hideStorybookLink,
+  overrideStorybookPath,
 }: {
   name: string
   friendlyName: string
   overrideHeadlessLink?: string
   overrideHeadlessLinkTitle?: string
   hideStorybookLink?: boolean
+  overrideStorybookPath?: string
 }) => {
   const baseUrl = useBaseUrl
-  const componentPath = `?path=/docs/components-${name.toLowerCase()}--docs`
+  const componentPath = overrideStorybookPath ?? `?path=/docs/components-${name.toLowerCase()}--docs`
   const storybookHost =
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:4400'

--- a/packages/components/src/badge/Badge.module.css
+++ b/packages/components/src/badge/Badge.module.css
@@ -18,6 +18,7 @@
 
 .badgeContainer {
   display: flex;
+  min-width: 0;
   position: relative;
 
   .badge {

--- a/packages/components/src/badge/Badge.tsx
+++ b/packages/components/src/badge/Badge.tsx
@@ -11,6 +11,7 @@ export const Badge: React.FC<React.HTMLAttributes<HTMLSpanElement>> = ({
 
   return (
     <span
+      data-badge
       className={clsx(
         styles.badge,
         hasChildren && styles.hasChildren,

--- a/packages/layout/src/navigation/navigation-link/NavigationLink.stories.tsx
+++ b/packages/layout/src/navigation/navigation-link/NavigationLink.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { NavigationLink } from '.'
-import { House } from 'lucide-react'
+import { Bell, House } from 'lucide-react'
 import { SidebarContext } from '../../sidebar'
+import { Badge, BadgeContainer } from '@midas-ds/components'
 
 type Story = StoryObj<typeof NavigationLink>
 
@@ -29,6 +30,64 @@ export const Collapsed: Story = {
   render: args => (
     <SidebarContext.Provider value={{ isCollapsed: true }}>
       <NavigationLink {...args} />
+    </SidebarContext.Provider>
+  ),
+}
+
+export const WithBadge: Story = {
+  args: {
+    children: 'Meddelanden',
+    href: '/meddelanden',
+    icon: (
+      <BadgeContainer>
+        <Bell />
+        <Badge />
+      </BadgeContainer>
+    ),
+  },
+}
+
+export const WithBadgeLabel: Story = {
+  args: {
+    children: 'Meddelanden',
+    href: '/meddelanden',
+    icon: (
+      <BadgeContainer>
+        <Bell />
+        <Badge>12</Badge>
+      </BadgeContainer>
+    ),
+  },
+}
+
+export const WithBadgeActive: Story = {
+  args: {
+    children: 'Meddelanden',
+    href: '/meddelanden',
+    isActive: true,
+    icon: (
+      <BadgeContainer>
+        <Bell />
+        <Badge>12</Badge>
+      </BadgeContainer>
+    ),
+  },
+}
+
+export const WithBadgeCollapsed: Story = {
+  render: args => (
+    <SidebarContext.Provider value={{ isCollapsed: true }}>
+      <NavigationLink
+        {...args}
+        icon={
+          <BadgeContainer>
+            <Bell />
+            <Badge>12</Badge>
+          </BadgeContainer>
+        }
+      >
+        Meddelanden
+      </NavigationLink>
     </SidebarContext.Provider>
   ),
 }

--- a/packages/layout/src/sidebar/Sidebar.module.css
+++ b/packages/layout/src/sidebar/Sidebar.module.css
@@ -49,3 +49,20 @@
 .sidebarContent {
   padding: var(--midas-space-small);
 }
+
+.sidebar[data-transitioning] :global([data-badge]) {
+  opacity: 0;
+  transition: none;
+}
+
+.sidebar :global([data-badge]) {
+  transition: opacity var(--midas-transition-duration-normal) ease
+    var(--midas-transition-duration-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar[data-transitioning] :global([data-badge]),
+  .sidebar :global([data-badge]) {
+    transition: none;
+  }
+}

--- a/packages/layout/src/sidebar/Sidebar.stories.tsx
+++ b/packages/layout/src/sidebar/Sidebar.stories.tsx
@@ -1,8 +1,10 @@
 import { composeStories, type Meta, type StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
-import { Button } from '@midas-ds/components'
+import { Badge, BadgeContainer, Button } from '@midas-ds/components'
 import { Sidebar } from './Sidebar'
 import * as navigationStories from '../navigation/Navigation.stories'
+import { Navigation, NavigationItem, NavigationLink, NavigationSection } from '../navigation'
+import { Bell, FileText, House, Settings } from 'lucide-react'
 
 type Story = StoryObj<typeof Sidebar>
 
@@ -28,6 +30,103 @@ export const Collapsed: Story = {
   args: {
     defaultCollapsed: true,
   },
+}
+
+export const WithBadge: Story = {
+  render: args => (
+    <Sidebar
+      {...args}
+      title='My app'
+    >
+      <Navigation>
+        <NavigationSection>
+          <NavigationItem>
+            <NavigationLink
+              href='/'
+              icon={<House />}
+              isActive
+            >
+              Hem
+            </NavigationLink>
+          </NavigationItem>
+          <NavigationItem>
+            <NavigationLink
+              href='/arenden'
+              icon={<FileText />}
+            >
+              Ärenden
+            </NavigationLink>
+          </NavigationItem>
+          <NavigationItem>
+            <NavigationLink
+              href='/meddelanden'
+              icon={
+                <BadgeContainer>
+                  <Bell />
+                  <Badge>12</Badge>
+                </BadgeContainer>
+              }
+            >
+              Meddelanden
+            </NavigationLink>
+          </NavigationItem>
+          <NavigationItem>
+            <NavigationLink
+              href='/installningar'
+              icon={<Settings />}
+            >
+              Inställningar
+            </NavigationLink>
+          </NavigationItem>
+        </NavigationSection>
+      </Navigation>
+    </Sidebar>
+  ),
+}
+
+export const WithBadgeCollapsed: Story = {
+  args: { defaultCollapsed: true },
+  render: args => (
+    <Sidebar
+      {...args}
+      title='My app'
+    >
+      <Navigation>
+        <NavigationSection>
+          <NavigationItem>
+            <NavigationLink
+              href='/'
+              icon={<House />}
+              isActive
+            >
+              Hem
+            </NavigationLink>
+          </NavigationItem>
+          <NavigationItem>
+            <NavigationLink
+              href='/meddelanden'
+              icon={
+                <BadgeContainer>
+                  <Bell />
+                  <Badge>12</Badge>
+                </BadgeContainer>
+              }
+            >
+              Meddelanden
+            </NavigationLink>
+          </NavigationItem>
+          <NavigationItem>
+            <NavigationLink
+              href='/installningar'
+              icon={<Settings />}
+            >
+              Inställningar
+            </NavigationLink>
+          </NavigationItem>
+        </NavigationSection>
+      </Navigation>
+    </Sidebar>
+  ),
 }
 
 export const Controlled: Story = {

--- a/packages/layout/src/sidebar/Sidebar.tsx
+++ b/packages/layout/src/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import clsx from 'clsx'
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { Button, useLocalizedStringFormatter } from '@midas-ds/components'
@@ -41,8 +42,18 @@ export const Sidebar = ({
     props.onCollapseChange,
   )
 
-  const handlePress = () =>
+  const [isTransitioning, setIsTransitioning] = React.useState(false)
+
+  const handlePress = () => {
+    setIsTransitioning(true)
     setIsCollapsed(previouslyCollapsed => !previouslyCollapsed)
+  }
+
+  const handleTransitionEnd = (e: React.TransitionEvent<HTMLElement>) => {
+    if (e.propertyName === 'width' && e.target === e.currentTarget) {
+      setIsTransitioning(false)
+    }
+  }
 
   return isMobileDevice ? null : (
     <SidebarContext.Provider value={{ isCollapsed }}>
@@ -50,6 +61,8 @@ export const Sidebar = ({
         className={clsx(className, styles.sidebar, {
           [styles.collapsed]: isCollapsed,
         })}
+        data-transitioning={isTransitioning || undefined}
+        onTransitionEnd={handleTransitionEnd}
         {...filterDOMProps(props)}
       >
         <PanelHeader


### PR DESCRIPTION
## Background

Users reported the sidebar shrinking when using `BadgeContainer` with `NavigationLink`. Root cause: the Badge docs template (`Button > BadgeContainer > icon + Badge`) doesn't map cleanly to `NavigationLink`, which has a dedicated `icon` prop. Users were wrapping the entire link with `BadgeContainer`, introducing an unintended flex context.

## Changes

**Bug fixes**
- `BadgeContainer` — added `min-width: 0` to prevent flex layout issues when used as a flex item
- `Badge` — added `data-badge` attribute for targeted CSS hooks
- `Sidebar` — tracks transition state on button press, sets `data-transitioning` while sidebar width animates; badge hides instantly and fades back in after the transition (respects `prefers-reduced-motion`)

**Storybook**
- `NavigationLink.stories` — 4 new stories: `WithBadge`, `WithBadgeLabel`, `WithBadgeActive`, `WithBadgeCollapsed`
- `Sidebar.stories` — 2 new composite stories: `WithBadge`, `WithBadgeCollapsed`

**Docs**
- `getComponentMetaData` — added `overrideStorybookPath` prop to `ComponentHeader` for layout package support
- `navigation.mdx` — correct badge pattern, live example, complete copy-pasteable snippet
- `header`, `sidebar`, `navbar`, `panel`, `layout` mdx — all now have Storybook links via `ComponentHeader`
- `NavigationExamples.tsx` — new live example component

## Test plan

- [ ] Badge visible and correctly positioned in `Sidebar.WithBadge` story
- [ ] Badge doesn't visually move during sidebar collapse/expand in `Sidebar.WithBadgeCollapsed`
- [ ] Badge fades in smoothly after transition, no abrupt blink
- [ ] `prefers-reduced-motion` — badge snaps without fade
- [ ] Docs navigation page shows correct live example and Storybook link
- [ ] All layout doc pages show Storybook link in header