### PR TITLE
Add virtualized opt-out to ListBox/Select/ComboBox

### DIFF
--- a/apps/docs/docs/components/combobox.mdx
+++ b/apps/docs/docs/components/combobox.mdx
@@ -130,6 +130,10 @@ return (
   <SectionedExample />
 </div>
 
+:::info
+`ListBox` renderas alltid via React Arias `Virtualizer`, vilket kräver en riktig webbläsares layoutmotor. I miljöer utan detta (t.ex. `happy-dom` eller `jsdom`, vanligt vid testning) kan sektionerade listor sluta rendera alternativ efter den första sektionens rubrik. Sätt `listBoxProps={{ virtualized: false }}` för att stänga av virtualisering, av testskäl eller andra anledningar.
+:::
+
 ## Asynkron laddning
 
 Om data finns på en server kan en laddningsindikator visas med en `ListBoxLoadMoreItem`-komponent.

--- a/apps/docs/docs/components/select.mdx
+++ b/apps/docs/docs/components/select.mdx
@@ -136,6 +136,10 @@ Vid många val kan alternativen struktureras i sektioner.
   <SectionedExample />
 </div>
 
+:::info
+`ListBox` renderas alltid via React Arias `Virtualizer`, vilket kräver en riktig webbläsares layoutmotor. I miljöer utan detta (t.ex. `happy-dom` eller `jsdom`, vanligt vid testning) kan sektionerade listor sluta rendera alternativ efter den första sektionens rubrik. Sätt `listBoxProps={{ virtualized: false }}` för att stänga av virtualisering, av testskäl eller andra anledningar.
+:::
+
 ## Anpassa popover
 
 Det inbyggda popover-fönstret kan konfigureras via `popoverProps`, som skickas vidare till den underliggande `Popover`-komponenten.

--- a/packages/components/src/combobox/ComboBox.spec.tsx
+++ b/packages/components/src/combobox/ComboBox.spec.tsx
@@ -122,8 +122,7 @@ describe('given a ComboBox with listBoxProps={{ virtualized: false }}', async ()
   it('should render items in every section', async () => {
     const { getByRole } = await render(<NotVirtualized />)
 
-    await userEvent.click(getByRole('combobox'))
-    await userEvent.keyboard('[ArrowDown]')
+    await userEvent.click(getByRole('button'))
 
     const listbox = page.getByRole('listbox')
     await expect.element(listbox.getByText('Ananas')).toBeVisible()

--- a/packages/components/src/combobox/ComboBox.spec.tsx
+++ b/packages/components/src/combobox/ComboBox.spec.tsx
@@ -7,7 +7,7 @@ import { render } from '../../test-utils'
 import { ComboBox } from './ComboBox'
 import { ListBoxItem } from '../list-box'
 
-const { Primary, Required, Sectioned } = composeStories(stories)
+const { Primary, Required, Sectioned, NotVirtualized } = composeStories(stories)
 
 describe('given a primary ComboBox', async () => {
   it('it should preserve its classNames when being passed new ones', async () => {
@@ -115,5 +115,19 @@ describe('given an async ComboBox with allowsEmptyCollection', async () => {
     await expect
       .element(page.getByText('No results found'))
       .toBeInTheDocument()
+  })
+})
+
+describe('given a ComboBox with listBoxProps={{ virtualized: false }}', async () => {
+  it('should render items in every section', async () => {
+    await render(<NotVirtualized />)
+
+    await userEvent.tab()
+    await userEvent.keyboard('[ArrowDown]')
+
+    const listbox = page.getByRole('listbox')
+    await expect.element(listbox.getByText('Ananas')).toBeVisible()
+    await expect.element(listbox.getByText('Kokosnöt')).toBeVisible()
+    await expect.element(listbox.getByText('Päron')).toBeVisible()
   })
 })

--- a/packages/components/src/combobox/ComboBox.spec.tsx
+++ b/packages/components/src/combobox/ComboBox.spec.tsx
@@ -120,9 +120,9 @@ describe('given an async ComboBox with allowsEmptyCollection', async () => {
 
 describe('given a ComboBox with listBoxProps={{ virtualized: false }}', async () => {
   it('should render items in every section', async () => {
-    await render(<NotVirtualized />)
+    const { getByRole } = await render(<NotVirtualized />)
 
-    await userEvent.tab()
+    await userEvent.click(getByRole('combobox'))
     await userEvent.keyboard('[ArrowDown]')
 
     const listbox = page.getByRole('listbox')

--- a/packages/components/src/combobox/ComboBox.stories.tsx
+++ b/packages/components/src/combobox/ComboBox.stories.tsx
@@ -153,6 +153,26 @@ export const Sectioned: Story<Section> = {
   ),
 }
 
+export const NotVirtualized: Story<Section> = {
+  tags: ['!autodocs', '!snapshot'],
+  args: {
+    ...Sectioned.args,
+    listBoxProps: { virtualized: false },
+  },
+  render: args => (
+    <ComboBox {...args}>
+      {section => (
+        <ListBoxSection id={section.name}>
+          <ListBoxHeader>{section.name}</ListBoxHeader>
+          <Collection items={section.children}>
+            {item => <ListBoxItem id={item.id}>{item.name}</ListBoxItem>}
+          </Collection>
+        </ListBoxSection>
+      )}
+    </ComboBox>
+  ),
+}
+
 export const PerformanceTest: Story = {
   tags: ['!dev', '!autodocs'],
   parameters: {

--- a/packages/components/src/list-box/ListBox.spec.tsx
+++ b/packages/components/src/list-box/ListBox.spec.tsx
@@ -3,7 +3,7 @@ import { composeStories } from '@storybook/react-vite'
 import * as stories from './ListBox.stories'
 import { render } from '../../test-utils'
 
-const { SelectionModeSingle } = composeStories(stories)
+const { SelectionModeSingle, NotVirtualized } = composeStories(stories)
 
 describe('given a ListBoxItem in a ListBox with selectionMode="single"', async () => {
   it('should change cursor on hover', async () => {
@@ -28,5 +28,26 @@ describe('given a ListBoxItem in a ListBox with selectionMode="single"', async (
     observer.disconnect()
 
     expect(pressedAtSomePoint).toBe(true)
+  })
+})
+
+describe('given a ListBox with virtualized (default)', async () => {
+  it('should render items through the Virtualizer', async () => {
+    const { container } = await render(<SelectionModeSingle />)
+    expect(
+      container.querySelector('[style*="contain: size layout style"]'),
+    ).toBeTruthy()
+  })
+})
+
+describe('given a ListBox with virtualized={false}', async () => {
+  it('should render all items in a section without the Virtualizer', async () => {
+    const { container, getByText } = await render(<NotVirtualized />)
+
+    await expect.element(getByText('Item 1')).toBeInTheDocument()
+    await expect.element(getByText('Item 2')).toBeInTheDocument()
+    expect(
+      container.querySelector('[style*="contain: size layout style"]'),
+    ).toBeFalsy()
   })
 })

--- a/packages/components/src/list-box/ListBox.stories.tsx
+++ b/packages/components/src/list-box/ListBox.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { type Fruit, fruit } from '@midas-ds/test-utils'
 import { ListBox } from './ListBox'
 import { ListBoxItem } from './ListBoxItem'
+import { ListBoxSection } from './ListBoxSection'
+import { ListBoxHeader } from './ListBoxHeader'
 
 type Story = StoryObj<typeof ListBox<Fruit>>
 
@@ -22,4 +24,23 @@ export const SelectionModeSingle: Story = {
   args: {
     selectionMode: 'single',
   },
+}
+
+export const NotVirtualized: Story = {
+  tags: ['!autodocs', '!snapshot'],
+  args: {
+    virtualized: false,
+  },
+  render: args => (
+    <ListBox<Fruit>
+      {...args}
+      items={undefined}
+    >
+      <ListBoxSection>
+        <ListBoxHeader>Sektion 1</ListBoxHeader>
+        <ListBoxItem id='item-1'>Item 1</ListBoxItem>
+        <ListBoxItem id='item-2'>Item 2</ListBoxItem>
+      </ListBoxSection>
+    </ListBox>
+  ),
 }

--- a/packages/components/src/list-box/ListBox.tsx
+++ b/packages/components/src/list-box/ListBox.tsx
@@ -1,30 +1,44 @@
 import {
   ListBox as AriaListBox,
-  ListBoxProps,
+  type ListBoxProps as AriaListBoxProps,
   Virtualizer,
 } from 'react-aria-components'
 import clsx from '../utils/clsx'
 import { SectionedListLayout } from './SectionedListLayout'
 import styles from './ListBox.module.css'
 
-export type { ListBoxProps }
+export interface ListBoxProps<T extends object> extends AriaListBoxProps<T> {
+  /** @default true */
+  virtualized?: boolean
+}
 
 export const ListBox = <T extends object>({
   className,
   children,
+  virtualized = true,
   ...rest
-}: ListBoxProps<T>) => (
-  <Virtualizer
-    layout={SectionedListLayout}
-    layoutOptions={{
-      headingHeight: 38,
-    }}
-  >
+}: ListBoxProps<T>) => {
+  const listBox = (
     <AriaListBox
       className={clsx(styles.listBox, className)}
       {...rest}
     >
       {children}
     </AriaListBox>
-  </Virtualizer>
-)
+  )
+
+  if (!virtualized) {
+    return listBox
+  }
+
+  return (
+    <Virtualizer
+      layout={SectionedListLayout}
+      layoutOptions={{
+        headingHeight: 38,
+      }}
+    >
+      {listBox}
+    </Virtualizer>
+  )
+}

--- a/packages/components/src/select/Select.spec.tsx
+++ b/packages/components/src/select/Select.spec.tsx
@@ -12,6 +12,7 @@ const {
   WithTags,
   SelectAllEnabled,
   DynamicSections,
+  NotVirtualized,
   RequiredSingleSelect,
   RequiredMultipleSelectAll,
   RequiredMultipleWithTags,
@@ -176,6 +177,25 @@ describe('given a sectioned Select ', async () => {
     await userEvent.keyboard('[Space]')
 
     expect(warn).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('given a Select with listBoxProps={{ virtualized: false }}', async () => {
+  it('should render items in every section', async () => {
+    const { getByRole } = await render(<NotVirtualized />)
+
+    await userEvent.tab()
+    await userEvent.keyboard('[Space]')
+
+    const listbox = page.getByRole('listbox')
+    await expect.element(listbox.getByText('Apple')).toBeVisible()
+    await expect.element(listbox.getByText('Banana')).toBeVisible()
+    await expect.element(listbox.getByText('Cabbage')).toBeVisible()
+    await expect.element(listbox.getByText('Broccoli')).toBeVisible()
+
+    expect(getByRole('listbox').element().innerHTML).not.toContain(
+      'contain: size layout style',
+    )
   })
 })
 

--- a/packages/components/src/select/Select.stories.tsx
+++ b/packages/components/src/select/Select.stories.tsx
@@ -171,6 +171,14 @@ export const StaticSections: Story = {
   },
 }
 
+export const NotVirtualized: Story = {
+  tags: ['!autodocs', '!snapshot'],
+  args: {
+    ...StaticSections.args,
+    listBoxProps: { virtualized: false },
+  },
+}
+
 export const DynamicSections: Story<Section> = {
   args: {
     ...Primary.args,

--- a/packages/components/src/select/Select.tsx
+++ b/packages/components/src/select/Select.tsx
@@ -13,7 +13,7 @@ import { Text } from '../text'
 import { FieldError } from '../field-error'
 import { SelectAll } from './SelectAll'
 import { MultiSelectValue } from './MultiSelectValue'
-import { ListBox } from '../list-box'
+import { ListBox, type ListBoxProps } from '../list-box'
 import { Popover } from '../popover'
 import { SelectTags } from './SelectTags'
 import { SelectTrigger } from './SelectTrigger'
@@ -55,6 +55,10 @@ export interface MidasSelectProps<
    * Props passed to the internal Popover element.
    */
   popoverProps?: Omit<React.ComponentProps<typeof Popover>, 'children'>
+  /**
+   * Props passed to the internal ListBox element.
+   */
+  listBoxProps?: Omit<ListBoxProps<T>, 'items' | 'children'>
 }
 
 export function Select<T extends object, M extends SelectionMode = 'single'>({
@@ -66,6 +70,7 @@ export function Select<T extends object, M extends SelectionMode = 'single'>({
   label,
   popover,
   popoverProps,
+  listBoxProps,
   size = 'large',
   ...props
 }: MidasSelectProps<T, M>) {
@@ -105,6 +110,7 @@ export function Select<T extends object, M extends SelectionMode = 'single'>({
           <ListBox
             escapeKeyBehavior='none'
             items={items}
+            {...listBoxProps}
           >
             {children}
           </ListBox>


### PR DESCRIPTION
Non-breaking. Default unchanged. `virtualized={false}` on ListBox/Select/ComboBox (via listBoxProps) skips the Virtualizer, fixing rendering in happy-dom/jsdom testing.