### PR TITLE
test(components,accordion): replace misleading AccordionHasBackground story and add JSDoc

### DIFF
--- a/packages/components/src/accordion/Accordion.stories.tsx
+++ b/packages/components/src/accordion/Accordion.stories.tsx
@@ -158,25 +158,3 @@ const ExpandableStuff = () => {
   )
 }
 
-export const AccordionHasBackground: Story = {
-  args: {
-    isContained: true,
-    children: ITEMS.map((item, i) => (
-      <AccordionItem
-        id={item}
-        key={item}
-        title={'En öppningsbar panel ' + item.toLocaleLowerCase()}
-        type={i === 2 ? 'success' : i === 3 ? 'warning' : undefined}
-      >
-        Innehåll i öppningsbar panel {item} Lorem ipsum dolor sit amet
-        consectetur adipisicing elit. Repellendus perspiciatis officia,
-        voluptate ratione quam nemo quod aut maiores animi nostrum, in labore
-        adipisci ullam suscipit esse vel odit tenetur dicta. Lorem ipsum dolor,
-        sit amet consectetur adipisicing elit. Impedit dolorem tempora
-        laboriosam asperiores eum dignissimos accusantium voluptate eligendi
-        beatae vel quis rerum error dolore cum incidunt pariatur accusamus,
-        illum consequuntur?
-      </AccordionItem>
-    )),
-  },
-}

--- a/packages/components/src/accordion/AccordionItem.stories.tsx
+++ b/packages/components/src/accordion/AccordionItem.stories.tsx
@@ -74,3 +74,19 @@ export const StatusDisabled: Story = {
     isContained: true,
   },
 }
+
+export const HasBackground: Story = {
+  args: {
+    type: 'success',
+    isContained: true,
+    hasBackground: true,
+  },
+}
+
+export const NoBackground: Story = {
+  args: {
+    type: 'success',
+    isContained: true,
+    hasBackground: false,
+  },
+}

--- a/packages/components/src/accordion/AccordionItem.tsx
+++ b/packages/components/src/accordion/AccordionItem.tsx
@@ -26,7 +26,7 @@ export interface AccordionItemProps extends DisclosureProps {
   /** Display an accordion item with different type styles. */
   type?: FeedbackStatus
   /**
-   * Adds a background element to the content, set to false for a transparent look
+   * Adds a neutral background to the content area. When using `type`, set to `false` to let the status color show through the content area as well.
    * @default true
    **/
   hasBackground?: boolean


### PR DESCRIPTION
## Summary

- Removed `AccordionHasBackground` story from `Accordion.stories.tsx` — it never actually used `hasBackground` and was visually identical to a plain contained accordion
- Added `HasBackground` and `NoBackground` stories to `AccordionItem.stories.tsx` where the prop actually lives and the props panel works correctly
- Improved JSDoc on `hasBackground` to clarify its relationship with `type`

No behaviour changes.