### PR TITLE
build: add configuration to serve docs with hideAPI=true

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -18,6 +18,11 @@
       "options": {
         "hideApi": false,
         "port": 3000
+      },
+      "configurations": {
+        "fast": {
+          "hideApi": true
+        }
       }
     },
     "lint": {


### PR DESCRIPTION
## Description

When updating the docs I always run `DOCUSAURUS_HIDE_API=true nx serve docs` to view the docpage, as it takes forever otherwise. Its a long command, so I wanted to shorten it. You can now write `nx run docs:serve:fast` which is faster

## Changes

Added fast configuration to serve in `project.json`

## Additional Information

Optimally, I just want to write `nx serve docs:fast`. But it seems to be a no go :/

## Checklist

- [ ] Tests added if applicable
- [ ] Documentation updated
- [x] Conventional commit messages
