### PR TITLE
docs(components): document errorMessage function variant in forms guide

### DIFF
--- a/apps/docs/docs/components/textfield.mdx
+++ b/apps/docs/docs/components/textfield.mdx
@@ -95,6 +95,10 @@ TextField kan valideras precis som en standard `<input>` via **HTML constraint v
 `type="email"`, `isRequired`, `minLength` etc, eller ett eget `pattern` för godtycklig regular expression. Felmeddelanden
 renderas automatiskt på valt språk i browsern. Se [API](#api) för möjliga varianter.
 
+### Felmeddelanden
+
+`errorMessage` accepterar en sträng eller en funktion för constraint-specifika meddelanden. Se [Formulär — Felmeddelanden](/dev/forms#constraint-specifika-felmeddelanden) för mer info och exempel.
+
 ### Egen validering
 
 Komponenten kan valideras med en egen funktion `validate()`.

--- a/apps/docs/docs/dev/forms.mdx
+++ b/apps/docs/docs/dev/forms.mdx
@@ -9,6 +9,7 @@ import {
   RealtimeValidation,
   ServerValidation,
 } from '@site/src/components/examples/form/FormExamples'
+import { ErrorMessageExample } from '@site/src/components/examples/form/TextFieldExamples'
 
 # Formulär
 
@@ -184,6 +185,29 @@ export const RealtimeValidation = () => {
 :::info
 Felmeddelande kan presenteras under eller över formulärskomponenten via `errorPosition`.
 :::
+
+### Constraint-specifika felmeddelanden
+
+Prop `errorMessage` accepterar antingen en sträng eller en funktion — `(validation: ValidationResult) => string`.
+
+Strängen räcker i de flesta fall. Funktionen är användbar när du kombinerar flera HTML constraint-regler och vill ge användaren ett specifikt meddelande beroende på *varför* fältet är ogiltigt. Funktionen tar emot ett `ValidationResult`-objekt med `validationDetails` som berättar exakt vilket krav som bröts:
+
+```tsx
+<TextField
+  label='Användarnamn'
+  minLength={3}
+  isRequired
+  errorMessage={({ validationDetails }) => {
+    if (validationDetails.tooShort) return 'Minst 3 tecken krävs'
+    if (validationDetails.valueMissing) return 'Fältet är obligatoriskt'
+    return 'Ogiltigt värde'
+  }}
+/>
+```
+
+<div className='card'>
+  <ErrorMessageExample />
+</div>
 
 ### Server validation
 

--- a/apps/docs/src/components/examples/form/TextFieldExamples.tsx
+++ b/apps/docs/src/components/examples/form/TextFieldExamples.tsx
@@ -1,6 +1,23 @@
 import { TextField, Text } from '@midas-ds/components'
 import * as React from 'react'
 
+export function ErrorMessageExample() {
+  return (
+    <div className='card'>
+      <TextField
+        label='Användarnamn'
+        minLength={3}
+        isRequired
+        errorMessage={({ validationDetails }) => {
+          if (validationDetails.tooShort) return 'Minst 3 tecken krävs'
+          if (validationDetails.valueMissing) return 'Fältet är obligatoriskt'
+          return 'Ogiltigt värde'
+        }}
+      />
+    </div>
+  )
+}
+
 export function ControlledValue() {
   const [text, setText] = React.useState('')
 


### PR DESCRIPTION
## Summary

- Adds a "Constraint-specifika felmeddelanden" section to the forms guide (`/dev/forms`) explaining when to use `errorMessage` as a string vs. a function, with a live example
- Adds a short pointer in the TextField docs linking to the forms guide
- Puts the explanation in a shared location so it's discoverable for all field components (ComboBox, Select, DatePicker, etc.)

## Test plan

- [ ] Visit `/dev/forms` — new section renders correctly with live example
- [ ] Visit `/components/textfield` — link to forms guide works
- [ ] Try submitting empty, then a 1-char value in the live example to see different messages