### PR TITLE
fix(theme): use opacity tokens for secondary button hover/active

### DIFF
--- a/packages/theme/tokens/buttons.json
+++ b/packages/theme/tokens/buttons.json
@@ -23,11 +23,11 @@
           "$description": "Färg på sekundärknapp"
         },
         "hover": {
-          "$value": "light-dark({color.white.hover}, {color.gray.190})",
+          "$value": "light-dark({color.black.opacity5}, {color.white.opacity13})",
           "$description": "Hover state på sekundärknapp"
         },
         "active": {
-          "$value": "light-dark({color.gray.30}, {color.gray.180})",
+          "$value": "light-dark({color.black.opacity10}, {color.white.opacity15})",
           "$description": "Active state för sekundärknapp"
         }
       },
@@ -37,7 +37,7 @@
           "$description": "Hover state för tertiär knapp"
         },
         "active": {
-          "$value": "light-dark({color.gray.30}, {color.gray.180})",
+          "$value": "light-dark({color.black.opacity10}, {color.white.opacity15})",
           "$description": "Active state för tertiär knapp"
         }
       },

--- a/packages/theme/tokens/colors.json
+++ b/packages/theme/tokens/colors.json
@@ -15,6 +15,10 @@
       "opacity5": {
         "$value": "#0000000d",
         "$description": "Black with 5% opacity"
+      },
+      "opacity10": {
+        "$value": "#0000001a",
+        "$description": "Black with 10% opacity"
       }
     },
     "white": {
@@ -30,6 +34,10 @@
       "opacity13": {
         "$value": "#ffffff21",
         "$description": "White with 13% opacity"
+      },
+      "opacity15": {
+        "$value": "#ffffff26",
+        "$description": "White with 15% opacity"
       }
     },
     "gray": {


### PR DESCRIPTION
Secondary button hover/active used solid gray tokens that broke on `layer-01` (invisible or wrong direction in dark mode). Switched to opacity-based tokens that work on any surface.

- `secondary.hover`: `light-dark(black.opacity5, white.opacity13)`
- `secondary.active`: `light-dark(black.opacity10, white.opacity15)`
- Added `black.opacity10`, `white.opacity15`, `white.opacity20` to color primitives