### PR TITLE
chore(storybook): fix stale preview deploys

### DIFF
--- a/.github/workflows/deploy-docs-pr.yml
+++ b/.github/workflows/deploy-docs-pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build storybook
         if: github.event.action != 'closed'
-        run: npx nx run storybook:build:ci
+        run: npx nx run storybook:build:ci --skip-nx-cache
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -31,6 +31,8 @@ export default {
     },
   },
   staticDirs: [join(basePath, 'static')],
+  managerHead: head => `${head}<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />`,
+  previewHead: head => `${head}<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />`,
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {


### PR DESCRIPTION
## Summary

- Adds `--skip-nx-cache` to the Storybook build step in the PR deploy workflow — ensures Nx always rebuilds instead of potentially serving cached output
- Adds `Cache-Control: no-cache` meta tags to both the Storybook manager and preview frames — tells browsers not to cache the HTML entry points between visits

## Why

UX was seeing stale Storybook previews (over a day old) after new commits were pushed. Two potential culprits: Nx reusing a cached build, and browsers/CDN serving old `index.html`.