### PR TITLE
feat(components,color-scheme-switch): add scheme and onSchemeChange props

### DIFF
--- a/apps/docs/docs/components/color-scheme-switch.mdx
+++ b/apps/docs/docs/components/color-scheme-switch.mdx
@@ -48,6 +48,35 @@ Som standard påverkas `:root`, men du kan rikta mot ett annat element med `sele
 <ColorSchemeSwitch defaultScheme='dark' />
 ```
 
+## Spara val i localStorage
+
+Använd `onSchemeChange` för att reagera på användarens val — till exempel för att spara det i `localStorage` och återställa det vid nästa sidladdning.
+
+```tsx
+const savedScheme = localStorage.getItem('color-scheme') as ColorScheme | null
+
+<ColorSchemeSwitch
+  defaultScheme={savedScheme ?? 'light dark'}
+  onSchemeChange={scheme => localStorage.setItem('color-scheme', scheme)}
+/>
+```
+
+För ett fullt kontrollerat flöde, kombinera `scheme` med `onSchemeChange`:
+
+```tsx
+const [scheme, setScheme] = useState<ColorScheme>(
+  () => (localStorage.getItem('color-scheme') as ColorScheme) ?? 'light dark'
+)
+
+<ColorSchemeSwitch
+  scheme={scheme}
+  onSchemeChange={s => {
+    setScheme(s)
+    localStorage.setItem('color-scheme', s)
+  }}
+/>
+```
+
 ## API
 
 <PropTable name='ColorSchemeSwitch' />

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitch.spec.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitch.spec.tsx
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import { composeStories } from '@storybook/react-vite'
 import * as stories from './ColorSchemeSwitch.stories'
 import { render } from '../../test-utils'
+import { ColorSchemeSwitch } from './ColorSchemeSwitch'
 
 const { Primary } = composeStories(stories)
 
@@ -30,5 +31,16 @@ describe('given a primary ColorSchemeSwitch', async () => {
     expect(page.getByRole('radiogroup')).toHaveClass(
       Primary.args.className as string,
     )
+  })
+})
+
+describe('given a ColorSchemeSwitch with onSchemeChange', () => {
+  it('should call onSchemeChange with the selected scheme', async () => {
+    const onSchemeChange = vi.fn()
+    await render(<ColorSchemeSwitch onSchemeChange={onSchemeChange} />)
+    await userEvent.tab()
+    await userEvent.keyboard('[ArrowRight]')
+    await userEvent.keyboard('[Space]')
+    expect(onSchemeChange).toHaveBeenCalledWith('light')
   })
 })

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitch.stories.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitch.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { ColorSchemeSwitch } from './ColorSchemeSwitch'
+import { useState } from 'react'
+import { ColorSchemeSwitch, type ColorScheme } from './ColorSchemeSwitch'
 
 const meta: Meta<typeof ColorSchemeSwitch> = {
   component: ColorSchemeSwitch,
@@ -14,3 +15,15 @@ export default meta
 type Story = StoryObj<typeof ColorSchemeSwitch>
 
 export const Primary: Story = {}
+
+export const WithCallback: Story = {
+  render: () => {
+    const [last, setLast] = useState<ColorScheme | null>(null)
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <ColorSchemeSwitch onSchemeChange={setLast} />
+        {last && <span>onSchemeChange called with: {last}</span>}
+      </div>
+    )
+  },
+}

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitch.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitch.tsx
@@ -21,6 +21,10 @@ export interface ColorSchemeSwitchProps {
    * @default 'light dark'
    */
   defaultScheme?: ColorScheme
+  /** The controlled color scheme. When provided, the component becomes controlled — pair with `onSchemeChange` to update it. */
+  scheme?: ColorScheme
+  /** Called when the user selects a new color scheme. Use this to persist the selection, e.g. to `localStorage`. */
+  onSchemeChange?: (scheme: ColorScheme) => void
   /**
    * @deprecated since v17.9.0 Use `defaultScheme` instead.
    */
@@ -31,36 +35,46 @@ export interface ColorSchemeSwitchProps {
 export const ColorSchemeSwitch: React.FC<ColorSchemeSwitchProps> = ({
   selector = ':root',
   defaultScheme = 'light dark',
+  scheme,
+  onSchemeChange,
   defaultValue,
   className,
 }) => {
   const [colorScheme, setColorScheme] = React.useState<Set<Key>>(
-    defaultValue ?? new Set([defaultScheme]),
+    defaultValue ?? new Set([scheme ?? defaultScheme]),
   )
+
+  const resolvedKeys = scheme ? new Set<Key>([scheme]) : colorScheme
 
   React.useEffect(() => {
     const targetElement = document.querySelector<HTMLElement>(selector)
 
     if (targetElement) {
-      const scheme = Array.from(colorScheme).join(' ')
+      const resolved = Array.from(resolvedKeys).join(' ')
       targetElement.style.removeProperty('color-scheme')
-      if (scheme === 'light dark') {
+      if (resolved === 'light dark') {
         delete targetElement.dataset.colorScheme
       } else {
-        targetElement.dataset.colorScheme = scheme
+        targetElement.dataset.colorScheme = resolved
       }
     } else {
       console.warn(`No element found for selector: "${selector}"`)
     }
-  }, [colorScheme, selector])
+  }, [resolvedKeys, selector])
 
   const strings = useLocalizedStringFormatter(messages)
+
+  const handleSelectionChange = (keys: Set<Key>) => {
+    const next = Array.from(keys)[0] as ColorScheme
+    setColorScheme(keys)
+    onSchemeChange?.(next)
+  }
 
   return (
     <ToggleButtonGroup
       selectionMode='single'
-      selectedKeys={colorScheme}
-      onSelectionChange={setColorScheme}
+      selectedKeys={resolvedKeys}
+      onSelectionChange={handleSelectionChange}
       disallowEmptySelection
       className={className}
     >


### PR DESCRIPTION
Adds controlled `scheme` prop and `onSchemeChange` callback so consumers can react to theme changes, e.g. to persist to localStorage.