### PR TITLE
feat(layout,header): responsive header improvements

### DIFF
--- a/apps/docs/docs/dev/layout/components/header.mdx
+++ b/apps/docs/docs/dev/layout/components/header.mdx
@@ -1,9 +1,10 @@
 ---
 title: Header
-description: Sidhuvud med stöd för logotyp, åtgärdsknappar och mobilmeny.
+description: Sidhuvud med stöd för logotyp, systemnamn, åtgärdsknappar och mobilmeny.
 ---
 
 import { ComponentHeader } from '@site/src/components/getComponentMetaData'
+import { BasicHeaderExample, MobileHeaderExample, OverflowHeaderExample } from '@site/src/components/examples/layout/HeaderExamples'
 
 <ComponentHeader
   name='Header'
@@ -14,87 +15,164 @@ import { ComponentHeader } from '@site/src/components/getComponentMetaData'
 
 # Header
 
-Sidhuvudet innehåller logotypen och plats för åtgärdsknappar. På mobil används `MobileMenu` för att visa navigationen som ett drawer-mönster.
+Sidhuvudet innehåller logotyp, systemnamn och åtgärdsknappar. På mobil används `MobileMenu` för att visa navigationen som ett drawer-mönster.
 
-## Header
+## Grundläggande exempel
 
-Semantiskt `<header>`-element. Tillhandahåller kontext för logotypstorlek (responsiv).
+<BasicHeaderExample />
 
 ```tsx
-import { Header } from '@midas-ds/layout'
-import { Logo } from '@midas-ds/components'
+import { Bell, Settings, User } from 'lucide-react'
+import { Header, HeaderAction, HeaderActions, HeaderLogo, HeaderTitle } from '@midas-ds/layout'
 
 <Header>
-  <Logo />
+  <HeaderLogo />
+  <HeaderTitle>Mitt system</HeaderTitle>
+  <HeaderActions>
+    <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+    <HeaderAction icon={<User size={20} />}>Min profil</HeaderAction>
+    <HeaderAction icon={<Settings size={20} />}>Inställningar</HeaderAction>
+  </HeaderActions>
 </Header>
 ```
 
-## HeaderActions & HeaderAction
+## Med MobileMenu
 
-`HeaderActions` är en container för knappar längst till höger i sidhuvudet. `HeaderAction` är en enskild knapp med ikon och/eller etikett.
+På smala skärmar (≤ 640px) döljs sidomenyn. Lägg till `MobileMenu` i headern så att mobilanvändare ändå kan nå navigationen.
+
+<MobileHeaderExample />
 
 ```tsx
-import { Header, HeaderActions, HeaderAction } from '@midas-ds/layout'
-import { Bell, User } from 'lucide-react'
+import { Header, HeaderLogo, HeaderTitle, HeaderActions, HeaderAction, MobileMenu, Navigation, NavigationItem, NavigationLink } from '@midas-ds/layout'
+import { Bell, House } from 'lucide-react'
 
 <Header>
+  <MobileMenu title='Mitt system'>
+    <Navigation>
+      <NavigationItem>
+        <NavigationLink href='/' icon={<House />} isActive>Hem</NavigationLink>
+      </NavigationItem>
+    </Navigation>
+  </MobileMenu>
+  <HeaderLogo />
+  <HeaderTitle>Mitt system</HeaderTitle>
   <HeaderActions>
-    <HeaderAction icon={<Bell />}>Notiser</HeaderAction>
-    <HeaderAction icon={<User />}>Min profil</HeaderAction>
+    <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
   </HeaderActions>
 </Header>
 ```
 
 :::note
 
-`HeaderAction` renderar som en `tertiary`-knapp av storlek `medium`. Om du utelämnar både `icon` och `children` får du en varning i development-läge.
+`MobileMenu` renderar ingenting på desktop — den är villkorsstyrd via `useIsMobileDevice()`. Det är säkert att alltid inkludera den i trädet.
 
 :::
 
-## MobileMenu
+## Overflow-meny för många åtgärder
 
