### PR TITLE
fix(components,accordion): ignore type prop when isContained is false

### DIFF
--- a/packages/components/src/accordion/AccordionItem.spec.tsx
+++ b/packages/components/src/accordion/AccordionItem.spec.tsx
@@ -3,7 +3,7 @@ import { composeStories } from '@storybook/react-vite'
 import * as stories from './AccordionItem.stories'
 import { render } from '../../test-utils'
 
-const { Default, Success, Info, Warning, Important } = composeStories(stories)
+const { Default, Success, Info, Warning, Important, TypeWithoutContained } = composeStories(stories)
 
 describe('given a Default AccordionItem', async () => {
   it('should accept a function as children', async () => {
@@ -53,5 +53,12 @@ describe('given an AccordionItem with type = "important"', async () => {
     await expect
       .element(getByLabelText('important information'))
       .toBeInTheDocument()
+  })
+})
+
+describe('given an AccordionItem with type but without isContained', async () => {
+  it('should not render the status icon', async () => {
+    const { container } = await render(<TypeWithoutContained />)
+    expect(container.querySelector('svg[aria-label]')).toBeNull()
   })
 })

--- a/packages/components/src/accordion/AccordionItem.stories.tsx
+++ b/packages/components/src/accordion/AccordionItem.stories.tsx
@@ -60,6 +60,13 @@ export const Important: Story = {
   },
 }
 
+export const TypeWithoutContained: Story = {
+  args: {
+    type: 'success',
+    isContained: false,
+  },
+}
+
 export const Disabled: Story = {
   args: {
     isDisabled: true,

--- a/packages/components/src/accordion/AccordionItem.tsx
+++ b/packages/components/src/accordion/AccordionItem.tsx
@@ -70,7 +70,7 @@ export const AccordionItem = ({
       {...props}
       className={clsx(
         itemStyles.item,
-        type && itemStyles[type],
+        type && isContained && itemStyles[type],
         (size === 'medium' || context?.size === 'medium') && itemStyles.medium,
         isContained && itemStyles.contained,
         className,
@@ -101,7 +101,7 @@ export const AccordionItem = ({
                   </Heading>
                 )}
               </div>
-              {type && (
+              {type && isContained && (
                 <FeedbackStatusIcon
                   aria-label={iconAriaLabel}
                   className={itemStyles.statusIcon}


### PR DESCRIPTION
## Summary

- `type` prop on `AccordionItem` now has no visual effect when `isContained` is false — the color CSS class and status icon are both guarded
- Existing `console.warn` is kept for dev feedback
- Added `TypeWithoutContained` story and a test verifying the status icon is not rendered in this case

## Test plan

- [ ] `nx test components -- accordion/AccordionItem.spec` passes (7 tests)
- [ ] Setting `type` on an uncontained `AccordionItem` renders no color or icon
- [ ] Setting `type` with `isContained` still works as before