### PR TITLE
docs(docs): improve contribution docs with clearer onboarding and RAC guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Bidra till Midas
+
+Tack för att du vill bidra till Midas! Här är de snabbaste vägarna in.
+
+## Hittat en bugg eller har ett förslag?
+
+Öppna ett [Issue](https://github.com/migrationsverket/midas/issues/new/choose) och beskriv vad du hittade eller saknar.
+
+## Bidra med kod eller dokumentation
+
+```bash
+git clone https://github.com/migrationsverket/midas.git
+```
+
+Läs sedan vår [bidragsguide](https://designsystem.migrationsverket.se/get-started/contribute/) för hur du sätter upp miljön, skriver kod och skapar en Pull Request.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ nx serve storybook
 
 ## 🤝 Bidra
 
-Vi välkomnar bidrag! Läs vår [guide för att bidra](https://designsystem.migrationsverket.se/get-started/contribute/) för att komma igång.
+Vi välkomnar bidrag av alla slag — buggar, idéer, kod och dokumentation.
+
+- 🐛 **Hittat en bugg eller har ett förslag?** Öppna ett [Issue](https://github.com/migrationsverket/midas/issues/new/choose)
+- 💻 **Bidra med kod?** Klona repot, skapa en branch och öppna en Pull Request
+
+Läs vår fullständiga [bidragsguide](https://designsystem.migrationsverket.se/get-started/contribute/) för mer information.
 
 ## 📄 Licens
 

--- a/apps/docs/docs/get-started/contribute/architecture.mdx
+++ b/apps/docs/docs/get-started/contribute/architecture.mdx
@@ -45,6 +45,16 @@ Komponenter byggs **i första hand** på [React Aria Components](https://react-s
 - Ökar underhållsbördan för teamet
 - Riskerar att vi bygger egen komplexitet som redan är löst
 
+### RAC är i aktiv utveckling
+
+React Aria Components är ett aktivt projekt som regelbundet får nya komponenter, props och beteenden. Innan du försöker lösa något på egen hand — kolla om det redan finns eller är på väg:
+
+- 🔍 [RAC-releasar](https://github.com/adobe/react-spectrum/releases) — nya versioner kan ha exakt det du behöver
+- 📋 [Öppna issues](https://github.com/adobe/react-spectrum/issues) — kanske är funktionen redan planerad
+- 💬 [Discussions](https://github.com/adobe/react-spectrum/discussions) — se om andra har löst samma problem
+
+Det är nästan alltid bättre att vänta på en officiell RAC-lösning än att bygga en egen. En hemmasnickrad implementation riskerar att krocka med RAC:s API när det väl landar — och det landar förr eller senare.
+
 :::tip
 Om du behöver anpassa beteende, fråga dig först om React Aria redan har en lösning via props, composition eller hooks.
 :::

--- a/apps/docs/docs/get-started/contribute/coding.mdx
+++ b/apps/docs/docs/get-started/contribute/coding.mdx
@@ -7,7 +7,32 @@ sidebar_position: 1
 
 Här beskriver vi hur du sätter upp din utvecklingsmiljö för att kunna bidra till Midas.
 
-## 🐳 Docker (Rekommenderat)
+## 1. Forka och klona repot
+
+Källkoden finns på [GitHub](https://github.com/migrationsverket/midas). Eftersom du troligtvis inte har skrivrättigheter till repot direkt behöver du först **forka** det — det vill säga skapa en egen kopia på ditt GitHub-konto.
+
+1. Gå till [github.com/migrationsverket/midas](https://github.com/migrationsverket/midas)
+2. Klicka på **Fork** uppe till höger
+3. Klona din fork lokalt:
+
+```bash
+git clone https://github.com/<ditt-användarnamn>/midas.git
+cd midas
+```
+
+4. Lägg till originalrepot som `upstream` så att du kan hämta senaste ändringar:
+
+```bash
+git remote add upstream https://github.com/migrationsverket/midas.git
+```
+
+Nu är du redo att sätta upp din utvecklingsmiljö nedan.
+
+---
+
+## 2. Sätt upp utvecklingsmiljön
+
+### 🐳 Docker (Rekommenderat)
 
 Det snabbaste sättet att komma igång är med Docker. Då behöver du inte installera Node.js, npm eller några beroenden lokalt - allt körs i en isolerad miljö med exakt rätt versioner.
 
@@ -76,7 +101,7 @@ docker compose up -d
 
 ---
 
-## 💻 Lokal installation (Alternativ)
+### 💻 Lokal installation (Alternativ)
 
 Om du föredrar att köra allt lokalt behöver du:
 
@@ -115,7 +140,7 @@ nx build docs    # Produktionsbygge
 
 ---
 
-## 🧪 Testa lokalt end-to-end
+## 3. Testa lokalt end-to-end
 
 För att testa komponentbiblioteket i en annan app kan du publicera det till ett lokalt Verdaccio-registry.
 

--- a/apps/docs/docs/get-started/contribute/coding.mdx
+++ b/apps/docs/docs/get-started/contribute/coding.mdx
@@ -5,34 +5,13 @@ sidebar_position: 1
 
 # 🛠️ Sätt upp utvecklingsmiljön
 
-Här beskriver vi hur du sätter upp din utvecklingsmiljö för att kunna bidra till Midas.
-
-## 1. Forka och klona repot
-
-Källkoden finns på [GitHub](https://github.com/migrationsverket/midas). Eftersom du troligtvis inte har skrivrättigheter till repot direkt behöver du först **forka** det — det vill säga skapa en egen kopia på ditt GitHub-konto.
-
-1. Gå till [github.com/migrationsverket/midas](https://github.com/migrationsverket/midas)
-2. Klicka på **Fork** uppe till höger
-3. Klona din fork lokalt:
+Klona [repot](https://github.com/migrationsverket/midas) och välj ett av alternativen nedan.
 
 ```bash
-git clone https://github.com/<ditt-användarnamn>/midas.git
-cd midas
+git clone https://github.com/migrationsverket/midas.git
 ```
 
-4. Lägg till originalrepot som `upstream` så att du kan hämta senaste ändringar:
-
-```bash
-git remote add upstream https://github.com/migrationsverket/midas.git
-```
-
-Nu är du redo att sätta upp din utvecklingsmiljö nedan.
-
----
-
-## 2. Sätt upp utvecklingsmiljön
-
-### 🐳 Docker (Rekommenderat)
+## 🐳 Docker (Rekommenderat)
 
 Det snabbaste sättet att komma igång är med Docker. Då behöver du inte installera Node.js, npm eller några beroenden lokalt - allt körs i en isolerad miljö med exakt rätt versioner.
 
@@ -101,7 +80,7 @@ docker compose up -d
 
 ---
 
-### 💻 Lokal installation (Alternativ)
+## 💻 Lokal installation (Alternativ)
 
 Om du föredrar att köra allt lokalt behöver du:
 
@@ -140,7 +119,7 @@ nx build docs    # Produktionsbygge
 
 ---
 
-## 3. Testa lokalt end-to-end
+## 🧪 Testa lokalt end-to-end
 
 För att testa komponentbiblioteket i en annan app kan du publicera det till ett lokalt Verdaccio-registry.
 

--- a/apps/docs/docs/get-started/contribute/index.mdx
+++ b/apps/docs/docs/get-started/contribute/index.mdx
@@ -15,18 +15,28 @@ Ett av våra viktigaste mål är att erbjuda en så bra **developer experience (
 
 ## Hur du kan bidra
 
-- 🐛 **Rapportera buggar** — öppna ett [GitHub Issue](https://github.com/migrationsverket/midas/issues)
-- 💻 **Bidra med kod** — forka repot och öppna en Pull Request
-- 📝 **Förbättra dokumentation** — samma flöde som kodändringar
-- 💬 **Delta i diskussioner** — i [GitHub Discussions](https://github.com/migrationsverket/midas/discussions) eller i Issues
-- 🌟 **Dela din erfarenhet** av att använda Midas
+### 🐛 Hitta och rapportera buggar
 
-Din feedback och ditt engagemang är avgörande för att göra Midas bättre. Tveka inte att höra av dig!
+Hittat något som inte stämmer? Öppna ett [GitHub Issue](https://github.com/migrationsverket/midas/issues/new/choose). Beskriv vad du förväntade dig och vad som hände — en minimal reproduktion är guld värd.
+
+### 💡 Föreslå förbättringar
+
+Saknar du en komponent, ett prop eller ett beteende? Öppna ett Issue och berätta om ditt användningsfall. Vi läser allt.
+
+### 💻 Bidra med kod
+
+Klona repot, skapa en branch och öppna en Pull Request mot `main`. Läs [Utvecklingsmiljö](/get-started/contribute/coding) för att komma igång och [Bidra med kod](/get-started/contribute/contributing) för krav och checklista.
+
+### 📝 Förbättra dokumentation
+
+Otydlig text, saknade exempel eller felaktig information — dokumentationsändringar är lika välkomna som kodändringar och följer samma PR-flöde.
 
 ---
 
 ## 📚 Fördjupning
 
-- [Design Tokens](/get-started/contribute/tokens) - Arbeta med design tokens
+- [Utvecklingsmiljö](/get-started/contribute/coding) - Klona repot och sätt upp miljön
+- [Bidra med kod](/get-started/contribute/contributing) - Krav, workflow och PR-checklista
 - [Arkitektur](/get-started/contribute/architecture) - Vår designfilosofi och val av beroenden
 - [Arbetsflöde](/get-started/contribute/conventions) - Commit-format och versionshantering
+- [Design Tokens](/get-started/contribute/tokens) - Arbeta med design tokens

--- a/apps/docs/docs/get-started/contribute/index.mdx
+++ b/apps/docs/docs/get-started/contribute/index.mdx
@@ -5,16 +5,20 @@ sidebar_position: 0
 
 # 🤝 Bidra till Midas
 
+Midas är ett **öppet källkodsprojekt** på GitHub — vem som helst kan bidra.
+
+[![GitHub](https://img.shields.io/badge/migrationsverket%2Fmidas-24292e?style=flat-square&logo=github)](https://github.com/migrationsverket/midas)
+
 Midas komponentbibliotek är **gemenskapsdriven** - det är ett strategiskt mål att biblioteket produceras av och för användarcommunityn. Ett litet core-team ansvarar för att hantera projektet och säkerställa kvalitet, men **bidrag från användare är mer än välkomna**.
 
 Ett av våra viktigaste mål är att erbjuda en så bra **developer experience (DX)** som möjligt. För att uppnå detta behöver vi er feedback, era idéer och era bidrag. Genom att vara gemenskapsdrivna säkerställer vi att biblioteket möter verkliga behov och utmaningar som ni stöter på i era projekt.
 
 ## Hur du kan bidra
 
-- 🐛 **Rapportera buggar** och föreslå förbättringar
-- 💻 **Bidra med kod** för nya komponenter eller funktionalitet
-- 📝 **Förbättra dokumentation**
-- 💬 **Delta i diskussioner** och code reviews
+- 🐛 **Rapportera buggar** — öppna ett [GitHub Issue](https://github.com/migrationsverket/midas/issues)
+- 💻 **Bidra med kod** — forka repot och öppna en Pull Request
+- 📝 **Förbättra dokumentation** — samma flöde som kodändringar
+- 💬 **Delta i diskussioner** — i [GitHub Discussions](https://github.com/migrationsverket/midas/discussions) eller i Issues
 - 🌟 **Dela din erfarenhet** av att använda Midas
 
 Din feedback och ditt engagemang är avgörande för att göra Midas bättre. Tveka inte att höra av dig!


### PR DESCRIPTION
## Description

Addresses feedback that it was unclear how to contribute to Midas as an open source project.

## Changes

- `index.mdx` — makes the GitHub link prominent, restructures "Hur du kan bidra" into named sections with links, removes Discussions
- `coding.mdx` — replaces the overly detailed fork/clone section with a simple one-liner, removes filler text
- `architecture.mdx` — adds a "RAC är i aktiv utveckling" section encouraging contributors to check RAC releases and issues before rolling their own solutions
- `README.md` — expands the Bidra section with specific action points
- `CONTRIBUTING.md` — new file at repo root (GitHub surfaces this automatically on Issues/PR pages)