### PR TITLE
fix(theme,button): use opacity token for disabled background

### DIFF
--- a/packages/theme/tokens/buttons.json
+++ b/packages/theme/tokens/buttons.json
@@ -56,7 +56,7 @@
         }
       },
       "disabled": {
-        "$value": "light-dark({color.gray.10}, {color.gray.180})",
+        "$value": "light-dark({color.black.opacity5},{color.white.opacity13})",
         "$description": "Disabled state för knappar"
       }
     },


### PR DESCRIPTION
Disabled button background was `gray.10` (solid), which is identical to `layer-01` — making disabled buttons invisible on that surface.

Switched to `black.opacity5` / `white.opacity13` (same primitives already used for secondary/tertiary hover), so it works on any layer.