-En drawer-meny som bara visas på mobila enheter. Används för att ge mobilanvändare tillgång till navigationen.
+`HeaderActions` hanterar inte overflow automatiskt. När din app har många åtgärder och du vill dölja några i en meny på smala skärmar, löser du det med en mediaquery. Det ger full kontroll — rätt breakpoint beror på kombinationen av systemnamn, logotyp och antal knappar.
+
+Prova att ändra bredden på fönstret nedan för att se beteendet:
+
+<OverflowHeaderExample />
 
 ```tsx
-import { Header, MobileMenu, Navigation, NavigationItem, NavigationLink } from '@midas-ds/layout'
-import { House } from 'lucide-react'
+import { useMediaQuery } from '@react-spectrum/utils'
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from '@midas-ds/components'
+import { Bell, MoreHorizontal, Settings, User } from 'lucide-react'
+
+const collapsibleActions = [
+  { id: 'profile', label: 'Min profil', icon: <User size={20} /> },
+  { id: 'settings', label: 'Inställningar', icon: <Settings size={20} /> },
+]
 
 function AppHeader() {
+  // Välj den breakpoint som passar din app
+  const isNarrow = useMediaQuery('(max-width: 700px)')
+
   return (
     <Header>
-      <MobileMenu title='Meny'>
-        <Navigation>
-          <NavigationItem>
-            <NavigationLink
-              href='/'
-              icon={<House />}
-              isActive
-            >
-              Hem
-            </NavigationLink>
-          </NavigationItem>
-        </Navigation>
-      </MobileMenu>
+      <HeaderActions>
+        <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+        {isNarrow ? (
+          <MenuTrigger>
+            <HeaderAction aria-label='Fler alternativ' icon={<MoreHorizontal size={20} />} />
+            <MenuPopover>
+              <Menu>
+                {collapsibleActions.map(action => (
+                  <MenuItem key={action.id} id={action.id}>
+                    {action.label}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </MenuPopover>
+          </MenuTrigger>
+        ) : (
+          collapsibleActions.map(action => (
+            <HeaderAction key={action.id} icon={action.icon}>
+              {action.label}
+            </HeaderAction>
+          ))
+        )}
+      </HeaderActions>
     </Header>
   )
 }
 ```
 
-:::note
+## HeaderLogo
 
-`MobileMenu` renderar ingenting på desktop — den är villkorsstyrd via `useIsMobileDevice()`. Det är alltså säkert att alltid inkludera den i trädet.
+Hanterar responsiv logotyp automatiskt — visar ikonversionen (`x-small`) på mobil och den fullständiga logotypen (`small`) på desktop.
 
-:::
+```tsx
+import { HeaderLogo } from '@midas-ds/layout'
+
+<HeaderLogo />
+```
+
+Stöder `primary`-prop från `Logo` för att byta till monokrom variant:
+
+```tsx
+<HeaderLogo primary={false} />
+```
+
+Vill du länka logotypen till startsidan, wrappa den i din routing-komponent:
+
+```tsx
+// Vanilla HTML
+<a href='/'><HeaderLogo /></a>
+
+// Next.js
+import Link from 'next/link'
+<Link href='/'><HeaderLogo /></Link>
+
+// React Router
+import { Link } from 'react-router-dom'
+<Link to='/'><HeaderLogo /></Link>
+```
 
 ## Props
 
 ### HeaderAction
 
-| Prop         | Typ         | Beskrivning                              |
-| ------------ | ----------- | ---------------------------------------- |
-| `icon`       | `ReactNode` | Valfri ikon                              |
-| `children`   | `ReactNode` | Etikett                                  |
-| `aria-label` | `string`    | Krävs om varken ikon eller etikett anges |
+| Prop         | Typ         | Beskrivning                                              |
+| ------------ | ----------- | -------------------------------------------------------- |
+| `icon`       | `ReactNode` | Valfri ikon                                              |
+| `children`   | `ReactNode` | Etikett — visas på desktop, döljs som sr-only på mobil  |
+| `aria-label` | `string`    | Alternativt om `children` inte används                   |
+
+### HeaderTitle
+
+| Prop        | Typ         | Beskrivning      |
+| ----------- | ----------- | ---------------- |
+| `children`  | `ReactNode` | Systemnamnet     |
+| `className` | `string`    | Extra CSS-klass  |
+
+### HeaderLogo
+
+| Prop      | Typ       | Standard | Beskrivning                  |
+| --------- | --------- | -------- | ---------------------------- |
+| `primary` | `boolean` | `true`   | Monokrom variant om `false`  |
 
 ### MobileMenu
 

--- a/apps/docs/src/components/examples/layout/HeaderExamples.tsx
+++ b/apps/docs/src/components/examples/layout/HeaderExamples.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+export const BasicHeaderExample: React.FC = () => {
+  const url = useBaseUrl('/layout-examples/header')
+  return (
+    <div className='card'>
+      <iframe
+        title='Header example'
+        style={{ width: '100%', height: 200, border: 'none' }}
+        src={url}
+      />
+    </div>
+  )
+}
+
+export const MobileHeaderExample: React.FC = () => {
+  const url = useBaseUrl('/layout-examples/header-mobile')
+  return (
+    <div className='card'>
+      <iframe
+        title='Header with mobile menu example'
+        style={{ width: '100%', height: 350, border: 'none' }}
+        src={url}
+      />
+    </div>
+  )
+}
+
+export const OverflowHeaderExample: React.FC = () => {
+  const url = useBaseUrl('/layout-examples/header-overflow')
+  return (
+    <div className='card'>
+      <iframe
+        title='Header overflow menu example'
+        style={{ width: '100%', height: 200, border: 'none' }}
+        src={url}
+      />
+    </div>
+  )
+}

