### PR TITLE
docs(docs,layout): clarify that default.css is required and explain body margin

### DIFF
--- a/apps/docs/docs/dev/layout/index.mdx
+++ b/apps/docs/docs/dev/layout/index.mdx
@@ -100,11 +100,28 @@ Skissen nedan visar ett exempel på hur komponenterna kan sättas ihop. Vilket u
 npm install @midas-ds/layout
 ```
 
-Importera `default.css`. Denna fil innehåller global css för att layout-komponenterna ska få rätt utseende. Importera filen i roten av din applikation:
+Importera `default.css` i roten av din applikation. Denna fil innehåller global CSS som krävs för att layout-komponenterna ska fylla hela viewporten korrekt — bland annat `body { margin: 0 }` och `html { overflow: hidden }` för att förhindra att sidans scrollning konkurrerar med layoutens egna scrollbara regioner.
 
 ```tsx title="main.tsx"
 import '@midas-ds/layout/default.css'
 ```
+
+:::tip Avancerad installation
+
+Använder du den avancerade installationen och importerar `variables.css`, `fonts.css` och `color-scheme.css` separat istället för `default.css`? Kom då ihåg att lägga till nedanstående i din rot-CSS manuellt.
+
+:::
+
+```css title="index.css"
+html {
+  overflow: hidden;
+}
+
+body {
+  margin: 0;
+}
+```
+
 
 ## Snabbstart
 


### PR DESCRIPTION
## Description

Addresses feedback that it was unclear why `body { margin: 0 }` is needed when using the layout package.

## Changes

- Explains what `default.css` actually contains and why it's required for the layout to fill the viewport correctly
- Adds a tip callout for devs using the advanced install path (separate CSS imports) with the manual CSS they need to add