### PR TITLE
fix(components,select): trigger required validation when clearing all selected items

### DIFF
--- a/packages/components/src/select/MultiSelectValue.tsx
+++ b/packages/components/src/select/MultiSelectValue.tsx
@@ -79,7 +79,7 @@ const SelectClearButton = <
 
   const handlePress = () => {
     focusManager?.focusFirst()
-    state?.setValue(null)
+    state?.selectionManager.clearSelection()
   }
 
   return (

--- a/packages/components/src/select/Select.spec.tsx
+++ b/packages/components/src/select/Select.spec.tsx
@@ -14,6 +14,8 @@ const {
   DynamicSections,
   RequiredSingleSelect,
   RequiredMultipleSelectAll,
+  RequiredMultipleWithTags,
+  RequiredMultipleWithClearAll,
   DS872,
 } = composeStories(stories)
 
@@ -234,5 +236,34 @@ describe('given a DS872 ', async () => {
         }),
       )
       .toBeInTheDocument()
+  })
+})
+
+describe('given a required multiple Select with tags (DS-1817)', async () => {
+  it('should show invalid state when all tags are removed via dismiss buttons', async () => {
+    const { getByRole } = await render(<RequiredMultipleWithTags />)
+
+    const tagGrid = page.getByRole('grid')
+    await expect.element(tagGrid).toBeVisible()
+
+    const count = (await tagGrid.getByRole('button').elements()).length
+
+    for (let i = 0; i < count; i++) {
+      await userEvent.click(tagGrid.getByRole('button').first())
+    }
+
+    await expect
+      .element(getByRole('button', { name: 'Label' }))
+      .toHaveAttribute('data-invalid')
+  })
+
+  it('should show invalid state when all items are cleared via the clear-all button', async () => {
+    const { getByRole } = await render(<RequiredMultipleWithClearAll />)
+
+    await userEvent.click(getByRole('button', { name: 'Clear all' }))
+
+    await expect
+      .element(getByRole('button', { name: 'Label' }))
+      .toHaveAttribute('data-invalid')
   })
 })

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -186,6 +186,45 @@ export const DynamicSections: Story<Section> = {
   },
 }
 
+export const RequiredMultipleWithTags: Story<Item, 'multiple'> = {
+  tags: ['!dev', '!autodocs', '!snapshot'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    selectionMode: 'multiple',
+    isRequired: true,
+    showTags: true,
+    errorMessage: 'Obligatoriskt fält',
+    defaultValue: ['ananas', 'kiwi'],
+  },
+  render: args => (
+    <form onSubmit={e => e.preventDefault()}>
+      <Select {...args} />
+      <button type='submit'>submit</button>
+    </form>
+  ),
+}
+
+export const RequiredMultipleWithClearAll: Story<Item, 'multiple'> = {
+  tags: ['!dev', '!autodocs', '!snapshot'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    selectionMode: 'multiple',
+    isRequired: true,
+    errorMessage: 'Obligatoriskt fält',
+    defaultValue: ['ananas', 'kiwi'],
+  },
+  render: args => (
+    <form onSubmit={e => e.preventDefault()}>
+      <Select {...args} />
+      <button type='submit'>submit</button>
+    </form>
+  ),
+}
+
 export const RequiredMultipleSelectAll: Story<Item, 'multiple'> = {
   tags: ['!dev', '!autodocs', '!snapshot'],
   parameters: {


### PR DESCRIPTION
Fixes required validation not showing when clearing a multi-select via the clear-all button.

`state.setValue(null)` bypassed the selection manager, so `onSelectionChange` never fired and `commitValidation()` was never called. Replaced with `state.selectionManager.clearSelection()`.

Regression tests added for both the clear-all button and tag dismiss button paths.