### PR TITLE
fix(components,calendar): set chevron icon size to 20 in CalendarHeader

### DIFF
--- a/packages/components/src/calendar/CalendarHeader.tsx
+++ b/packages/components/src/calendar/CalendarHeader.tsx
@@ -17,7 +17,7 @@ export const CalendarHeader: React.FC<CalendarHeaderProps> = ({
       size='medium'
       data-readonly={isReadOnly || undefined}
     >
-      <ChevronLeft />
+      <ChevronLeft size={20} />
     </Button>
     <Heading
       level={3}
@@ -29,7 +29,7 @@ export const CalendarHeader: React.FC<CalendarHeaderProps> = ({
       size='medium'
       data-readonly={isReadOnly || undefined}
     >
-      <ChevronRight />
+      <ChevronRight size={20} />
     </Button>
   </header>
 )


### PR DESCRIPTION
## Description

Navigation chevrons in `CalendarHeader` were rendered at Lucide's default 24px instead of the 20px used consistently across all other icon usages in the component library.

## Changes

- Set `size={20}` on `ChevronLeft` and `ChevronRight` in `CalendarHeader.tsx`