### PR TITLE
fix(docs,file-upload): set icon size to 20 in FileUpload example

### DIFF
--- a/apps/docs/src/components/examples/file-upload/FileUploadExamples.tsx
+++ b/apps/docs/src/components/examples/file-upload/FileUploadExamples.tsx
@@ -84,7 +84,7 @@ export const DropZoneExample = () => {
           onSelect={handleSelect}
         >
           <Button variant='secondary'>
-            <ArrowUpFromLine /> Välj fil
+            <ArrowUpFromLine size={20} /> Välj fil
           </Button>
         </FileTrigger>
         <Text slot='label'>Dra och släpp filer här</Text>


### PR DESCRIPTION
## Description

`ArrowUpFromLine` in the FileUpload docs example was rendered at Lucide's default 24px instead of the 20px used consistently across the component library.