### PR TITLE
fix(layout,main): correct main content padding

### DIFF
--- a/packages/layout/src/main/Main.module.css
+++ b/packages/layout/src/main/Main.module.css
@@ -5,7 +5,7 @@
   height: 100%;
   overflow: hidden auto;
   scrollbar-gutter: stable;
-  padding: 1rem;
+  padding: var(--midas-space-xlarge);
 
   &:focus-visible {
     box-shadow: var(--midas-state-focus-inset);


### PR DESCRIPTION
Fixes padding in the `Main` component from `1rem` to `2rem`, using the `--midas-space-xlarge` token.