### PR TITLE
fix(components,link): add visually hidden label for new-tab and download icons

### DIFF
--- a/apps/playground/src/pages/LinkA11yPage.tsx
+++ b/apps/playground/src/pages/LinkA11yPage.tsx
@@ -1,0 +1,46 @@
+import { Link, LinkButton } from '@midas-ds/components'
+
+export function LinkA11yPage() {
+  return (
+    <div style={{ padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem', maxWidth: '600px' }}>
+      <h1>Link — skärmläsartest</h1>
+
+      <div>
+        <p>Extern länk (öppnas i ny flik)</p>
+        <Link href='https://example.com' target='_blank'>Besök exempel.se</Link>
+      </div>
+
+      <div>
+        <p>Vanlig länk (ingen ikon)</p>
+        <Link href='#'>Intern länk</Link>
+      </div>
+
+      <div>
+        <p>Fristående länk</p>
+        <Link href='#' standalone>Läs mer</Link>
+      </div>
+
+      <div>
+        <p>Nedladdningslänk</p>
+        <Link href='#' download>Ladda ner fil</Link>
+      </div>
+
+      <h1>LinkButton — skärmläsartest</h1>
+
+      <div>
+        <p>Extern knapp-länk (öppnas i ny flik)</p>
+        <LinkButton href='https://example.com' target='_blank'>Besök exempel.se</LinkButton>
+      </div>
+
+      <div>
+        <p>Vanlig knapp-länk</p>
+        <LinkButton href='#'>Gå vidare</LinkButton>
+      </div>
+
+      <div>
+        <p>Bakåt-knapp</p>
+        <LinkButton href='#' iconPlacement='left'>Föregående steg</LinkButton>
+      </div>
+    </div>
+  )
+}

--- a/packages/components/src/link-button/LinkButton.spec.tsx
+++ b/packages/components/src/link-button/LinkButton.spec.tsx
@@ -3,7 +3,20 @@ import { composeStories } from '@storybook/react-vite'
 import * as stories from './LinkButton.stories'
 import { render } from '../../test-utils'
 
-const { Primary, Secondary, Tertiary, Danger, Disabled } = composeStories(stories)
+const { Primary, Secondary, Tertiary, Danger, Disabled, NewTab } = composeStories(stories)
+
+describe('given a LinkButton that opens in a new tab', async () => {
+  it('should include visually hidden text for the new tab icon', async () => {
+    const { getByText } = await render(<NewTab />)
+    expect(getByText('Opens in new tab')).toBeDefined()
+  })
+
+  it('should hide the icon from the accessibility tree', async () => {
+    const { container } = await render(<NewTab />)
+    const icon = container.querySelector('svg')
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+  })
+})
 
 describe('given a disabled LinkButton', async () => {
   it('should have cursor not allowed when disabled', async () => {

--- a/packages/components/src/link-button/LinkButton.stories.tsx
+++ b/packages/components/src/link-button/LinkButton.stories.tsx
@@ -83,3 +83,11 @@ export const Danger: Story = {
     variant: 'danger',
   },
 }
+
+export const NewTab: Story = {
+  args: {
+    children: 'Öppnas i ny flik',
+    href: 'https://example.com',
+    target: '_blank',
+  },
+}

--- a/packages/components/src/link-button/LinkButton.tsx
+++ b/packages/components/src/link-button/LinkButton.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { Link as AriaLink, RouterProvider } from 'react-aria-components'
+import { VisuallyHidden } from 'react-aria'
 import styles from './LinkButton.module.css'
 import clsx from '../utils/clsx'
 import {
@@ -12,6 +13,8 @@ import {
   SquareArrowOutUpRight,
 } from 'lucide-react'
 import { Size } from '../common/types'
+import { useLocalizedStringFormatter } from '../utils/intl'
+import messages from './intl/translations.json'
 
 export interface LinkButtonComponentProps<C extends React.ElementType> {
   children: React.ReactNode
@@ -66,14 +69,16 @@ export const LinkButton = <C extends React.ElementType = typeof AriaLink>({
 }: LinkButtonProps<C>) => {
   const Component = as || AriaLink
 
-  const getIcon = (): LucideIcon => {
-    if (customIcon) return customIcon
-    if (rest.target === '_blank') return SquareArrowOutUpRight
-    if (iconPlacement === 'left') return ArrowLeft
-    return ArrowRight
+  const strings = useLocalizedStringFormatter(messages)
+
+  const getIcon = (): { icon: LucideIcon; label?: string } => {
+    if (customIcon) return { icon: customIcon }
+    if (rest.target === '_blank') return { icon: SquareArrowOutUpRight, label: strings.format('opensInNewTab') }
+    if (iconPlacement === 'left') return { icon: ArrowLeft }
+    return { icon: ArrowRight }
   }
 
-  const icon = getIcon()
+  const iconConfig = getIcon()
 
   return (
     <Component
@@ -94,9 +99,11 @@ export const LinkButton = <C extends React.ElementType = typeof AriaLink>({
       {children}
       <Icon
         className={styles.icon}
-        icon={icon}
+        icon={iconConfig.icon}
         size={20}
+        aria-hidden={true}
       />
+      {iconConfig.label && <VisuallyHidden>{iconConfig.label}</VisuallyHidden>}
     </Component>
   )
 }

--- a/packages/components/src/link-button/intl/translations.json
+++ b/packages/components/src/link-button/intl/translations.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "opensInNewTab": "Opens in new tab"
+  },
+  "sv": {
+    "opensInNewTab": "Öppnas i ny flik"
+  }
+}

--- a/packages/components/src/link/Link.spec.tsx
+++ b/packages/components/src/link/Link.spec.tsx
@@ -4,7 +4,20 @@ import * as stories from './Link.stories'
 import { render } from '../../test-utils'
 import { userEvent } from 'vitest/browser'
 
-const { PrimaryDisabled } = composeStories(stories)
+const { PrimaryDisabled, ExternalLink } = composeStories(stories)
+
+describe('given a link that opens in a new tab', async () => {
+  it('should include visually hidden text for the new tab icon', async () => {
+    const { getByText } = await render(<ExternalLink />)
+    expect(getByText('Opens in new tab')).toBeDefined()
+  })
+
+  it('should hide the icon from the accessibility tree', async () => {
+    const { container } = await render(<ExternalLink />)
+    const icon = container.querySelector('svg')
+    expect(icon?.getAttribute('aria-hidden')).toBe('true')
+  })
+})
 
 describe('given a disabled link', async () => {
   afterEach(() => {

--- a/packages/components/src/link/Link.tsx
+++ b/packages/components/src/link/Link.tsx
@@ -2,6 +2,7 @@
 
 import styles from './Link.module.css'
 import { Link as AriaLink, RouterProvider } from 'react-aria-components'
+import { VisuallyHidden } from 'react-aria'
 import clsx from '../utils/clsx'
 import {
   ArrowDownToLine,
@@ -10,6 +11,8 @@ import {
   SquareArrowOutUpRight,
   type LucideIcon,
 } from 'lucide-react'
+import { useLocalizedStringFormatter } from '../utils/intl'
+import messages from './intl/translations.json'
 
 export interface LinkComponentProps<C extends React.ElementType> {
   children: React.ReactNode
@@ -42,15 +45,17 @@ export const Link = <C extends React.ElementType = typeof AriaLink>({
 }: LinkProps<C>) => {
   const Component = as || AriaLink
 
-  const getIcon = (): LucideIcon | null => {
-    if (customIcon) return customIcon
-    if (download) return ArrowDownToLine
-    if (target === '_blank') return SquareArrowOutUpRight
-    if (standalone) return ArrowRight
+  const strings = useLocalizedStringFormatter(messages)
+
+  const getIcon = (): { icon: LucideIcon; label?: string } | null => {
+    if (customIcon) return { icon: customIcon }
+    if (download) return { icon: ArrowDownToLine, label: strings.format('downloadsFile') }
+    if (target === '_blank') return { icon: SquareArrowOutUpRight, label: strings.format('opensInNewTab') }
+    if (standalone) return { icon: ArrowRight }
     return null
   }
 
-  const icon = getIcon()
+  const iconConfig = getIcon()
 
   return (
     <Component
@@ -62,17 +67,20 @@ export const Link = <C extends React.ElementType = typeof AriaLink>({
       )}
       {...rest}
       target={target}
+      download={download}
     >
-      <>
-        {children}
-        {icon ? (
+      {children}
+      {iconConfig ? (
+        <>
           <Icon
             className={styles.icon}
-            icon={icon}
+            icon={iconConfig.icon}
             size={16}
+            aria-hidden={true}
           />
-        ) : null}
-      </>
+          {iconConfig.label && <VisuallyHidden>{iconConfig.label}</VisuallyHidden>}
+        </>
+      ) : null}
     </Component>
   )
 }

--- a/packages/components/src/link/intl/translations.json
+++ b/packages/components/src/link/intl/translations.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "opensInNewTab": "Opens in new tab",
+    "downloadsFile": "Downloads file"
+  },
+  "sv": {
+    "opensInNewTab": "Öppnas i ny flik",
+    "downloadsFile": "Hämtar fil"
+  }
+}


### PR DESCRIPTION
## Summary

- `Link` and `LinkButton` now include a `VisuallyHidden` span inside the anchor when rendering the external link (🗗) or download (↓) icon, so screen readers announce e.g. *"Besök exempel.se, Öppnas i ny flik, länk"* as one unit on focus
- Icon gets `aria-hidden={true}` so it's not read as a separate element
- Labels are i18n'd via `translations.json` (en/sv) using `useLocalizedStringFormatter`
- Also fixes a pre-existing bug where `download` prop was swallowed by destructuring and never forwarded to the `<a>` element — download links had the icon but no actual download behavior
- Added `NewTab` story and tests for both components

## Test plan

- [ ] Tab to an external `Link` or `LinkButton` — screen reader should read the full label including "Öppnas i ny flik"
- [ ] Download link actually triggers download (fixed regression)
- [ ] `nx test components` passes