--- a/apps/docs/src/components/examples/layout/HeaderExamples.tsx
+++ b/apps/docs/src/components/examples/layout/HeaderExamples.tsx
@@ -1,15 +1,71 @@
 import React from 'react'
 import useBaseUrl from '@docusaurus/useBaseUrl'
+import { Bell, HelpCircle, MoreHorizontal, Settings, User } from 'lucide-react'
+import { useMediaQuery } from '@react-spectrum/utils'
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from '@midas-ds/components'
+import {
+  Header,
+  HeaderAction,
+  HeaderActions,
+  HeaderLogo,
+  HeaderTitle,
+} from '@midas-ds/layout'
 
-export const BasicHeaderExample: React.FC = () => {
-  const url = useBaseUrl('/layout-examples/header')
+const collapsibleActions = [
+  { id: 'profile', label: 'Min profil', icon: <User size={20} /> },
+  { id: 'settings', label: 'Inställningar', icon: <Settings size={20} /> },
+  { id: 'help', label: 'Hjälp', icon: <HelpCircle size={20} /> },
+]
+
+export const BasicHeaderExample: React.FC = () => (
+  <div className='card' style={{ overflow: 'hidden', padding: 0 }}>
+    <Header>
+      <HeaderLogo />
+      <HeaderTitle>Mitt system</HeaderTitle>
+      <HeaderActions>
+        <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+        <HeaderAction icon={<User size={20} />}>Min profil</HeaderAction>
+        <HeaderAction icon={<Settings size={20} />}>Inställningar</HeaderAction>
+      </HeaderActions>
+    </Header>
+  </div>
+)
+
+export const OverflowHeaderExample: React.FC = () => {
+  const isNarrow = useMediaQuery('(max-width: 700px)')
+
   return (
-    <div className='card'>
-      <iframe
-        title='Header example'
-        style={{ width: '100%', height: 200, border: 'none' }}
-        src={url}
-      />
+    <div className='card' style={{ overflow: 'hidden', padding: 0 }}>
+      <Header>
+        <HeaderLogo />
+        <HeaderTitle>Mitt system</HeaderTitle>
+        <HeaderActions>
+          <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+          {isNarrow ? (
+            <MenuTrigger>
+              <HeaderAction
+                aria-label='Fler alternativ'
+                icon={<MoreHorizontal size={20} />}
+              />
+              <MenuPopover>
+                <Menu>
+                  {collapsibleActions.map(action => (
+                    <MenuItem key={action.id} id={action.id}>
+                      {action.label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </MenuPopover>
+            </MenuTrigger>
+          ) : (
+            collapsibleActions.map(action => (
+              <HeaderAction key={action.id} icon={action.icon}>
+                {action.label}
+              </HeaderAction>
+            ))
+          )}
+        </HeaderActions>
+      </Header>
     </div>
   )
 }
@@ -17,23 +73,13 @@ export const BasicHeaderExample: React.FC = () => {
 export const MobileHeaderExample: React.FC = () => {
   const url = useBaseUrl('/layout-examples/header-mobile')
   return (
-    <div className='card'>
+    <div
+      className='card'
+      style={{ overflow: 'hidden', padding: 0, maxWidth: 480 }}
+    >
       <iframe
         title='Header with mobile menu example'
-        style={{ width: '100%', height: 350, border: 'none' }}
-        src={url}
-      />
-    </div>
-  )
-}
-
-export const OverflowHeaderExample: React.FC = () => {
-  const url = useBaseUrl('/layout-examples/header-overflow')
-  return (
-    <div className='card'>
-      <iframe
-        title='Header overflow menu example'
-        style={{ width: '100%', height: 200, border: 'none' }}
+        style={{ width: '100%', height: 72, border: 'none', display: 'block' }}
         src={url}
       />
     </div>

--- a/apps/docs/src/pages/layout-examples/header-mobile.tsx
+++ b/apps/docs/src/pages/layout-examples/header-mobile.tsx
@@ -1,0 +1,43 @@
+import { Bell, House, Settings, User } from 'lucide-react'
+import {
+  Header,
+  HeaderAction,
+  HeaderActions,
+  HeaderLogo,
+  HeaderTitle,
+  Layout,
+  LayoutContent,
+  Main,
+  MobileMenu,
+  Navigation,
+  NavigationItem,
+  NavigationLink,
+} from '@midas-ds/layout'
+
+export default function HeaderMobileExample() {
+  return (
+    <Layout>
+      <Header>
+        <MobileMenu title='Mitt system'>
+          <Navigation>
+            <NavigationItem>
+              <NavigationLink href='#' icon={<House />} isActive>Hem</NavigationLink>
+            </NavigationItem>
+          </Navigation>
+        </MobileMenu>
+        <HeaderLogo />
+        <HeaderTitle>Mitt system</HeaderTitle>
+        <HeaderActions>
+          <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+          <HeaderAction icon={<User size={20} />}>Min profil</HeaderAction>
+          <HeaderAction icon={<Settings size={20} />}>Inställningar</HeaderAction>
+        </HeaderActions>
+      </Header>
+      <LayoutContent>
+        <Main>
+          <div style={{ height: '100%', border: 'dashed 2px var(--midas-border-color-subtle)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--midas-text-subtle)' }}>App-innehåll</div>
+        </Main>
+      </LayoutContent>
+    </Layout>
+  )
+}

--- a/apps/docs/src/pages/layout-examples/header-mobile.tsx
+++ b/apps/docs/src/pages/layout-examples/header-mobile.tsx
@@ -1,13 +1,10 @@
-import { Bell, House, Settings, User } from 'lucide-react'
+import { Bell, House, User } from 'lucide-react'
 import {
   Header,
   HeaderAction,
   HeaderActions,
   HeaderLogo,
   HeaderTitle,
-  Layout,
-  LayoutContent,
-  Main,
   MobileMenu,
   Navigation,
   NavigationItem,
@@ -16,7 +13,8 @@ import {
 
 export default function HeaderMobileExample() {
   return (
-    <Layout>
+    <>
+      <style>{`.navbar, .footer { display: none !important; } .main-wrapper { padding-top: 0 !important; }`}</style>
       <Header>
         <MobileMenu title='Mitt system'>
           <Navigation>
@@ -30,14 +28,8 @@ export default function HeaderMobileExample() {
         <HeaderActions>
           <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
           <HeaderAction icon={<User size={20} />}>Min profil</HeaderAction>
-          <HeaderAction icon={<Settings size={20} />}>Inställningar</HeaderAction>
         </HeaderActions>
       </Header>
-      <LayoutContent>
-        <Main>
-          <div style={{ height: '100%', border: 'dashed 2px var(--midas-border-color-subtle)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--midas-text-subtle)' }}>App-innehåll</div>
-        </Main>
-      </LayoutContent>
-    </Layout>
+    </>
   )
 }

--- a/apps/docs/src/pages/layout-examples/header-overflow.tsx
+++ b/apps/docs/src/pages/layout-examples/header-overflow.tsx
@@ -1,0 +1,60 @@
+import { Bell, HelpCircle, MoreHorizontal, Settings, User } from 'lucide-react'
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from '@midas-ds/components'
+import { useMediaQuery } from '@react-spectrum/utils'
+import {
+  Header,
+  HeaderAction,
+  HeaderActions,
+  HeaderLogo,
+  HeaderTitle,
+  Layout,
+  LayoutContent,
+  Main,
+} from '@midas-ds/layout'
+
+const collapsibleActions = [
+  { id: 'profile', label: 'Min profil', icon: <User size={20} /> },
+  { id: 'settings', label: 'Inställningar', icon: <Settings size={20} /> },
+  { id: 'help', label: 'Hjälp', icon: <HelpCircle size={20} /> },
+]
+
+export default function HeaderOverflowExample() {
+  const isNarrow = useMediaQuery('(max-width: 700px)')
+
+  return (
+    <Layout>
+      <Header>
+        <HeaderLogo />
+        <HeaderTitle>Mitt system</HeaderTitle>
+        <HeaderActions>
+          <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+          {isNarrow ? (
+            <MenuTrigger>
+              <HeaderAction aria-label='Fler alternativ' icon={<MoreHorizontal size={20} />} />
+              <MenuPopover>
+                <Menu>
+                  {collapsibleActions.map(action => (
+                    <MenuItem key={action.id} id={action.id}>
+                      {action.label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </MenuPopover>
+            </MenuTrigger>
+          ) : (
+            collapsibleActions.map(action => (
+              <HeaderAction key={action.id} icon={action.icon}>
+                {action.label}
+              </HeaderAction>
+            ))
+          )}
+        </HeaderActions>
+      </Header>
+      <LayoutContent>
+        <Main>
+          <div style={{ height: '100%', border: 'dashed 2px var(--midas-border-color-subtle)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--midas-text-subtle)' }}>App-innehåll</div>
+        </Main>
+      </LayoutContent>
+    </Layout>
+  )
+}

--- a/apps/docs/src/pages/layout-examples/header.tsx
+++ b/apps/docs/src/pages/layout-examples/header.tsx
@@ -1,0 +1,43 @@
+import { Bell, House, Settings, User } from 'lucide-react'
+import {
+  Header,
+  HeaderAction,
+  HeaderActions,
+  HeaderLogo,
+  HeaderTitle,
+  Layout,
+  LayoutContent,
+  Main,
+  Navigation,
+  NavigationItem,
+  NavigationLink,
+  Sidebar,
+} from '@midas-ds/layout'
+
+export default function HeaderExample() {
+  return (
+    <Layout>
+      <Header>
+        <HeaderLogo />
+        <HeaderTitle>Mitt system</HeaderTitle>
+        <HeaderActions>
+          <HeaderAction icon={<Bell size={20} />}>Notiser</HeaderAction>
+          <HeaderAction icon={<User size={20} />}>Min profil</HeaderAction>
+          <HeaderAction icon={<Settings size={20} />}>Inställningar</HeaderAction>
+        </HeaderActions>
+      </Header>
+      <LayoutContent>
+        <Sidebar title='Mitt system'>
+          <Navigation>
+            <NavigationItem>
+              <NavigationLink href='#' icon={<House />} isActive>Hem</NavigationLink>
+            </NavigationItem>
+          </Navigation>
+        </Sidebar>
+        <Main>
+          <div style={{ height: '100%', border: 'dashed 2px var(--midas-border-color-subtle)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--midas-text-subtle)' }}>App-innehåll</div>
+        </Main>
+      </LayoutContent>
+    </Layout>
+  )
+}

--- a/apps/playground/src/app/app.tsx
+++ b/apps/playground/src/app/app.tsx
@@ -1,5 +1,5 @@
-import { FileListPage } from '../pages/FileListPage';
+import { HeaderPage } from '../pages/HeaderPage';
 
 export default function App() {
-  return <FileListPage />;
+  return <HeaderPage />;
 }

--- a/apps/playground/src/main.tsx
+++ b/apps/playground/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import '@midas-ds/components/default.css'
+import '@midas-ds/layout/default.css'
 
 import App from './app/app';
 

--- a/apps/playground/src/pages/HeaderPage.tsx
+++ b/apps/playground/src/pages/HeaderPage.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { Bell, CircleUserRound, HelpCircle, Languages, MoreHorizontal, Settings, Sun } from 'lucide-react'
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from '@midas-ds/components'
+import { useMediaQuery } from '@react-spectrum/utils'
+import {
+  Header,
+  HeaderAction,
+  HeaderActions,
+  HeaderLogo,
+  HeaderTitle,
+  Layout,
+  LayoutContent,
+  Main,
+  MobileMenu,
+  Navigation,
+  NavigationItem,
+  NavigationLink,
+  Sidebar,
+} from '@midas-ds/layout'
+import { House } from 'lucide-react'
+
+const Nav = () => (
+  <Navigation>
+    <NavigationItem>
+      <NavigationLink href='/' icon={<House />} isActive>Hem</NavigationLink>
+    </NavigationItem>
+  </Navigation>
+)
+
+// The app knows it has 5 collapsible actions and they stop fitting around 480px.
+// Pick whatever breakpoint makes sense for your content.
+const overflowActions = [
+  { label: 'Profil', icon: <CircleUserRound size={20} />, onPress: () => alert('Profil') },
+  { label: 'Språk', icon: <Languages size={20} />, onPress: () => alert('Språk') },
+  { label: 'Tema', icon: <Sun size={20} />, onPress: () => alert('Tema') },
+  { label: 'Hjälp', icon: <HelpCircle size={20} />, onPress: () => alert('Hjälp') },
+  { label: 'Inställningar', icon: <Settings size={20} />, onPress: () => alert('Inställningar') },
+]
+
+export const HeaderPage = () => {
+  const isNarrow = useMediaQuery('(max-width: 480px)')
+
+  return (
+    <Layout>
+      <Header>
+        <MobileMenu title='Min app'>
+          <Nav />
+        </MobileMenu>
+        <HeaderLogo />
+        <HeaderTitle>HETA</HeaderTitle>
+        <HeaderActions>
+          <HeaderAction icon={<Bell size={20} />} onPress={() => alert('Notifikationer')}>
+            Notifikationer
+          </HeaderAction>
+          {isNarrow ? (
+            <MenuTrigger>
+              <HeaderAction aria-label='Fler alternativ' icon={<MoreHorizontal size={20} />} />
+              <MenuPopover>
+                <Menu onAction={key => overflowActions[Number(key)]?.onPress()}>
+                  {overflowActions.map((action, i) => (
+                    <MenuItem key={i} id={String(i)}>
+                      {action.icon} {action.label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </MenuPopover>
+            </MenuTrigger>
+          ) : (
+            overflowActions.map((action, i) => (
+              <HeaderAction key={i} icon={action.icon} onPress={action.onPress}>
+                {action.label}
+              </HeaderAction>
+            ))
+          )}
+        </HeaderActions>
+      </Header>
+      <LayoutContent>
+        <Sidebar title='Min app'>
+          <Nav />
+        </Sidebar>
+        <Main>Page content</Main>
+      </LayoutContent>
+    </Layout>
+  )
+}

--- a/packages/layout/src/header/Header.module.css
+++ b/packages/layout/src/header/Header.module.css
@@ -2,5 +2,7 @@
   background-color: var(--midas-background-base);
   border-bottom: 1px solid var(--midas-border-color-subtle);
   display: flex;
-  gap: var(--midas-space-xlarge);
+  align-items: center;
+  min-height: 4.5rem;
+  padding-inline: var(--midas-space-medium);
 }

--- a/packages/layout/src/header/Header.stories.tsx
+++ b/packages/layout/src/header/Header.stories.tsx
@@ -1,8 +1,9 @@
-import { Logo } from '@midas-ds/components'
 import { composeStories, type Meta, type StoryObj } from '@storybook/react-vite'
 import * as headerActionsStories from './header-actions/HeaderActions.stories'
 import * as MobileMenuStories from './mobile-menu/MobileMenu.stories'
 import { Header } from './Header'
+import { HeaderLogo } from './header-logo'
+import { HeaderTitle } from './header-title'
 
 type Story = StoryObj<typeof Header>
 
@@ -16,20 +17,23 @@ export default {
   parameters: { layout: 'fullscreen', rootElement: 'div' },
 } satisfies Meta<typeof Header>
 
-export const Primary: Story = {
+export const Desktop: Story = {
   render: () => (
     <Header>
-      <Logo />
+      <HeaderLogo />
+      <HeaderTitle>System name</HeaderTitle>
       <PrimaryHeaderActions />
     </Header>
   ),
 }
 
-export const WithMobileMenu: Story = {
+export const Mobile: Story = {
+  globals: { viewport: { value: 'small' } },
   render: () => (
     <Header>
       <PrimaryMobileMenu />
-      <Logo />
+      <HeaderLogo />
+      <HeaderTitle>System name</HeaderTitle>
       <PrimaryHeaderActions />
     </Header>
   ),

--- a/packages/layout/src/header/Header.tsx
+++ b/packages/layout/src/header/Header.tsx
@@ -2,8 +2,6 @@
 
 import clsx from 'clsx'
 import { DetailedHTMLProps, HTMLAttributes } from 'react'
-import { LogoContext } from '@midas-ds/components'
-import { useIsMobileDevice } from '../utils'
 import styles from './Header.module.css'
 
 export type HeaderProps = DetailedHTMLProps<
@@ -11,15 +9,9 @@ export type HeaderProps = DetailedHTMLProps<
   HTMLElement
 >
 
-export const Header = ({ className, ...rest }: HeaderProps) => {
-  const isMobile = useIsMobileDevice()
-
-  return (
-    <LogoContext.Provider value={{ size: isMobile ? 'x-small' : 'large' }}>
-      <header
-        className={clsx(className, styles.header)}
-        {...rest}
-      />
-    </LogoContext.Provider>
-  )
-}
+export const Header = ({ className, ...rest }: HeaderProps) => (
+  <header
+    className={clsx(className, styles.header)}
+    {...rest}
+  />
+)

--- a/packages/layout/src/header/header-action/HeaderAction.module.css
+++ b/packages/layout/src/header/header-action/HeaderAction.module.css
@@ -1,12 +1,17 @@
-.label {
-  @media (width <= 640px) {
+.headerAction {
+  color: var(--midas-text-primary);
+  position: relative;
+}
+
+@media (width <= 768px) {
+  .label {
     position: absolute;
     width: 1px;
     height: 1px;
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     white-space: nowrap;
     border-width: 0;
   }

--- a/packages/layout/src/header/header-action/HeaderAction.module.css
+++ b/packages/layout/src/header/header-action/HeaderAction.module.css
@@ -15,4 +15,8 @@
     white-space: nowrap;
     border-width: 0;
   }
+
+  .headerAction {
+    padding-inline: calc(var(--midas-space-50) - var(--border-width));
+  }
 }

--- a/packages/layout/src/header/header-action/HeaderAction.tsx
+++ b/packages/layout/src/header/header-action/HeaderAction.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import clsx from 'clsx'
 import { forwardRef, ReactNode } from 'react'
 import { composeRenderProps } from 'react-aria-components'
 import { type ButtonProps, Button } from '@midas-ds/components'
@@ -10,7 +11,7 @@ export interface HeaderActionProps extends Omit<ButtonProps, 'icon'> {
 }
 
 export const HeaderAction = forwardRef<HTMLButtonElement, HeaderActionProps>(
-  ({ children, icon, ...props }, ref) => {
+  ({ children, icon, className, ...props }, ref) => {
     if (
       !children &&
       !props['aria-label'] &&
@@ -26,6 +27,7 @@ export const HeaderAction = forwardRef<HTMLButtonElement, HeaderActionProps>(
         ref={ref}
         size='medium'
         variant='tertiary'
+        className={clsx(styles.headerAction, className)}
         {...props}
       >
         {composeRenderProps(children, children => (

--- a/packages/layout/src/header/header-actions/HeaderActions.module.css
+++ b/packages/layout/src/header/header-actions/HeaderActions.module.css
@@ -1,6 +1,6 @@
 .headerActions {
   display: flex;
-  gap: 0.25rem;
+  gap: 0;
   align-items: center;
   margin-inline-start: auto;
 }

--- a/packages/layout/src/header/header-actions/HeaderActions.tsx
+++ b/packages/layout/src/header/header-actions/HeaderActions.tsx
@@ -1,15 +1,14 @@
+'use client'
+
 import clsx from 'clsx'
-import { type DetailedHTMLProps, type HTMLAttributes } from 'react'
+import { type ReactNode } from 'react'
 import styles from './HeaderActions.module.css'
 
-export type HeaderActionsProps = DetailedHTMLProps<
-  HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
+export interface HeaderActionsProps {
+  children?: ReactNode
+  className?: string
+}
 
-export const HeaderActions = ({ className, ...rest }: HeaderActionsProps) => (
-  <div
-    className={clsx(className, styles.headerActions)}
-    {...rest}
-  />
+export const HeaderActions = ({ children, className }: HeaderActionsProps) => (
+  <div className={clsx(styles.headerActions, className)}>{children}</div>
 )

--- a/packages/layout/src/header/header-logo/HeaderLogo.module.css
+++ b/packages/layout/src/header/header-logo/HeaderLogo.module.css
@@ -1,0 +1,15 @@
+.mobile {
+  flex-shrink: 0;
+
+  @media (width > 640px) {
+    display: none;
+  }
+}
+
+.desktop {
+  flex-shrink: 0;
+
+  @media (width <= 640px) {
+    display: none;
+  }
+}

--- a/packages/layout/src/header/header-logo/HeaderLogo.module.css
+++ b/packages/layout/src/header/header-logo/HeaderLogo.module.css
@@ -1,5 +1,7 @@
 .mobile {
   flex-shrink: 0;
+  height: 2.25rem;
+  aspect-ratio: 100 / 92;
 
   @media (width > 640px) {
     display: none;
@@ -8,6 +10,8 @@
 
 .desktop {
   flex-shrink: 0;
+  height: 2.5rem;
+  aspect-ratio: 112 / 40;
 
   @media (width <= 640px) {
     display: none;

--- a/packages/layout/src/header/header-logo/HeaderLogo.tsx
+++ b/packages/layout/src/header/header-logo/HeaderLogo.tsx
@@ -9,7 +9,7 @@ export interface HeaderLogoProps {
 
 export const HeaderLogo = ({ primary }: HeaderLogoProps) => (
   <>
-    <Logo size='x-small' primary={primary} className={styles.mobile} />
-    <Logo size='small' primary={primary} className={styles.desktop} />
+    <Logo size='x-small' primary={primary} padding={false} className={styles.mobile} />
+    <Logo size='small' primary={primary} padding={false} className={styles.desktop} />
   </>
 )

--- a/packages/layout/src/header/header-logo/HeaderLogo.tsx
+++ b/packages/layout/src/header/header-logo/HeaderLogo.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Logo } from '@midas-ds/components'
+import styles from './HeaderLogo.module.css'
+
+export interface HeaderLogoProps {
+  primary?: boolean
+}
+
+export const HeaderLogo = ({ primary }: HeaderLogoProps) => (
+  <>
+    <Logo size='x-small' primary={primary} className={styles.mobile} />
+    <Logo size='small' primary={primary} className={styles.desktop} />
+  </>
+)

--- a/packages/layout/src/header/header-logo/index.ts
+++ b/packages/layout/src/header/header-logo/index.ts
@@ -1,0 +1,1 @@
+export * from './HeaderLogo'

--- a/packages/layout/src/header/header-title/HeaderTitle.module.css
+++ b/packages/layout/src/header/header-title/HeaderTitle.module.css
@@ -6,4 +6,5 @@
   color: var(--midas-text-primary);
   white-space: nowrap;
   margin-inline-start: var(--midas-space-medium);
+  padding-inline-end: var(--midas-space-medium);
 }

--- a/packages/layout/src/header/header-title/HeaderTitle.module.css
+++ b/packages/layout/src/header/header-title/HeaderTitle.module.css
@@ -1,0 +1,9 @@
+.headerTitle {
+  font-family: var(--midas-typography-font-family);
+  font-size: var(--midas-typography-font-size-30);
+  font-weight: var(--midas-typography-weight-semi-bold);
+  line-height: var(--midas-typography-line-height-50);
+  color: var(--midas-text-primary);
+  white-space: nowrap;
+  margin-inline-start: var(--midas-space-medium);
+}

--- a/packages/layout/src/header/header-title/HeaderTitle.tsx
+++ b/packages/layout/src/header/header-title/HeaderTitle.tsx
@@ -1,0 +1,12 @@
+import clsx from 'clsx'
+import { type HTMLAttributes } from 'react'
+import styles from './HeaderTitle.module.css'
+
+export type HeaderTitleProps = HTMLAttributes<HTMLSpanElement>
+
+export const HeaderTitle = ({ className, ...rest }: HeaderTitleProps) => (
+  <span
+    className={clsx(styles.headerTitle, className)}
+    {...rest}
+  />
+)

--- a/packages/layout/src/header/header-title/index.ts
+++ b/packages/layout/src/header/header-title/index.ts
@@ -1,0 +1,2 @@
+export { HeaderTitle } from './HeaderTitle'
+export type { HeaderTitleProps } from './HeaderTitle'

--- a/packages/layout/src/header/index.ts
+++ b/packages/layout/src/header/index.ts
@@ -1,4 +1,6 @@
 export * from './header-actions'
 export * from './header-action'
+export * from './header-logo'
+export * from './header-title'
 export * from './mobile-menu'
 export * from './Header'

--- a/packages/layout/src/header/mobile-menu/MobileMenu.module.css
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.module.css
@@ -1,3 +1,7 @@
+.triggerButton {
+  margin-inline-start: calc(-1 * var(--midas-space-50));
+}
+
 .overlay {
   display: block;
 

--- a/packages/layout/src/header/mobile-menu/MobileMenu.tsx
+++ b/packages/layout/src/header/mobile-menu/MobileMenu.tsx
@@ -56,6 +56,8 @@ export const MobileMenu = ({
           aria-label={strings.format('openMenu')}
           icon={Menu}
           variant='icon'
+          size='medium'
+          className={styles.triggerButton}
         />
         <ModalOverlay
           className={clsx(className, styles.overlay)}

--- a/packages/layout/src/layout/Layout.stories.tsx
+++ b/packages/layout/src/layout/Layout.stories.tsx
@@ -6,7 +6,7 @@ import { Main } from '../main'
 import { Layout, LayoutContent } from '.'
 import { Panel } from '../panel'
 
-const { Primary: PrimaryHeader, WithMobileMenu: HeaderWithMobileMenu } =
+const { Desktop: PrimaryHeader, Mobile: HeaderWithMobileMenu } =
   composeStories(headerStories)
 const { Primary: PrimarySidebar } = composeStories(sidebarStories)
 const { Primary: PrimaryNavbar } = composeStories(navbarStories)


### PR DESCRIPTION
## Summary

- Adds `HeaderTitle` component for displaying the application/system name (H3 typography)
- Removes JS-based logo size switching — replaces with two static `Logo` elements (desktop `small`, mobile `x-small`) shown/hidden via CSS media query with `flex-shrink: 0` to prevent flex squishing
- `HeaderActions` simplified to a clean flex wrapper
- `HeaderAction` labels visually hidden at ≤ 768px (icons only on tablet/mobile) using `clip-path: inset(50%)` sr-only pattern
- Updated Storybook stories to reflect desktop and mobile states
- Playground wired up to `HeaderPage` for manual testing

## Test plan

- [ ] Resize playground from desktop to mobile — desktop logo visible above 640px, mobile logo below
- [ ] Labels on `HeaderAction` buttons hidden at ≤ 768px, visible above
- [ ] `HeaderTitle` renders with correct H3 typography (semi-bold, correct size/line-height)
- [ ] Storybook desktop and mobile stories render correctly