### PR TITLE
feat(components): add ColorSchemeSwitchMenu compact variant

### DIFF
--- a/apps/docs/docs/components/color-scheme-switch.mdx
+++ b/apps/docs/docs/components/color-scheme-switch.mdx
@@ -4,7 +4,7 @@ description: Växlare för färgschema (ljust, mörkt, systemets inställning)
 ---
 
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
-import { ColorSchemeSwitch } from '@midas-ds/components'
+import { ColorSchemeSwitch, ColorSchemeSwitchMenu } from '@midas-ds/components'
 import { PropTable } from '@site/src/components/PropsTable'
 import { SelectorExample } from '@site/src/components/examples/color-scheme-switch/ColorSchemeSwitchExamples'
 
@@ -14,7 +14,7 @@ import { SelectorExample } from '@site/src/components/examples/color-scheme-swit
   overrideHeadlessLink=''
 />
 
-`ColorSchemeSwitch` låter användaren välja mellan ljust läge, mörkt läge eller att följa systemets inställning.
+`ColorSchemeSwitch` låter användaren välja att visa applikationen i ljust läge, mörkt läge eller enligt inställningarna i webbläsaren/operativsystemet.
 
 ```tsx
 import { ColorSchemeSwitch } from '@midas-ds/components'
@@ -28,9 +28,59 @@ import { ColorSchemeSwitch } from '@midas-ds/components'
   <ColorSchemeSwitch />
 </div>
 
-## Selector
+## Varianter
 
-Som standard påverkas `:root`, men du kan rikta mot ett annat element med `selector`-propen. Det är användbart om du bara vill byta färgschema för en avgränsad del av sidan.
+ColorSchemeSwitch finns i två varianter: en version som visar alla tre alternativen och en kompakt version som bara visar det aktiva läget.
+
+### Fullstor
+
+Den fullstora `ColorSchemeSwitch` visar alla tre alternativen (ljust, mörkt, system) i en rad. Den är lämplig att använda i situationer där det finns gott om plats, t.ex. i en inställningspanel.
+
+### Kompakt
+
+`ColorSchemeSwitchMenu` är en kompakt variant som bara visar det aktiva läget. Valet görs via en meny. Den är lämplig att använda i situationer när det är ont om plats, t.ex. i [Header](/dev/layout/components/header/).
+
+```tsx
+import { ColorSchemeSwitchMenu } from '@midas-ds/components'
+```
+
+```tsx
+<ColorSchemeSwitchMenu />
+```
+
+<div
+  className='card'
+  style={{ padding: 0, overflow: 'hidden' }}
+>
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0.5rem 1rem',
+      borderBottom: '1px solid var(--midas-border-color-subtle)',
+      gap: '0.5rem',
+    }}
+  >
+    <span style={{ flex: 1, fontWeight: 500 }}>Min applikation</span>
+    <ColorSchemeSwitchMenu />
+  </div>
+</div>
+
+## Användning
+
+API:t är identiskt i båda varianter. `selector`, `defaultScheme`, `scheme` och `onSchemeChange` fungerar på samma sätt.
+
+### Standardvärde
+
+`defaultScheme` styr vilket läge som är förvalt. Standardvärdet är `'light dark'`, vilket innebär att operativsystemets/webbläsarens inställning används.
+
+```tsx
+<ColorSchemeSwitch defaultScheme='dark' />
+```
+
+### Selector
+
+Som standard påverkas `:root`, men det går att rikta mot ett annat element med `selector`-propen. Det kan användas för att bara byta färgschema på en avgränsad del av sidan.
 
 ```tsx
 <ColorSchemeSwitch selector='#min-widget' />
@@ -40,17 +90,9 @@ Som standard påverkas `:root`, men du kan rikta mot ett annat element med `sele
   <SelectorExample />
 </div>
 
-## Standardvärde
+### Spara val i localStorage
 
-`defaultScheme` styr vilket läge som är förvalt. Standardvärdet är `'light dark'`, vilket innebär att systemets inställning används.
-
-```tsx
-<ColorSchemeSwitch defaultScheme='dark' />
-```
-
-## Spara val i localStorage
-
-Använd `onSchemeChange` för att reagera på användarens val — till exempel för att spara det i `localStorage` och återställa det vid nästa sidladdning.
+Använd `onSchemeChange` för att reagera på användarens val. Det kan till exempel användas för att spara valet i `localStorage` och återställa det vid nästa sidladdning.
 
 ```tsx
 const savedScheme = localStorage.getItem('color-scheme') as ColorScheme | null
