### PR TITLE
chore(ci): separate PR preview cleanup into dedicated workflow

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,28 @@
+name: 'Cleanup PR Preview'
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  cleanup:
+    name: Remove PR preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/docs
+          pages-base-url: 'designsystem.migrationsverket.se'

--- a/.github/workflows/deploy-docs-pr.yml
+++ b/.github/workflows/deploy-docs-pr.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
 
 permissions:
   contents: write
@@ -39,15 +38,12 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        if: github.event.action != 'closed'
         run: npm ci
 
       - name: Lint, test and build website
-        if: github.event.action != 'closed'
         run: npx nx run-many -t lint,test,build --projects=docs
 
       - name: Build storybook
-        if: github.event.action != 'closed'
         run: npx nx run storybook:build:ci --skip-nx-cache
 
       - name: Deploy preview


### PR DESCRIPTION
## Summary

- Extracts PR preview cleanup into its own `cleanup-pr-preview.yml` workflow that fires exclusively on `pull_request: closed`
- Removes `closed` from the deploy workflow triggers and strips the `if: github.event.action != 'closed'` guards that were no longer needed
- Adds `--skip-nx-cache` to the Storybook build step (same fix as #1296)

## Why

The `closed` event was mixed into the deploy workflow behind a job condition that skips `chore/` and `ops/` branches — meaning those PRs never got their preview cleaned up. Over time this caused 1000+ stale preview directories to accumulate in the `gh-pages` branch, making GitHub Pages deployments time out during file sync.

A dedicated cleanup workflow has no branch conditions and can't be accidentally skipped.