### PR TITLE
fix(layout,panel): panel polish

### DIFF
--- a/apps/docs/docs/dev/layout/components/panel.mdx
+++ b/apps/docs/docs/dev/layout/components/panel.mdx
@@ -4,6 +4,7 @@ description: Animerad sidopanel för att visa extra innehåll bredvid huvudinneh
 ---
 
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+import { PropTable } from '@site/src/components/PropsTable'
 
 <ComponentHeader
   name='Panel'
@@ -97,7 +98,14 @@ function App() {
 När du har flera paneler som kan öppnas och stängas oberoende av varandra, använd `PanelProvider` och `usePanels`-hooken.
 
 ```tsx
-import { Layout, LayoutContent, Main, PanelProvider, PanelRegion, usePanels } from '@midas-ds/layout'
+import {
+  Layout,
+  LayoutContent,
+  Main,
+  PanelProvider,
+  PanelRegion,
+  usePanels,
+} from '@midas-ds/layout'
 import { Button } from '@midas-ds/components'
 
 function PanelControls() {
@@ -105,15 +113,19 @@ function PanelControls() {
 
   return (
     <>
-      <Button onPress={() => addPanel({ id: 'panel-a', title: 'Panel A' })}>Öppna Panel A</Button>
-      <Button onPress={() => addPanel({ id: 'panel-b', title: 'Panel B' })}>Öppna Panel B</Button>
+      <Button onPress={() => addPanel({ id: 'panel-a', title: 'Panel A' })}>
+        Öppna Panel A
+      </Button>
+      <Button onPress={() => addPanel({ id: 'panel-b', title: 'Panel B' })}>
+        Öppna Panel B
+      </Button>
     </>
   )
 }
 
 function App() {
   return (
-    <PanelProvider panelBehavior='bring-to-front'>
+    <PanelProvider>
       <Layout>
         <LayoutContent>
           <Main>
@@ -127,16 +139,91 @@ function App() {
 }
 ```
 
-### panelBehavior
+`replace` är standard och rekommenderas för de flesta fall. I applikationer där flera paneler ska kunna leva parallellt kan `panelBehavior` sättas till `bring-to-front` eller `pop-to` för att styra hur panelerna hanteras när de aktiveras.
 
-Styr vad som händer när man öppnar en panel som redan är öppen:
+```tsx
+<PanelProvider panelBehavior='bring-to-front'> {/* replace | bring-to-front | pop-to */}
+```
 
-| Värde                       | Beteende                                        |
-| --------------------------- | ----------------------------------------------- |
-| `bring-to-front` (standard) | Panelen flyttas framåt i ordningen              |
-| `pop-to`                    | Alla paneler ovanför stängs, den klickade visas |
+## Detaljvy — byta innehåll utan animation
 
-## usePanels
+Använd ett stabilt `id` när du anropar `addPanel` för att uppdatera panelinnehållet på plats utan att animera om. React känner igen id:t och uppdaterar titel och innehåll direkt.
+
+```tsx
+import {
+  Layout,
+  LayoutContent,
+  Main,
+  PanelProvider,
+  PanelRegion,
+  usePanels,
+} from '@midas-ds/layout'
+
+const items = [
+  { id: '1', name: 'Ansökan #1042', status: 'Inlämnad' },
+  { id: '2', name: 'Ansökan #1043', status: 'Under granskning' },
+  { id: '3', name: 'Ansökan #1044', status: 'Beviljad' },
+]
+
+function ItemList() {
+  const { addPanel } = usePanels()
+
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          <button
+            onClick={() =>
+              addPanel({
+                id: 'detail',       // same id every time → no re-animation
+                title: item.name,
+                children: <p>Status: {item.status}</p>,
+              })
+            }
+          >
+            {item.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function App() {
+  return (
+    <PanelProvider panelBehavior='replace'>
+      <Layout>
+        <LayoutContent>
+          <Main>
+            <ItemList />
+          </Main>
+          <PanelRegion />
+        </LayoutContent>
+      </Layout>
+    </PanelProvider>
+  )
+}
+```
+
+:::tip
+
+Använd **`id: 'detail'`** (stabilt) — inte **`id: item.id`** (unikt per rad). Med ett unikt id monteras panelen om för varje val och animeringen spelas upp på nytt.
+
+Se storyn **DetailView** i Storybook för ett fullständigt exempel.
+
+:::
+
+## API
+
+### Panel
+
+<PropTable name='Panel' />
+
+### PanelProvider
+
+<PropTable name='PanelProvider' />
+
+### usePanels
 
 Hook för att komma åt `PanelContext` och hantera panelernas tillstånd programmatiskt.
 
@@ -144,48 +231,4 @@ Hook för att komma åt `PanelContext` och hantera panelernas tillstånd program
 const { panels, addPanel, closePanel, removePanel } = usePanels()
 ```
 
-| Metod             | Beskrivning                                  |
-| ----------------- | -------------------------------------------- |
-| `addPanel(panel)` | Öppnar eller aktiverar en panel              |
-| `closePanel(id)`  | Stänger en panel (animeras ut)               |
-| `removePanel(id)` | Tar permanent bort en panel från tillståndet |
-
-## Props — Panel
-
-| Prop           | Typ                         | Standard | Beskrivning                    |
-| -------------- | --------------------------- | -------- | ------------------------------ |
-| `id`           | `string`                    | —        | **Obligatorisk.** Unikt id     |
-| `title`        | `string`                    | —        | Panelrubrik                    |
-| `actions`      | `ReactNode`                 | —        | Egna åtgärder i headern        |
-| `isOpen`       | `boolean`                   | —        | Kontrollerat öppet-läge        |
-| `defaultOpen`  | `boolean`                   | —        | Okontrollerat starttillstånd   |
-| `onOpenChange` | `(isOpen: boolean) => void` | —        | Callback vid öppning/stängning |
-
-## Props — PanelProvider
-
-| Prop            | Typ                                          | Standard    | Beskrivning                                                                 |
-| --------------- | -------------------------------------------- | ----------- | --------------------------------------------------------------------------- |
-| `panelBehavior` | `'replace' \| 'bring-to-front' \| 'pop-to'` | `'replace'` | Beteende när en panel öppnas                                                |
-| `panelVariant`  | `'overlay' \| 'push'`                        | `'overlay'` | Hur panelen visas i förhållande till huvudinnehållet                        |
-| `defaultPanels` | `PanelItem[]`                                | —           | Förhandsöppnade paneler                                                     |
-
-### panelBehavior
-
-| Värde             | Beteende                                                                         |
-| ----------------- | -------------------------------------------------------------------------------- |
-| `replace`         | Ny panel ersätter alla befintliga. Rekommenderas för de flesta användningsfall.  |
-| `bring-to-front`  | Paneler staplas. Öppnar man en befintlig panel flyttas den framåt i ordningen.   |
-| `pop-to`          | Öppnar man en befintlig panel stängs alla paneler ovanför den.                   |
-
-:::info
-
-Det rekommenderas att visa en panel åt gången. Standardvärdet `replace` speglar detta. `bring-to-front` och `pop-to` finns tillgängliga för situationer där flera paneler är välmotiverade.
-
-:::
-
-### panelVariant
-
-| Värde     | Beteende                                                                                    |
-| --------- | ------------------------------------------------------------------------------------------- |
-| `overlay` | Panelen lägger sig ovanpå huvudinnehållet utan att påverka dess bredd.                      |
-| `push`    | Panelen skjuter undan huvudinnehållet och minskar dess tillgängliga bredd.                  |
+<PropTable name='usePanels' />

--- a/apps/docs/docs/dev/layout/components/panel.mdx
+++ b/apps/docs/docs/dev/layout/components/panel.mdx
@@ -14,7 +14,7 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 # Panel
 
-En animerad sidopanel som visas bredvid `Main` i `LayoutContent`. Vanlig användning är för detaljvyer, formulär eller annan kontextuell information.
+En animerad sidopanel som visas bredvid `Main` i `LayoutContent`. Vanlig användning är för detaljvyer eller annan kontextuell information.
 
 ## Enkel panel
 
@@ -52,6 +52,45 @@ function App() {
 `id` är obligatoriskt och måste vara unikt på sidan. Det används internt för att hantera panelens tillstånd.
 
 :::
+
+## Panel med egna åtgärder
+
+Använd `actions`-propen för att lägga till egna knappar i panelens header, till höger om titeln och till vänster om stängknappen.
+
+```tsx
+import { Layout, LayoutContent, Main, Panel } from '@midas-ds/layout'
+import { Button } from '@midas-ds/components'
+import { Ellipsis } from 'lucide-react'
+import { useState } from 'react'
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <Layout>
+      <LayoutContent>
+        <Main>
+          <Button onPress={() => setIsOpen(true)}>Öppna panel</Button>
+        </Main>
+
+        <Panel
+          id='detaljer'
+          title='Detaljer'
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          actions={
+            <Button variant='icon' size='medium' aria-label='Fler alternativ'>
+              <Ellipsis size={20} />
+            </Button>
+          }
+        >
+          {/* Panelinnehåll */}
+        </Panel>
+      </LayoutContent>
+    </Layout>
+  )
+}
+```
 
 ## Flera paneler med PanelProvider
 
@@ -117,13 +156,36 @@ const { panels, addPanel, closePanel, removePanel } = usePanels()
 | -------------- | --------------------------- | -------- | ------------------------------ |
 | `id`           | `string`                    | —        | **Obligatorisk.** Unikt id     |
 | `title`        | `string`                    | —        | Panelrubrik                    |
+| `actions`      | `ReactNode`                 | —        | Egna åtgärder i headern        |
 | `isOpen`       | `boolean`                   | —        | Kontrollerat öppet-läge        |
 | `defaultOpen`  | `boolean`                   | —        | Okontrollerat starttillstånd   |
 | `onOpenChange` | `(isOpen: boolean) => void` | —        | Callback vid öppning/stängning |
 
 ## Props — PanelProvider
 
-| Prop            | Typ                            | Standard           | Beskrivning                                |
-| --------------- | ------------------------------ | ------------------ | ------------------------------------------ |
-| `panelBehavior` | `'bring-to-front' \| 'pop-to'` | `'bring-to-front'` | Beteende vid aktivering av befintlig panel |
-| `defaultPanels` | `PanelItem[]`                  | —                  | Förhandsöppnade paneler                    |
+| Prop            | Typ                                          | Standard    | Beskrivning                                                                 |
+| --------------- | -------------------------------------------- | ----------- | --------------------------------------------------------------------------- |
+| `panelBehavior` | `'replace' \| 'bring-to-front' \| 'pop-to'` | `'replace'` | Beteende när en panel öppnas                                                |
+| `panelVariant`  | `'overlay' \| 'push'`                        | `'overlay'` | Hur panelen visas i förhållande till huvudinnehållet                        |
+| `defaultPanels` | `PanelItem[]`                                | —           | Förhandsöppnade paneler                                                     |
+
+### panelBehavior
+
+| Värde             | Beteende                                                                         |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `replace`         | Ny panel ersätter alla befintliga. Rekommenderas för de flesta användningsfall.  |
+| `bring-to-front`  | Paneler staplas. Öppnar man en befintlig panel flyttas den framåt i ordningen.   |
+| `pop-to`          | Öppnar man en befintlig panel stängs alla paneler ovanför den.                   |
+
+:::info
+
+Det rekommenderas att visa en panel åt gången. Standardvärdet `replace` speglar detta. `bring-to-front` och `pop-to` finns tillgängliga för situationer där flera paneler är välmotiverade.
+
+:::
+
+### panelVariant
+
+| Värde     | Beteende                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------- |
+| `overlay` | Panelen lägger sig ovanpå huvudinnehållet utan att påverka dess bredd.                      |
+| `push`    | Panelen skjuter undan huvudinnehållet och minskar dess tillgängliga bredd.                  |

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -48,6 +48,7 @@ const config: Config = {
             src: [
               `${packagesDir}/components/src/**/[A-Z]*.tsx`,
               `${packagesDir}/table-styles/src/**/[A-Z]*.tsx`,
+              `${packagesDir}/layout/src/**/[A-Z]*.tsx`,
             ],
             parserOptions: {
               shouldExtractValuesFromUnion: true,

--- a/packages/layout/src/layout/layout-content/LayoutContent.module.css
+++ b/packages/layout/src/layout/layout-content/LayoutContent.module.css
@@ -3,4 +3,8 @@
   position: relative;
   height: 100%;
   overflow: hidden;
+
+  @media (width < 800px) {
+    flex-direction: column;
+  }
 }

--- a/packages/layout/src/panel/Panel.module.css
+++ b/packages/layout/src/panel/Panel.module.css
@@ -1,5 +1,6 @@
 :root {
   --panel-width: 300px;
+  --panel-height-mobile: 40vh;
 }
 
 .panel {
@@ -14,7 +15,7 @@
   border-left: 1px solid var(--midas-border-color-subtle);
 
   &[data-promoting] {
-    animation: promote var(--midas-transition-duration-fast) ease-out;
+    animation: promote var(--midas-transition-duration-slow) ease-out;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -24,11 +25,11 @@
   }
 
   &[data-entering] {
-    animation: slide-horizontally var(--midas-transition-duration-fast);
+    animation: slide-horizontally var(--midas-transition-duration-slow);
   }
 
   &[data-exiting] {
-    animation: slide-horizontally var(--midas-transition-duration-fast) reverse
+    animation: slide-horizontally var(--midas-transition-duration-slow) reverse
       ease-in;
   }
 
@@ -42,18 +43,18 @@
   @media (width < 800px) {
     bottom: 0;
     width: 100%;
-    height: 25%;
+    height: var(--panel-height-mobile);
     left: 0;
     top: unset;
     border-left: none;
     border-top: 1px solid var(--midas-border-color-subtle);
 
     &[data-entering] {
-      animation: slide-vertically var(--midas-transition-duration-fast);
+      animation: slide-vertically var(--midas-transition-duration-slow);
     }
 
     &[data-exiting] {
-      animation: slide-vertically var(--midas-transition-duration-fast) reverse
+      animation: slide-vertically var(--midas-transition-duration-slow) reverse
         ease-in;
     }
   }

--- a/packages/layout/src/panel/Panel.module.css
+++ b/packages/layout/src/panel/Panel.module.css
@@ -1,5 +1,5 @@
 :root {
-  --panel-width: 320px;
+  --panel-width: 300px;
 }
 
 .panel {

--- a/packages/layout/src/panel/Panel.module.css
+++ b/packages/layout/src/panel/Panel.module.css
@@ -1,13 +1,16 @@
+:root {
+  --panel-width: 320px;
+}
+
 .panel {
   background: var(--midas-background-base);
-
-  /* important because position:relative is overridden by [data-debug] selector */
+  box-shadow: var(--midas-panel-shadow);
   height: 100%;
   overflow: hidden;
-  position: absolute !important;
+  position: absolute;
   right: 0;
   top: 0;
-  width: 320px;
+  width: var(--panel-width);
   border-left: 1px solid var(--midas-border-color-subtle);
 
   &[data-promoting] {
@@ -54,6 +57,12 @@
         ease-in;
     }
   }
+}
+
+.panelActions {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
 }
 
 .panelTitle {

--- a/packages/layout/src/panel/Panel.spec.tsx
+++ b/packages/layout/src/panel/Panel.spec.tsx
@@ -25,6 +25,7 @@ describe('given a controlled Panel', () => {
   it('should close when the dismiss button is pressed', async () => {
     const { getByRole } = await render(<Controlled />)
     await userEvent.click(getByRole('button', { name: 'Open panel' }))
+    await expect.element(getByRole('complementary')).not.toHaveAttribute('data-entering')
     await userEvent.click(getByRole('button', { name: 'Dismiss panel' }))
     await expect.element(getByRole('complementary')).not.toBeInTheDocument()
   })

--- a/packages/layout/src/panel/Panel.spec.tsx
+++ b/packages/layout/src/panel/Panel.spec.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { composeStories } from '@storybook/react-vite'
+import { render } from 'vitest-browser-react'
+import { userEvent } from 'vitest/browser'
+import * as stories from './Panel.stories'
+import styles from './PanelRegion.module.css'
+
+const {
+  Controlled,
+  WithActions,
+  BehaviorReplace,
+  BehaviorBringToFront,
+  BehaviorPopTo,
+  VariantPush,
+} = composeStories(stories)
+
+describe('given a controlled Panel', () => {
+  it('should open when the open button is pressed', async () => {
+    const { getByRole } = await render(<Controlled />)
+    await expect.element(getByRole('complementary')).not.toBeInTheDocument()
+    await userEvent.click(getByRole('button', { name: 'Open panel' }))
+    await expect.element(getByRole('complementary')).toBeVisible()
+  })
+
+  it('should close when the dismiss button is pressed', async () => {
+    const { getByRole } = await render(<Controlled />)
+    await userEvent.click(getByRole('button', { name: 'Open panel' }))
+    await userEvent.click(getByRole('button', { name: 'Dismiss panel' }))
+    await expect.element(getByRole('complementary')).not.toBeInTheDocument()
+  })
+
+  it('should close when the panel close button is pressed', async () => {
+    const { getByRole } = await render(<Controlled />)
+    await userEvent.click(getByRole('button', { name: 'Open panel' }))
+    await userEvent.click(getByRole('button', { name: 'Close panel' }))
+    await expect.element(getByRole('complementary')).not.toBeInTheDocument()
+  })
+})
+
+describe('given a Panel with actions', () => {
+  it('should render the actions in the header', async () => {
+    const { getByRole } = await render(<WithActions />)
+    await expect
+      .element(getByRole('button', { name: 'More options' }))
+      .toBeVisible()
+  })
+})
+
+describe('given a PanelProvider with replace behavior', () => {
+  it('should close the existing panel when a new one is opened', async () => {
+    const { getByRole } = await render(<BehaviorReplace />)
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel A' }))
+    await expect
+      .element(getByRole('complementary', { name: 'Panel A' }))
+      .toBeVisible()
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel B' }))
+    await expect
+      .element(getByRole('complementary', { name: 'Panel B' }))
+      .toBeVisible()
+    await expect
+      .element(getByRole('complementary', { name: 'Panel A' }))
+      .not.toBeInTheDocument()
+  })
+})
+
+describe('given a PanelProvider with bring-to-front behavior', () => {
+  it('should keep existing panels in the DOM when a new one is opened', async () => {
+    const { getByRole, container } = await render(<BehaviorBringToFront />)
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel A' }))
+    await userEvent.click(getByRole('button', { name: 'Open Panel B' }))
+
+    expect(container.querySelectorAll('aside')).toHaveLength(2)
+    await expect
+      .element(getByRole('complementary', { name: 'Panel B' }))
+      .toBeVisible()
+  })
+})
+
+describe('given a PanelProvider with pop-to behavior', () => {
+  it('should close panels opened after the target when it is reopened', async () => {
+    const { getByRole } = await render(<BehaviorPopTo />)
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel A' }))
+    await userEvent.click(getByRole('button', { name: 'Open Panel B' }))
+    await expect
+      .element(getByRole('complementary', { name: 'Panel B' }))
+      .toBeVisible()
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel A' }))
+    await expect
+      .element(getByRole('complementary', { name: 'Panel A' }))
+      .toBeVisible()
+    await expect
+      .element(getByRole('complementary', { name: 'Panel B' }))
+      .not.toBeInTheDocument()
+  })
+})
+
+describe('given a PanelProvider with push variant', () => {
+  it('should apply push styles to the region when a panel is open', async () => {
+    const { getByRole, container } = await render(<VariantPush />)
+
+    const region = container.querySelector(`.${styles.push}`) as HTMLElement
+    expect(region).toBeTruthy()
+    expect(region.dataset.open).toBeUndefined()
+
+    await userEvent.click(getByRole('button', { name: 'Open Panel A' }))
+    expect(region.dataset.open).toBe('true')
+  })
+})

--- a/packages/layout/src/panel/Panel.stories.tsx
+++ b/packages/layout/src/panel/Panel.stories.tsx
@@ -203,3 +203,72 @@ export const VariantPush: Story = {
   ],
   render: () => <span />,
 }
+
+const items = [
+  { id: '1', name: 'Application #1042', status: 'Pending', date: '2026-03-12', notes: 'Awaiting document submission from applicant.' },
+  { id: '2', name: 'Application #1043', status: 'Approved', date: '2026-03-14', notes: 'All documents verified. Decision letter sent.' },
+  { id: '3', name: 'Application #1044', status: 'Under review', date: '2026-03-15', notes: 'Assigned to case officer. Background check in progress.' },
+  { id: '4', name: 'Application #1045', status: 'Rejected', date: '2026-03-18', notes: 'Missing supporting documents. Applicant notified.' },
+]
+
+function DetailViewControls() {
+  const { addPanel } = usePanels()
+
+  return (
+    <Main style={{ padding: '1rem' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+        <thead>
+          <tr style={{ textAlign: 'left', borderBottom: '1px solid #ccc' }}>
+            <th style={{ padding: '0.5rem' }}>Name</th>
+            <th style={{ padding: '0.5rem' }}>Status</th>
+            <th style={{ padding: '0.5rem' }}>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(item => (
+            <tr
+              key={item.id}
+              style={{ borderBottom: '1px solid #eee', cursor: 'pointer' }}
+              onClick={() =>
+                addPanel({
+                  id: 'detail',
+                  title: item.name,
+                  children: (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', fontSize: '0.875rem' }}>
+                      <div><strong>Status:</strong> {item.status}</div>
+                      <div><strong>Date:</strong> {item.date}</div>
+                      <div><strong>Notes:</strong> {item.notes}</div>
+                    </div>
+                  ),
+                })
+              }
+            >
+              <td style={{ padding: '0.5rem' }}>{item.name}</td>
+              <td style={{ padding: '0.5rem' }}>{item.status}</td>
+              <td style={{ padding: '0.5rem' }}>{item.date}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Main>
+  )
+}
+
+export const DetailView: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider
+        panelBehavior='replace'
+        panelVariant='push'
+      >
+        <Layout>
+          <LayoutContent>
+            <DetailViewControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <span />,
+}

--- a/packages/layout/src/panel/Panel.stories.tsx
+++ b/packages/layout/src/panel/Panel.stories.tsx
@@ -1,11 +1,27 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 import { Button } from '@midas-ds/components'
+import { Ellipsis } from 'lucide-react'
 import { Layout, LayoutContent } from '../layout'
 import { Main } from '../main'
 import { Panel } from '.'
+import { PanelProvider } from './PanelProvider'
+import { PanelRegion } from './PanelRegion'
+import { usePanels } from './usePanels'
 
 type Story = StoryObj<typeof Panel>
+
+const loremParagraphs = [
+  'Lorem ipsum dolor sit amet consectetur adipisicing elit. Saepe voluptates mollitia natus beatae libero tenetur accusantium harum rem voluptatum blanditiis.',
+  'Odit corrupti consequatur nam culpa nesciunt cupiditate autem suscipit. Vel ipsum veritatis quisquam amet rem aperiam error nostrum earum consequuntur.',
+  'Quidem fugit blanditiis odit corrupti consequatur nam culpa nesciunt. Cupiditate autem suscipit asperiores expedita excepturi hic modi tenetur maxime.',
+  'Dicta omnis aliquam quas doloremque cumque repellendus iure. Eveniet reprehenderit sapiente quidem culpa nam vel ipsum veritatis quisquam amet.',
+  'Rem aperiam error nostrum earum consequuntur quidem fugit. Blanditiis odit corrupti consequatur nam culpa nesciunt cupiditate autem suscipit.',
+]
+
+const loremIpsum = loremParagraphs.map((text, i) => (
+  <p key={i} style={{ marginBottom: '1rem' }}>{text}</p>
+))
 
 export default {
   component: Panel,
@@ -34,12 +50,18 @@ export const Primary: Story = {
 
 export const Controlled: Story = {
   render: args => {
-    const [isOpen, setIsOpen] = useState(true)
+    const [isOpen, setIsOpen] = useState(false)
 
     return (
       <>
-        <Main>
+        <Main style={{ display: 'flex', gap: '0.5rem', padding: '1rem', alignItems: 'flex-start' }}>
           <Button onPress={() => setIsOpen(true)}>Open panel</Button>
+          <Button
+            variant='secondary'
+            onPress={() => setIsOpen(false)}
+          >
+            Dismiss panel
+          </Button>
         </Main>
         <Panel
           {...args}
@@ -49,4 +71,135 @@ export const Controlled: Story = {
       </>
     )
   },
+}
+
+export const WithActions: Story = {
+  args: {
+    defaultOpen: true,
+    actions: (
+      <Button
+        variant='icon'
+        size='medium'
+        aria-label='More options'
+      >
+        <Ellipsis size={20} />
+      </Button>
+    ),
+  },
+}
+
+export const WithScrollableContent: Story = {
+  args: {
+    defaultOpen: true,
+    children: loremIpsum,
+  },
+}
+
+function MultiplePanelControls() {
+  const { addPanel } = usePanels()
+  const panels = [
+    { id: 'panel-a', title: 'Panel A' },
+    { id: 'panel-b', title: 'Panel B' },
+    { id: 'panel-c', title: 'Panel C' },
+  ]
+
+  return (
+    <Main>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', padding: '1rem' }}>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          {panels.map(p => (
+            <Button
+              key={p.id}
+              variant='secondary'
+              size='medium'
+              onPress={() => addPanel(p)}
+            >
+              Open {p.title}
+            </Button>
+          ))}
+        </div>
+        {loremIpsum}
+      </div>
+    </Main>
+  )
+}
+
+export const BehaviorReplace: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider panelBehavior='replace'>
+        <Layout>
+          <LayoutContent>
+            <MultiplePanelControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <></>,
+}
+
+export const BehaviorBringToFront: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider panelBehavior='bring-to-front'>
+        <Layout>
+          <LayoutContent>
+            <MultiplePanelControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <></>,
+}
+
+export const BehaviorPopTo: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider panelBehavior='pop-to'>
+        <Layout>
+          <LayoutContent>
+            <MultiplePanelControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <></>,
+}
+
+export const VariantOverlay: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider panelVariant='overlay'>
+        <Layout>
+          <LayoutContent>
+            <MultiplePanelControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <></>,
+}
+
+export const VariantPush: Story = {
+  decorators: [
+    _Story => (
+      <PanelProvider panelVariant='push'>
+        <Layout>
+          <LayoutContent>
+            <MultiplePanelControls />
+            <PanelRegion />
+          </LayoutContent>
+        </Layout>
+      </PanelProvider>
+    ),
+  ],
+  render: () => <></>,
 }

--- a/packages/layout/src/panel/Panel.stories.tsx
+++ b/packages/layout/src/panel/Panel.stories.tsx
@@ -137,7 +137,7 @@ export const BehaviorReplace: Story = {
       </PanelProvider>
     ),
   ],
-  render: () => <></>,
+  render: () => <span />,
 }
 
 export const BehaviorBringToFront: Story = {
@@ -153,7 +153,7 @@ export const BehaviorBringToFront: Story = {
       </PanelProvider>
     ),
   ],
-  render: () => <></>,
+  render: () => <span />,
 }
 
 export const BehaviorPopTo: Story = {
@@ -169,7 +169,7 @@ export const BehaviorPopTo: Story = {
       </PanelProvider>
     ),
   ],
-  render: () => <></>,
+  render: () => <span />,
 }
 
 export const VariantOverlay: Story = {
@@ -185,7 +185,7 @@ export const VariantOverlay: Story = {
       </PanelProvider>
     ),
   ],
-  render: () => <></>,
+  render: () => <span />,
 }
 
 export const VariantPush: Story = {
@@ -201,5 +201,5 @@ export const VariantPush: Story = {
       </PanelProvider>
     ),
   ],
-  render: () => <></>,
+  render: () => <span />,
 }

--- a/packages/layout/src/panel/Panel.stories.tsx
+++ b/packages/layout/src/panel/Panel.stories.tsx
@@ -20,7 +20,7 @@ const loremParagraphs = [
 ]
 
 const loremIpsum = loremParagraphs.map((text, i) => (
-  <p key={i} style={{ marginBottom: '1rem' }}>{text}</p>
+  <p key={i} style={{ margin: '0 0 1rem' }}>{text}</p>
 ))
 
 export default {

--- a/packages/layout/src/panel/Panel.tsx
+++ b/packages/layout/src/panel/Panel.tsx
@@ -20,14 +20,21 @@ import messages from './intl/translations.json'
 import styles from './Panel.module.css'
 
 export interface PanelProps extends PanelBodyProps {
+  /** Required unique id used to manage panel state. */
   id: string
+  /** Panel title displayed in the header. */
   title: string
+  /** Controlled open state. */
   isOpen?: boolean
+  /** Uncontrolled initial open state. */
   defaultOpen?: boolean
+  /** Callback fired when the panel opens or closes. */
   onOpenChange?: (isOpen: boolean) => void
+  /** Callback fired when the exit animation completes. */
   onExited?: () => void
   promoting?: boolean
   onPromotionEnd?: () => void
+  /** Custom actions rendered in the panel header, to the right of the title. */
   actions?: ReactNode
 }
 

--- a/packages/layout/src/panel/Panel.tsx
+++ b/packages/layout/src/panel/Panel.tsx
@@ -15,13 +15,13 @@ import {
 import { PanelBody, PanelBodyProps } from './panel-body'
 import { PanelContent } from './panel-content'
 import { PanelHeader } from './panel-header'
-import { PanelTitle, PanelTitleProps } from './panel-title'
+import { PanelTitle } from './panel-title'
 import messages from './intl/translations.json'
 import styles from './Panel.module.css'
 
-export interface PanelProps
-  extends PanelBodyProps, Pick<PanelTitleProps, 'title'> {
+export interface PanelProps extends PanelBodyProps {
   id: string
+  title: string
   isOpen?: boolean
   defaultOpen?: boolean
   onOpenChange?: (isOpen: boolean) => void
@@ -110,14 +110,10 @@ const PanelInner = forwardRef<
         {...filterDOMProps(rest)}
       >
         <PanelHeader>
-          {title ? (
-            <PanelTitle
-              className={styles.panelTitle}
-              title={title}
-            />
-          ) : (
-            <div />
-          )}
+          <PanelTitle
+            className={styles.panelTitle}
+            title={title}
+          />
           <div className={styles.panelActions}>
             {actions}
             <Button

--- a/packages/layout/src/panel/Panel.tsx
+++ b/packages/layout/src/panel/Panel.tsx
@@ -5,7 +5,7 @@ import { Button, useLocalizedStringFormatter } from '@midas-ds/components'
 import { X } from 'lucide-react'
 import { useControlledState } from '@react-stately/utils'
 import { type PressEvent } from 'react-aria-components'
-import { AnimationEvent, forwardRef, useEffect, useRef } from 'react'
+import { AnimationEvent, forwardRef, ReactNode, useEffect, useRef } from 'react'
 import {
   filterDOMProps,
   useEnterAnimation,
@@ -28,6 +28,7 @@ export interface PanelProps
   onExited?: () => void
   promoting?: boolean
   onPromotionEnd?: () => void
+  actions?: ReactNode
 }
 
 export const Panel = (props: PanelProps) => {
@@ -74,6 +75,7 @@ const PanelInner = forwardRef<
     {
       className,
       title,
+      actions,
       onPress,
       children,
       isExiting,
@@ -98,6 +100,7 @@ const PanelInner = forwardRef<
     return (
       <PanelBody
         aria-hidden={ariaHidden || undefined}
+        aria-label={title}
         className={clsx(className, styles.panel)}
         ref={objectRef}
         data-entering={isEntering || undefined}
@@ -115,14 +118,17 @@ const PanelInner = forwardRef<
           ) : (
             <div />
           )}
-          <Button
-            aria-label={strings.format('closePanel')}
-            onPress={onPress}
-            size='medium'
-            variant='icon'
-          >
-            <X size={20} />
-          </Button>
+          <div className={styles.panelActions}>
+            {actions}
+            <Button
+              aria-label={strings.format('closePanel')}
+              onPress={onPress}
+              size='medium'
+              variant='icon'
+            >
+              <X size={20} />
+            </Button>
+          </div>
         </PanelHeader>
         <PanelContent>{children}</PanelContent>
       </PanelBody>

--- a/packages/layout/src/panel/PanelContext.tsx
+++ b/packages/layout/src/panel/PanelContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext } from 'react'
 import { PanelProps } from './Panel'
+import { PanelVariant } from './PanelProvider'
 
 export interface PanelItem extends PanelProps {
   promoting?: boolean
@@ -9,6 +10,7 @@ export interface PanelItem extends PanelProps {
 
 export interface PanelContextValue {
   panels: PanelItem[]
+  panelVariant: PanelVariant
   addPanel: (panel: Omit<PanelItem, 'isOpen' | 'defaultOpen'>) => void
   closePanel: (id: string) => void
   removePanel: (id: string) => void
@@ -17,6 +19,7 @@ export interface PanelContextValue {
 
 export const PanelContext = createContext<PanelContextValue>({
   panels: [],
+  panelVariant: 'overlay',
   addPanel: () => {
     /* noop */
   },

--- a/packages/layout/src/panel/PanelContext.tsx
+++ b/packages/layout/src/panel/PanelContext.tsx
@@ -9,13 +9,22 @@ export interface PanelItem extends PanelProps {
 }
 
 export interface PanelContextValue {
+  /** The current list of panels. */
   panels: PanelItem[]
+  /** The active panel variant inherited from `PanelProvider`. */
   panelVariant: PanelVariant
+  /** Opens or activates a panel. If a panel with the same id exists, it is updated in place. */
   addPanel: (panel: Omit<PanelItem, 'isOpen' | 'defaultOpen'>) => void
+  /** Closes a panel, triggering the exit animation. */
   closePanel: (id: string) => void
+  /** Permanently removes a panel from state. */
   removePanel: (id: string) => void
   resetPromoting: (id: string) => void
 }
+
+/** @internal — exists solely for PropTable introspection of usePanels return value */
+export const UsePanels = (_: PanelContextValue) => null
+UsePanels.displayName = 'usePanels'
 
 export const PanelContext = createContext<PanelContextValue>({
   panels: [],

--- a/packages/layout/src/panel/PanelProvider.tsx
+++ b/packages/layout/src/panel/PanelProvider.tsx
@@ -8,8 +8,29 @@ export type PanelVariant = 'overlay' | 'push'
 
 export interface PanelProviderProps {
   children: ReactNode
+  /** Panels to open on mount. */
   defaultPanels?: PanelItem[]
+  /**
+   * Behaviour when opening a panel that is already open.
+   *
+   * - `replace` — Replaces all existing panels. Recommended for most use cases.
+   * - `bring-to-front` — Panels stack; opening an existing panel moves it to the front.
+   * - `pop-to` — Opening an existing panel closes all panels above it.
+   *
+   * Showing one panel at a time is recommended. `replace` reflects this as the default.
+   * Use `bring-to-front` or `pop-to` only when multiple simultaneous panels are justified.
+   *
+   * @default 'replace'
+   */
   panelBehavior?: PanelBehavior
+  /**
+   * How the panel is displayed relative to the main content.
+   *
+   * - `overlay` — Panel overlays the main content without affecting its width.
+   * - `push` — Panel pushes the main content aside, reducing its available width.
+   *
+   * @default 'overlay'
+   */
   panelVariant?: PanelVariant
 }
 

--- a/packages/layout/src/panel/PanelProvider.tsx
+++ b/packages/layout/src/panel/PanelProvider.tsx
@@ -3,18 +3,21 @@
 import { ReactNode, useState } from 'react'
 import { PanelContext, type PanelItem } from './PanelContext'
 
-export type PanelBehavior = 'bring-to-front' | 'pop-to'
+export type PanelBehavior = 'replace' | 'bring-to-front' | 'pop-to'
+export type PanelVariant = 'overlay' | 'push'
 
 export interface PanelProviderProps {
   children: ReactNode
   defaultPanels?: PanelItem[]
   panelBehavior?: PanelBehavior
+  panelVariant?: PanelVariant
 }
 
 export const PanelProvider = ({
   children,
   defaultPanels = [],
-  panelBehavior = 'bring-to-front',
+  panelBehavior = 'replace',
+  panelVariant = 'overlay',
 }: PanelProviderProps) => {
   const [panels, setPanels] = useState<PanelItem[]>(
     defaultPanels.map(p => ({ ...p, isOpen: true, defaultOpen: true })),
@@ -22,6 +25,10 @@ export const PanelProvider = ({
 
   const addPanel = (panel: PanelItem) => {
     setPanels((prev): PanelItem[] => {
+      if (panelBehavior === 'replace') {
+        return [{ ...panel, isOpen: true }]
+      }
+
       const existingIndex = prev.findIndex(p => p.id === panel.id)
 
       if (existingIndex === -1) {
@@ -65,7 +72,7 @@ export const PanelProvider = ({
 
   return (
     <PanelContext.Provider
-      value={{ panels, addPanel, closePanel, removePanel, resetPromoting }}
+      value={{ panels, panelVariant, addPanel, closePanel, removePanel, resetPromoting }}
     >
       {children}
     </PanelContext.Provider>

--- a/packages/layout/src/panel/PanelRegion.module.css
+++ b/packages/layout/src/panel/PanelRegion.module.css
@@ -3,7 +3,7 @@
   height: 100%;
   overflow: hidden;
   position: relative;
-  transition: width var(--midas-transition-duration-fast);
+  transition: width var(--midas-transition-duration-slow);
   width: 0;
 }
 
@@ -12,7 +12,14 @@
 }
 
 @media (width < 800px) {
+  .push {
+    height: 0;
+    width: 100%;
+    transition: height var(--midas-transition-duration-slow);
+  }
+
   .push[data-open] {
+    height: var(--panel-height-mobile);
     width: 100%;
   }
 }

--- a/packages/layout/src/panel/PanelRegion.module.css
+++ b/packages/layout/src/panel/PanelRegion.module.css
@@ -1,0 +1,18 @@
+.push {
+  flex-shrink: 0;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  transition: width var(--midas-transition-duration-fast);
+  width: 0;
+}
+
+.push[data-open] {
+  width: var(--panel-width);
+}
+
+@media (width < 800px) {
+  .push[data-open] {
+    width: 100%;
+  }
+}

--- a/packages/layout/src/panel/PanelRegion.tsx
+++ b/packages/layout/src/panel/PanelRegion.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import clsx from 'clsx'
 import { DetailedHTMLProps, HTMLAttributes } from 'react'
 import { Panel } from './Panel'
 import { usePanels } from './usePanels'
+import styles from './PanelRegion.module.css'
 
 export type PanelRegionProps = DetailedHTMLProps<
   HTMLAttributes<HTMLDivElement>,
@@ -14,11 +16,13 @@ export const PanelRegion = ({
   className,
   ...rest
 }: PanelRegionProps) => {
-  const { panels, closePanel, removePanel, resetPromoting } = usePanels()
+  const { panels, panelVariant, closePanel, removePanel, resetPromoting } = usePanels()
+  const hasOpenPanels = panels.length > 0
 
   return (
     <div
-      className={className}
+      className={clsx(className, panelVariant === 'push' && styles.push)}
+      data-open={panelVariant === 'push' && hasOpenPanels ? true : undefined}
       {...rest}
     >
       {panels.map(({ id, ...panel }, index, { length }) => (
@@ -26,8 +30,7 @@ export const PanelRegion = ({
           aria-hidden={index < length - 1 || undefined}
           key={id}
           id={id}
-          data-debug='Panel'
-          onOpenChange={open => {
+onOpenChange={open => {
             if (!open) closePanel(id)
           }}
           onExited={() => removePanel(id)}

--- a/packages/layout/src/panel/PanelRegion.tsx
+++ b/packages/layout/src/panel/PanelRegion.tsx
@@ -30,7 +30,7 @@ export const PanelRegion = ({
           aria-hidden={index < length - 1 || undefined}
           key={id}
           id={id}
-onOpenChange={open => {
+          onOpenChange={open => {
             if (!open) closePanel(id)
           }}
           onExited={() => removePanel(id)}

--- a/packages/layout/src/panel/panel-body/PanelBody.module.css
+++ b/packages/layout/src/panel/panel-body/PanelBody.module.css
@@ -3,5 +3,5 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: var(--midas-space-medium);
+  gap: 0;
 }

--- a/packages/layout/src/panel/panel-content/PanelContent.module.css
+++ b/packages/layout/src/panel/panel-content/PanelContent.module.css
@@ -1,4 +1,16 @@
 .panelContent {
+  flex: 1 1 auto;
+  overflow: hidden auto;
   padding: var(--midas-space-small) var(--midas-space-medium)
     var(--midas-space-medium) var(--midas-space-medium);
+
+  &:focus-visible {
+    box-shadow: var(--midas-state-focus-inset);
+    outline: none;
+
+    @media (forced-colors: active) {
+      outline: var(--midas-state-focus-contrast-mode-outline) solid highlight;
+      outline-offset: calc(var(--midas-state-focus-contrast-mode-outline) * -1);
+    }
+  }
 }

--- a/packages/layout/src/panel/panel-content/PanelContent.module.css
+++ b/packages/layout/src/panel/panel-content/PanelContent.module.css
@@ -1,8 +1,7 @@
 .panelContent {
   flex: 1 1 auto;
   overflow: hidden auto;
-  padding: var(--midas-space-small) var(--midas-space-medium)
-    var(--midas-space-medium) var(--midas-space-medium);
+  padding: var(--midas-space-small) var(--midas-space-medium) 0;
 
   &:focus-visible {
     box-shadow: var(--midas-state-focus-inset);

--- a/packages/layout/src/panel/panel-content/PanelContent.tsx
+++ b/packages/layout/src/panel/panel-content/PanelContent.tsx
@@ -8,11 +8,14 @@ export type PanelContentProps = DetailedHTMLProps<
 >
 
 export const PanelContent = forwardRef<HTMLDivElement, PanelContentProps>(
-  ({ className, ...rest }, ref) => (
-    <div
-      ref={ref}
-      className={clsx(className, styles.panelContent)}
-      {...rest}
-    />
-  ),
+  ({ className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex -- WCAG 2.1.1: scrollable regions must be keyboard-reachable
+        className={clsx(className, styles.panelContent)}
+        {...rest}
+      />
+    )
+  },
 )

--- a/packages/layout/src/panel/panel-header/PanelHeader.module.css
+++ b/packages/layout/src/panel/panel-header/PanelHeader.module.css
@@ -2,6 +2,6 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
-  padding: var(--midas-space-small) var(--midas-space-small)
+  padding: var(--midas-space-small) var(--midas-space-30)
     var(--midas-space-small) var(--midas-space-medium);
 }

--- a/packages/theme/tokens/object-values.json
+++ b/packages/theme/tokens/object-values.json
@@ -602,5 +602,12 @@
       "$value": "0 3px 5px 0 rgba(0, 0, 0, 0.30)",
       "$description": "Skugga för Card"
     }
+  },
+  "panel": {
+    "shadow": {
+      "$type": "string",
+      "$value": "-2px 0px 12px -2px rgba(0, 0, 0, 0.10)",
+      "$description": "Skugga för Panel"
+    }
   }
 }

--- a/packages/theme/tokens/transitions.json
+++ b/packages/theme/tokens/transitions.json
@@ -3,9 +3,9 @@
     "$description": "Animationstokens för övergångar och rörelser i UI:t. Kombinera duration- och timing-tokens för att bygga konsekventa animationer.",
     "duration": {
       "slow": {
-        "$value": "500ms",
+        "$value": "400ms",
         "$type": "duration",
-        "$description": "Långsam övergång. 500ms. Används för större layoutförändringar som sidopaneler och expanderbara sektioner."
+        "$description": "Långsam övergång. 400ms. Används för större layoutförändringar som sidopaneler och expanderbara sektioner."
       },
       "normal": {
         "$value": "300ms",


### PR DESCRIPTION
## Changes

- Add `--midas-panel-shadow` token
- Add `box-shadow` to panel using new token
- Fix header right padding (`--midas-space-30`)
- Add `actions` prop (ReactNode slot between title and close button)
- Add `panelVariant`: `overlay` (default) or `push`
- Add `panelBehavior`: `replace` (new default), `bring-to-front`, `pop-to`
- Add `aria-label` on panel body (`<aside>`) for correct landmark semantics
- Fix scrollable panel content: `tabIndex={0}` + focus ring on `PanelContent`
- Remove `data-debug` from `PanelRegion` and drop `position: absolute !important`
- Add stories: `WithActions`, `WithScrollableContent`, `BehaviorReplace`, `BehaviorBringToFront`, `BehaviorPopTo`, `VariantOverlay`, `VariantPush`
- Add `Panel.spec.tsx`
- Update docs