@@ -79,4 +121,10 @@ const [scheme, setScheme] = useState<ColorScheme>(
 
 ## API
 
+### ColorSchemeSwitch
+
 <PropTable name='ColorSchemeSwitch' />
+
+### ColorSchemeSwitchMenu
+
+<PropTable name='ColorSchemeSwitchMenu' />

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitch.spec.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitch.spec.tsx
@@ -11,14 +11,13 @@ describe('given a primary ColorSchemeSwitch', async () => {
   beforeEach(async () => {
     await render(<Primary />)
 
-    // Select "light mode"
+    // Select "light mode" — light is now first in the DOM
     await userEvent.tab()
-    await userEvent.keyboard('[ArrowRight]')
     await userEvent.keyboard('[Space]')
   })
 
   it('should be possible to tab to a button and select it', async () => {
-    const lightModeButton = page.getByRole('radio').nth(1)
+    const lightModeButton = page.getByRole('radio').nth(0)
     expect(lightModeButton).toHaveAttribute('aria-checked', 'true')
   })
 
@@ -39,7 +38,6 @@ describe('given a ColorSchemeSwitch with onSchemeChange', () => {
     const onSchemeChange = vi.fn()
     await render(<ColorSchemeSwitch onSchemeChange={onSchemeChange} />)
     await userEvent.tab()
-    await userEvent.keyboard('[ArrowRight]')
     await userEvent.keyboard('[Space]')
     expect(onSchemeChange).toHaveBeenCalledWith('light')
   })

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitch.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitch.tsx
@@ -1,14 +1,15 @@
 'use client'
 
-import { Laptop, Moon, Sun } from 'lucide-react'
+import { Moon, Sun } from 'lucide-react'
+import { ContrastFilled } from '../icons'
 import * as React from 'react'
 import { VisuallyHidden } from 'react-aria'
-import { Key } from 'react-aria-components'
-import { SelectionIndicator } from 'react-aria-components'
+import { Key, SelectionIndicator } from 'react-aria-components'
 import { ToggleButton, ToggleButtonGroup } from '../toggle-button'
 import styles from './ColorSchemeSwitch.module.css'
 import { useLocalizedStringFormatter } from '../utils/intl'
 import messages from './intl/translations.json'
+import { useColorScheme } from './useColorScheme'
 
 export type ColorScheme = 'light' | 'dark' | 'light dark'
 
@@ -40,52 +41,30 @@ export const ColorSchemeSwitch: React.FC<ColorSchemeSwitchProps> = ({
   defaultValue,
   className,
 }) => {
-  const [colorScheme, setColorScheme] = React.useState<Set<Key>>(
-    defaultValue ?? new Set([scheme ?? defaultScheme]),
-  )
-
-  const resolvedKeys = scheme ? new Set<Key>([scheme]) : colorScheme
-
-  React.useEffect(() => {
-    const targetElement = document.querySelector<HTMLElement>(selector)
-
-    if (targetElement) {
-      const resolved = Array.from(resolvedKeys).join(' ')
-      targetElement.style.removeProperty('color-scheme')
-      if (resolved === 'light dark') {
-        delete targetElement.dataset.colorScheme
-      } else {
-        targetElement.dataset.colorScheme = resolved
-      }
-    } else {
-      console.warn(`No element found for selector: "${selector}"`)
-    }
-  }, [resolvedKeys, selector])
+  const { resolved, onChange } = useColorScheme({
+    selector,
+    defaultScheme: defaultValue
+      ? (Array.from(defaultValue)[0] as ColorScheme)
+      : defaultScheme,
+    scheme,
+    onSchemeChange,
+  })
 
   const strings = useLocalizedStringFormatter(messages)
 
   const handleSelectionChange = (keys: Set<Key>) => {
-    const next = Array.from(keys)[0] as ColorScheme
-    setColorScheme(keys)
-    onSchemeChange?.(next)
+    onChange(Array.from(keys)[0] as ColorScheme)
   }
 
   return (
     <ToggleButtonGroup
       selectionMode='single'
-      selectedKeys={resolvedKeys}
+      selectedKeys={new Set<Key>([resolved])}
       onSelectionChange={handleSelectionChange}
       disallowEmptySelection
+      aria-label={strings.format('colorScheme')}
       className={className}
     >
-      <ToggleButton
-        id='light dark'
-        className={styles.button}
-      >
-        <Laptop />
-        <VisuallyHidden>{strings.format('system')}</VisuallyHidden>
-        <SelectionIndicator className={styles.selectionIndicator} />
-      </ToggleButton>
       <ToggleButton
         id='light'
         className={styles.button}
@@ -100,6 +79,14 @@ export const ColorSchemeSwitch: React.FC<ColorSchemeSwitchProps> = ({
       >
         <Moon />
         <VisuallyHidden>{strings.format('darkMode')}</VisuallyHidden>
+        <SelectionIndicator className={styles.selectionIndicator} />
+      </ToggleButton>
+      <ToggleButton
+        id='light dark'
+        className={styles.button}
+      >
+        <ContrastFilled />
+        <VisuallyHidden>{strings.format('system')}</VisuallyHidden>
         <SelectionIndicator className={styles.selectionIndicator} />
       </ToggleButton>
     </ToggleButtonGroup>

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.module.css
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.module.css
@@ -1,0 +1,47 @@
+.trigger {
+  gap: var(--midas-space-50);
+  padding-inline-end: 0;
+
+  &[aria-expanded='true'] {
+    .chevron {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.chevron {
+  transition: transform var(--midas-transition-duration-instant)
+    var(--midas-transition-timing-ease-in-out);
+}
+
+.menu {
+  width: var(--midas-size-control);
+}
+
+.menuItem {
+  align-items: center;
+  background-color: var(--midas-layer-01-base);
+  color: var(--midas-icon-primary);
+  cursor: pointer;
+  display: flex;
+  height: var(--midas-size-control);
+  justify-content: center;
+  outline: none;
+  width: 100%;
+
+  &[data-hovered] {
+    background-color: var(--midas-layer-01-hover);
+  }
+
+  &[data-focus-visible] {
+    background-color: var(--midas-menu-item-background-selected);
+    box-shadow: var(--midas-state-focus-inset);
+  }
+
+  &[data-focused] {
+    @media (forced-colors: active) {
+      outline: var(--midas-state-focus-contrast-mode-outline) solid highlight;
+      outline-offset: calc(var(--midas-state-focus-contrast-mode-outline) * -1);
+    }
+  }
+}

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.spec.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.spec.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { composeStories } from '@storybook/react-vite'
+import * as stories from './ColorSchemeSwitchMenu.stories'
+import { render } from '../../test-utils'
+import { ColorSchemeSwitchMenu } from './ColorSchemeSwitchMenu'
+
+const { Primary } = composeStories(stories)
+
+afterEach(() => {
+  delete document.documentElement.dataset.colorScheme
+})
+
+describe('given a primary ColorSchemeSwitchMenu', () => {
+  it('should open the menu when the trigger is clicked', async () => {
+    await render(<Primary />)
+    await userEvent.click(page.getByRole('button', { name: 'Color scheme: Follows system' }))
+    await expect.element(page.getByRole('menu')).toBeVisible()
+  })
+
+  it('should set light color scheme when Light mode is selected', async () => {
+    await render(<Primary />)
+    await userEvent.click(page.getByRole('button', { name: 'Color scheme: Follows system' }))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Light mode' }))
+    expect(document.documentElement.dataset.colorScheme).toBe('light')
+  })
+
+  it('should set dark color scheme when Dark mode is selected', async () => {
+    await render(<Primary />)
+    await userEvent.click(page.getByRole('button', { name: 'Color scheme: Follows system' }))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Dark mode' }))
+    expect(document.documentElement.dataset.colorScheme).toBe('dark')
+  })
+
+  it('should remove data-colorScheme when Follows system is selected', async () => {
+    await render(<ColorSchemeSwitchMenu defaultScheme='light' />)
+    await userEvent.click(page.getByRole('button', { name: 'Color scheme: Light mode' }))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Follows system' }))
+    expect(document.documentElement.dataset.colorScheme).toBeUndefined()
+  })
+})
+
+describe('given a ColorSchemeSwitchMenu with onSchemeChange', () => {
+  it('should call onSchemeChange with the selected scheme', async () => {
+    const onSchemeChange = vi.fn()
+    await render(<ColorSchemeSwitchMenu onSchemeChange={onSchemeChange} />)
+    await userEvent.click(page.getByRole('button', { name: 'Color scheme: Follows system' }))
+    await userEvent.click(page.getByRole('menuitem', { name: 'Light mode' }))
+    expect(onSchemeChange).toHaveBeenCalledWith('light')
+  })
+})

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.stories.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { type ColorScheme } from './ColorSchemeSwitch'
+import { ColorSchemeSwitchMenu } from './ColorSchemeSwitchMenu'
+
+const meta: Meta<typeof ColorSchemeSwitchMenu> = {
+  component: ColorSchemeSwitchMenu,
+  title: 'Components/ColorSchemeSwitch/Menu',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ColorSchemeSwitchMenu>
+
+export const Primary: Story = {}
+
+export const DefaultDark: Story = {
+  args: {
+    defaultScheme: 'dark',
+  },
+}
+
+export const WithCallback: Story = {
+  render: () => {
+    const [last, setLast] = useState<ColorScheme | null>(null)
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <ColorSchemeSwitchMenu onSchemeChange={setLast} />
+        {last && <span>onSchemeChange called with: {last}</span>}
+      </div>
+    )
+  },
+}

--- a/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.tsx
+++ b/packages/components/src/color-scheme-switch/ColorSchemeSwitchMenu.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { ChevronDown, Moon, Sun } from 'lucide-react'
+import { ContrastFilled } from '../icons'
+import * as React from 'react'
+import { VisuallyHidden } from 'react-aria'
+import { Key, MenuItem as AriaMenuItem } from 'react-aria-components'
+import { Button } from '../button'
+import { Menu, MenuTrigger, MenuPopover } from '../menu'
+import clsx from '../utils/clsx'
+import { useLocalizedStringFormatter } from '../utils/intl'
+import type { ColorScheme, ColorSchemeSwitchProps } from './ColorSchemeSwitch'
+import styles from './ColorSchemeSwitchMenu.module.css'
+import messages from './intl/translations.json'
+import { useColorScheme } from './useColorScheme'
+
+const schemeIcon: Record<ColorScheme, React.ElementType> = {
+  light: Sun,
+  'light dark': ContrastFilled,
+  dark: Moon,
+}
+
+const schemeTriggerKey = (scheme: ColorScheme) =>
+  scheme === 'light'
+    ? 'triggerLightMode'
+    : scheme === 'dark'
+      ? 'triggerDarkMode'
+      : 'triggerSystem'
+
+export const ColorSchemeSwitchMenu: React.FC<
+  Omit<ColorSchemeSwitchProps, 'defaultValue'>
+> = ({
+  selector = ':root',
+  defaultScheme = 'light dark',
+  scheme,
+  onSchemeChange,
+  className,
+}) => {
+  const { resolved, onChange } = useColorScheme({
+    selector,
+    defaultScheme,
+    scheme,
+    onSchemeChange,
+  })
+  const Icon = schemeIcon[resolved]
+
+  React.useEffect(() => {
+    const targetElement = document.querySelector<HTMLElement>(selector)
+    if (!targetElement) {
+      console.warn(`No element found for selector: "${selector}"`)
+      return
+    }
+    if (resolved === 'light dark') {
+      delete targetElement.dataset.colorScheme
+    } else {
+      targetElement.dataset.colorScheme = resolved
+    }
+  }, [resolved, selector])
+
+  const strings = useLocalizedStringFormatter(messages)
+
+  const handleAction = (key: Key) => onChange(key as ColorScheme)
+
+  return (
+    <MenuTrigger>
+      <Button
+        variant='icon'
+        size='medium'
+        className={clsx(styles.trigger, className)}
+        aria-label={strings.format(schemeTriggerKey(resolved))}
+      >
+        <Icon size={20} />
+        <ChevronDown
+          size={20}
+          className={styles.chevron}
+        />
+      </Button>
+      <MenuPopover placement='bottom start'>
+        <Menu
+          onAction={handleAction}
+          className={styles.menu}
+        >
+          <AriaMenuItem
+            id='light'
+            textValue={strings.format('lightMode')}
+            className={styles.menuItem}
+          >
+            <Sun size={20} />
+            <VisuallyHidden>{strings.format('lightMode')}</VisuallyHidden>
+          </AriaMenuItem>
+          <AriaMenuItem
+            id='dark'
+            textValue={strings.format('darkMode')}
+            className={styles.menuItem}
+          >
+            <Moon size={20} />
+            <VisuallyHidden>{strings.format('darkMode')}</VisuallyHidden>
+          </AriaMenuItem>
+          <AriaMenuItem
+            id='light dark'
+            textValue={strings.format('system')}
+            className={styles.menuItem}
+          >
+            <ContrastFilled size={20} />
+            <VisuallyHidden>{strings.format('system')}</VisuallyHidden>
+          </AriaMenuItem>
+        </Menu>
+      </MenuPopover>
+    </MenuTrigger>
+  )
+}

--- a/packages/components/src/color-scheme-switch/index.ts
+++ b/packages/components/src/color-scheme-switch/index.ts
@@ -1,2 +1,3 @@
 export * from './ColorSchemeSwitch'
 export type { ColorSchemeSwitchProps } from './ColorSchemeSwitch'
+export * from './ColorSchemeSwitchMenu'

--- a/packages/components/src/color-scheme-switch/intl/translations.json
+++ b/packages/components/src/color-scheme-switch/intl/translations.json
@@ -1,12 +1,20 @@
 {
   "en": {
-    "darkMode": "Dark Mode",
-    "lightMode": "Light Mode",
-    "system": "System Setting"
+    "colorScheme": "Color scheme",
+    "darkMode": "Dark mode",
+    "lightMode": "Light mode",
+    "system": "Follows system",
+    "triggerDarkMode": "Color scheme: Dark mode",
+    "triggerLightMode": "Color scheme: Light mode",
+    "triggerSystem": "Color scheme: Follows system"
   },
   "sv": {
+    "colorScheme": "Färgschema",
     "darkMode": "Mörkt läge",
     "lightMode": "Ljust läge",
-    "system": "Systeminställning"
+    "system": "Följer systemet",
+    "triggerDarkMode": "Färgschema: Mörkt läge",
+    "triggerLightMode": "Färgschema: Ljust läge",
+    "triggerSystem": "Färgschema: Följer systemet"
   }
 }

--- a/packages/components/src/color-scheme-switch/useColorScheme.ts
+++ b/packages/components/src/color-scheme-switch/useColorScheme.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { ColorScheme } from './ColorSchemeSwitch'
+
+interface UseColorSchemeOptions {
+  selector?: string
+  defaultScheme?: ColorScheme
+  scheme?: ColorScheme
+  onSchemeChange?: (scheme: ColorScheme) => void
+}
+
+interface UseColorSchemeReturn {
+  resolved: ColorScheme
+  onChange: (next: ColorScheme) => void
+}
+
+export const useColorScheme = ({
+  selector = ':root',
+  defaultScheme = 'light dark',
+  scheme,
+  onSchemeChange,
+}: UseColorSchemeOptions): UseColorSchemeReturn => {
+  const [internal, setInternal] = useState<ColorScheme>(scheme ?? defaultScheme)
+
+  const resolved = scheme ?? internal
+
+  useEffect(() => {
+    const target = document.querySelector<HTMLElement>(selector)
+    if (!target) {
+      console.warn(`No element found for selector: "${selector}"`)
+      return
+    }
+    if (resolved === 'light dark') {
+      delete target.dataset.colorScheme
+    } else {
+      target.dataset.colorScheme = resolved
+    }
+  }, [resolved, selector])
+
+  const onChange = (next: ColorScheme) => {
+    setInternal(next)
+    onSchemeChange?.(next)
+  }
+
+  return { resolved, onChange }
+}


### PR DESCRIPTION
Adds a compact dropdown variant of `ColorSchemeSwitch` for use in space-constrained areas like headers.